### PR TITLE
xenopsd: Support driver domains for PV guests

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -927,7 +927,7 @@ module VM = struct
 				} in
 			let bridge_of_network = function
 				| Network.Local b -> b
-				| Network.Remote (_, _) -> failwith "Need to create a VIF frontend" in
+				| Network.Remote (_, b) -> b in
 			let nics = List.map (fun vif ->
 				vif.Vif.mac,
 				bridge_of_network vif.Vif.backend,
@@ -1942,7 +1942,7 @@ module VIF = struct
 							Device.Vif.add ~xs ~devid:vif.position
 								~netty:(match vif.backend with
 									| Network.Local x -> Netman.Vswitch x
-									| Network.Remote (_, _) -> raise (Unimplemented "network driver domains"))
+									| Network.Remote (_, x) -> Netman.Vswitch x)
 								~mac:vif.mac ~carrier:(vif.carrier && (vif.locking_mode <> Xenops_interface.Vif.Disabled))
 								~mtu:vif.mtu ~rate:vif.rate ~backend_domid
 								~other_config:vif.other_config


### PR DESCRIPTION
The case of HVM guests with emulated QEMU networks devices is not yet
handled.

(This patch was already in xen-api.git, but went missing after splitting off xenopsd)
