### PR TITLE
Use singleton usbdevice_list instead of usbdevice

### DIFF
--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1969,7 +1969,7 @@ module VM = struct
 								serial = hvm_info.Xenops_interface.Vm.serial;
 								boot = Some hvm_info.Xenops_interface.Vm.boot_order;
 								usb = Some true;
-								usbdevice = Some "tablet";
+								usbdevice_list = [ "tablet" ];
 							}
 						}
 					| PV { Xenops_interface.Vm.boot = Direct direct } ->


### PR DESCRIPTION
This is a workaround since the default value of [] for usbdevice_list is
interpreted as a specified option in libxl and libxl disallows specifying both
the usbdevice and usbdevice_list options.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
