### PR TITLE
CA-116551: Prevent xenguest from creating extra log files.

### DIFF
--- a/xc/xenguestHelper.ml
+++ b/xc/xenguestHelper.ml
@@ -49,9 +49,7 @@ let connect path domid (args: string list) (fds: (string * Unix.file_descr) list
 	let server_to_slave_r, server_to_slave_w = Unix.pipe () in
 
 	let args = [ "-controloutfd"; slave_to_server_w_uuid;
-		     "-controlinfd"; server_to_slave_r_uuid;
-		     "-debuglog";
-		     last_log_file
+		     "-controlinfd"; server_to_slave_r_uuid
 	] @ args in
 	let pid = Forkhelpers.safe_close_and_exec None None None 
 	  ([ slave_to_server_w_uuid, slave_to_server_w;


### PR DESCRIPTION
The C xenguest will write that log if given a "-debuglog /path/to/log" argument. By omitting the argument we prevent a file being created for each domain on the host under /tmp.

Signed-off-by: Akshay akshay.ramani@citrix.com
