### PR TITLE
xenlight: give read-only VBDs to Xenlight.domain_create_restore

### DIFF
--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2369,10 +2369,11 @@ module VM = struct
 					)
 			) Oldest task vm
 
-	let restore task progress_callback vm _ vifs data =
+	let restore task progress_callback vm vbds vifs data =
 		with_xs (fun xs ->
 			with_data ~xs task data false (fun fd ->
-				build ~restore_fd:fd task vm [] vifs
+				let vbds = List.filter (fun vbd -> vbd.Vbd.mode = Vbd.ReadOnly) vbds in
+				build ~restore_fd:fd task vm vbds vifs
 			)
 		)
 


### PR DESCRIPTION
Attempt to fix resume and migrate for HVM guests with inserted CDs.
