### PR TITLE
Add vm pre-resume hook.

### DIFF
--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -25,6 +25,7 @@ let scriptname__vm_pre_destroy  = "vm-pre-shutdown"
 let scriptname__vm_pre_migrate  = "vm-pre-migrate"
 let scriptname__vm_pre_start    = "vm-pre-start"
 let scriptname__vm_pre_reboot   = "vm-pre-reboot"
+let scriptname__vm_pre_resume   = "vm-pre-resume"
 let scriptname__vm_post_destroy  = "vm-post-destroy"
 
 (* VM Script hook reason codes *)
@@ -80,6 +81,8 @@ let vm_pre_start ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_start ~reason ~id
 let vm_pre_reboot ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_reboot ~reason ~id
+let vm_pre_resume ~reason ~id =
+  execute_vm_hook ~script_name:scriptname__vm_pre_resume ~reason ~id
 let vm_post_destroy ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_post_destroy ~reason ~id
 
@@ -88,6 +91,7 @@ type script =
 	| VM_pre_migrate
 	| VM_pre_start
 	| VM_pre_reboot
+	| VM_pre_resume
 	| VM_post_destroy
 with rpc
 
@@ -97,5 +101,6 @@ let vm ~script ~reason ~id =
 		| VM_pre_migrate  -> scriptname__vm_pre_migrate
 		| VM_pre_start    -> scriptname__vm_pre_start
 		| VM_pre_reboot   -> scriptname__vm_pre_reboot
+		| VM_pre_resume   -> scriptname__vm_pre_resume
 		| VM_post_destroy -> scriptname__vm_post_destroy in
 	execute_vm_hook ~script_name ~reason ~id

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -853,6 +853,7 @@ let rec atomics_of_operation = function
 		simplify [
 			VM_create (id, None);
 		] @ [
+			VM_hook_script(id, Xenops_hooks.VM_pre_resume, Xenops_hooks.reason__none);
 			VM_restore (id, data);
 		] @ (atomics_of_operation (VM_restore_devices id)
 		) @ [


### PR DESCRIPTION
No hooks are currently triggered on resume - including resume after
a live migrate, which is the only possible time a hook could trigger
on a new VM on the target host.
