### PR TITLE
CA-136054: Make path to vgpu configurable

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1888,7 +1888,7 @@ let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready
 			let args = vgpu_args_of_info info domid in
 			let ready_path = Printf.sprintf "/local/domain/%d/vgpu-pid" domid in
 			let cancel = Cancel_utils.Vgpu domid in
-			let vgpu_pid = init_daemon ~task ~path:"/usr/lib/xen/bin/vgpu" ~args
+			let vgpu_pid = init_daemon ~task ~path:!Xc_path.vgpu ~args
 				~name:"vgpu" ~domid ~xs ~ready_path ~timeout:!Xenopsd.vgpu_ready_timeout ~cancel () in
 			Forkhelpers.dontwaitpid vgpu_pid
 		| None -> () in

--- a/xc/xc_path.ml
+++ b/xc/xc_path.ml
@@ -25,6 +25,7 @@ let mount = ref "/bin/mount"
 let umount = ref "/bin/umount"
 let ionice = ref "/usr/bin/ionice"
 let setup_vif_rules = ref "/usr/lib/xcp/lib/setup-vif-rules"
+let vgpu = ref "/usr/lib/xen/bin/vgpu"
 let hvmloader = ref "/usr/lib/xen-4.1/boot/hvmloader"
 
 let alternatives = ref "/usr/lib/xcp/alternatives"
@@ -47,5 +48,6 @@ let essentials = [
 let nonessentials = [
 	X_OK, "pci-flr-script", pci_flr_script, "path to the PCI function-level reset script";
 	X_OK, "alternatives", alternatives, "path to the alternative xenguests";
+	X_OK, "vgpu", vgpu, "path to the vgpu binary";
 ]
 


### PR DESCRIPTION
vgpu is currently a non-essential resource as it's not yet installed in
trunk. We may or may not want to change this in the future.
