### PR TITLE
CA-138930: Xapi should not call domain_set_memmap_limit for HVM domains.

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -499,9 +499,11 @@ let build_pre ~xc ~xs ~vcpus ~xen_max_mib ~shadow_mib ~required_host_free_mib do
 	) vpt_align;
 	debug "VM = %s; domid = %d; domain_max_vcpus %d" (Uuid.to_string uuid) domid vcpus;
 	Xenctrl.domain_max_vcpus xc domid vcpus;
-	debug "VM = %s; domid = %d; domain_set_memmap_limit %Ld MiB" (Uuid.to_string uuid) domid xen_max_mib;
-	begin
-		let kib = Memory.kib_of_mib xen_max_mib in
+	let di = Xenctrl.domain_getinfo xc domid in
+	if not (di.Xenctrl.hvm_guest) then
+		begin
+			debug "VM = %s; domid = %d; domain_set_memmap_limit %Ld MiB" (Uuid.to_string uuid) domid xen_max_mib;
+			let kib = Memory.kib_of_mib xen_max_mib in
 		try
 			Xenctrl.domain_set_memmap_limit xc domid kib
 		with e ->


### PR DESCRIPTION
Since Xen 4.2 the hypercall behind xc_domain_set_memmap_limit() is not
permitted for HVM domains. Xapi should only call this for PV domains.

Signed-off-by: Akshay akshay.ramani@citrix.com
