### PR TITLE
Make libxl happy

### DIFF
--- a/xc/xenops_xc_main.ml
+++ b/xc/xenops_xc_main.ml
@@ -39,11 +39,15 @@ let check_domain0_uuid () =
 	   because the background thread will be gone after the fork() *)
 	forget_client ()	
 
+let make_var_run_xen () =
+	Unixext.mkdir_rec "/var/run/xen" 0o0755
+
 (* Start the program with the xen backend *)
 let _ =
 	Xenops_interface.queue_name := !Xenops_interface.queue_name ^ ".classic";
 	Xenops_utils.set_root "xenopsd/classic";
 	check_domain0_uuid ();
+	make_var_run_xen ();
 	Xenopsd.main
 		~specific_essential_paths:Xc_path.essentials
 		~specific_nonessential_paths:Xc_path.nonessentials

--- a/xl/xenops_xl_main.ml
+++ b/xl/xenops_xl_main.ml
@@ -28,12 +28,16 @@ let make_vnc_dir () =
 	Xl_path.vnc_dir := Filename.concat (Xenops_utils.get_root ()) "vnc";
 	Unixext.mkdir_rec !Xl_path.vnc_dir 0o0755
 
+let make_var_run_xen () =
+	Unixext.mkdir_rec "/var/run/xen" 0o0755
+
 (* Start the program with the xenlight backend *)
 let _ =
 	Xenops_interface.queue_name := !Xenops_interface.queue_name ^ ".xenlight";
 	Xenops_utils.set_root "xenopsd/xenlight";
 	check_domain0_uuid ();
 	make_vnc_dir ();
+	make_var_run_xen ();
 	Xenopsd.main
 		~specific_essential_paths:Xl_path.essentials
 		~specific_nonessential_paths:Xl_path.nonessentials


### PR DESCRIPTION
We need to
- xenstore-write /local/domain/0/domid 0
- mkdir -p /var/run/xen

to make libxl happy. If libxl is unhappy then the error messages can be hard to understand.
