### PR TITLE
CA-118130: Allow a domain to write to /local/domain/<domid>/hvmloader

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -223,7 +223,7 @@ let make ~xc ~xs vm_info uuid =
 				let ent = sprintf "%s/%s" dom_path dir in
 				t.Xst.mkdir ent;
 				t.Xst.setperms ent rwperm
-			) [ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data" ];
+			) [ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data"; "hvmloader" ];
 		);
 
 		xs.Xs.writev dom_path (filtered_xsdata vm_info.xsdata);


### PR DESCRIPTION
Fix to prevent EACCES errors when a domain writes to the hvmloader/generation-id-address field on boot

Signed-off-by: Akshay Ramani akshay.ramani@citrix.com
