### PR TITLE
xenlight: set O_CLOEXEC when opening a file for libxl

### DIFF
--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2290,7 +2290,7 @@ module VM = struct
 							let flags =
 								if write
 								then [ Unix.O_WRONLY; Unix.O_CREAT ]
-								else [ Unix.O_RDONLY ] in
+								else [ Unix.O_RDONLY; Unix.O_CLOEXEC ] in
 							let filename = dir ^ "/suspend-image" in
 							Unixext.with_file filename flags 0o600
 								(fun fd ->


### PR DESCRIPTION
This fixes VM resume for HVM guests: it seems that when libxl forks qemu, qemu
inherits the suspend image fd that was opened by xenopsd, and keeps it open.
This makes it impossible for xenopsd to unmount and cleanup the mount that was
created for the suspend image, after the resume completes.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
