### PR TITLE
CP-8987: Deserialise the Xenops record on restore

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -821,8 +821,10 @@ let restore_common (task: Xenops_task.t) ~xc ~xs ~hvm ~store_port ~store_domid ~
 			read_header fd >>= function
 			| Xenops, len ->
 				debug "Read Xenops record header (length=%Ld)" len;
-				let _ = Io.read fd (Io.int_of_int64_exn len) in
+				let rec_str = Io.read fd (Io.int_of_int64_exn len) in
 				debug "Read Xenops record contents";
+				let (_ : Xenops_record.t) = Xenops_record.of_string rec_str in
+				debug "Validated Xenops record contents";
 				process_header res
 			| Libxc, _ ->
 				debug "Read Libxc record header";


### PR DESCRIPTION
We want to make sure we're receiving a valid suspend image so, as well as
reading in the right amount of length for the record (checking that the
macro-structure of the suspend image is correct), we should also attempt to
deserialise the Xenops_record to check that it is valid on a deeper level. For
now, we are not doing anything with it but the deserialisation alone checks the
validity.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
