### PR TITLE
CA-116819: xenlight: don't attach storage during VM_restore

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -783,10 +783,14 @@ let rec atomics_of_operation = function
 			VM_destroy id
 		]
 	| VM_restore_devices id ->
+		(* Note: VBD_plug does not take a "simplify" modifier, because VM_restore
+		 * never attaches the storage, even in "simplified" backends. This is necessary when
+		 * migrating a VM, where the storage can be attached only after the sender host
+		 * has detached itself. *)
 		[
 		] @ (List.map (fun vbd -> VBD_set_active (vbd.Vbd.id, true))
 			(VBD_DB.vbds id)
-		) @ simplify (List.map (fun vbd -> VBD_plug vbd.Vbd.id)
+		) @ (List.map (fun vbd -> VBD_plug vbd.Vbd.id)
 			(VBD_DB.vbds id |> vbd_plug_order)
 		) @ (List.map (fun vif -> VIF_set_active (vif.Vif.id, true))
 			(VIF_DB.vifs id)

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2332,10 +2332,10 @@ module VM = struct
 					)
 			) Oldest task vm
 
-	let restore task progress_callback vm vbds vifs data =
+	let restore task progress_callback vm _ vifs data =
 		with_xs (fun xs ->
 			with_data ~xs task data false (fun fd ->
-				build ~restore_fd:fd task vm vbds vifs
+				build ~restore_fd:fd task vm [] vifs
 			)
 		)
 


### PR DESCRIPTION
When migration a VM, its VBDs need to be attached after VM_restore, during the
VM_restore_devices operation.  This is the case in classic xenopsd, and must
also be the case in the xenlight version, because the sender host in a
migration detaches itself from the storage only after sending the memory image
across.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
