### PR TITLE
CA-136054: Update path to 64-bit vgpu-binary to allow vgpu-vms to start

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1888,7 +1888,7 @@ let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready
 			let args = vgpu_args_of_info info domid in
 			let ready_path = Printf.sprintf "/local/domain/%d/vgpu-pid" domid in
 			let cancel = Cancel_utils.Vgpu domid in
-			let vgpu_pid = init_daemon ~task ~path:"/usr/lib/xen/bin/vgpu" ~args
+			let vgpu_pid = init_daemon ~task ~path:"/usr/lib64/xen/bin/vgpu" ~args
 				~name:"vgpu" ~domid ~xs ~ready_path ~timeout:!Xenopsd.vgpu_ready_timeout ~cancel () in
 			Forkhelpers.dontwaitpid vgpu_pid
 		| None -> () in


### PR DESCRIPTION
The vgpu binary is now located in /usr/lib64/xen/bin/vgpu instead of
/usr/lib/xen/bin/vgpu.

Signed-off-by: Robert Breker robert.breker@citrix.com
