### PR TITLE
Imported two patches from xen-api.git

### DIFF
--- a/scripts/setup-vif-rules
+++ b/scripts/setup-vif-rules
@@ -194,9 +194,18 @@ def create_vswitch_rules(bridge_name, port, config):
     # Drop everything else.
     add_flow(bridge_name, "in_port=%s,priority=4000,idle_timeout=0,action=drop" % port)
 
+def get_bridge_name_vswitch(vif_name):
+    '''return bridge vif belong to'''
+    (rc, stdout, stderr) = doexec([vsctl, "iface-to-br",  vif_name ])
+    temp_bridge_name = stdout.readline().strip() 
+    '''get bridge parent, in case we were given a fake bridge device'''
+    '''will return same name if it is already a real bridge'''
+    (rc, stdout, stderr) = doexec([vsctl, "br-to-parent", temp_bridge_name ])
+    return stdout.readline().strip()
+
 def handle_vswitch(vif_name, domuuid, devid, action):
     if (action == "clear") or (action == "filter"):
-        bridge_name = "xenbr%s" % devid
+        bridge_name = get_bridge_name_vswitch(vif_name)
         ip_link_set(vif_name, "down")
         port = get_vswitch_port(vif_name)
         clear_vswitch_rules(bridge_name, port)


### PR DESCRIPTION
commit fa5d8321c27725fad175a2c4d259726e9b63d0ac
Author: Kevin Tower ktower@towerfamily.org
Date:   Mon Apr 29 14:10:44 2013 -0700

```
Altering get_bridge_name_vswitch() to work correctly with VLANs.
VLAN-tagged networks/ports are connected to a "fake bridge" device.
Most ovs-* commands will not work with a fake bridge
device, so this function needs to return the true parent bridge
device name, not the fake bridge.  Otherwise, subsequent calls
in this script to configure port locking via ovs-ofctl will
(silently) fail, and port locking will not activate.

Signed-off-by: Kevin Tower <ktower@towerfamily.org>
```

commit 06c2d0fedc7031c27ad9215a751c404fde1ebb70
Author: George Shuklin shuklin@selectel.ru
Date:   Thu Dec 20 17:41:46 2012 +0400

```
Fix bridge name selection for vswitch mode in scripts/setup-vif-rules
  -        bridge_name = "xenbr%s" % devid
  +        bridge_name = get_bridge_name_vswitch(vif_name)

  Devid is device number for domU (f.e. vif1.15; 15 - devid) and is definitely NOT a
  xenbr number (xenbr0, xenbr1, etc).

Signed-off-by: George Shuklin <george.shuklin@gmail.com>
```

Committed-by: Rob Hoes rob.hoes@citrix.com
