### PR TITLE
CA-140252: Hack for legacy PV tools evtchn alignment

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -35,6 +35,7 @@ let use_upstream_qemu = ref false
 let watch_queue_length = ref 1000
 
 let default_vbd_backend_kind = ref "vbd"
+let ca_140252_workaround = ref false
 
 let options = [
     "queue", Arg.Set_string Xenops_interface.queue_name, (fun () -> !Xenops_interface.queue_name), "Listen on a specific queue";
@@ -49,6 +50,7 @@ let options = [
     "use-qdisk", Arg.Bool (fun x -> use_qdisk := x), (fun () -> string_of_bool !use_qdisk), "True if we want to use QEMU as our storage backend";
     "use-upstream-qemu", Arg.Bool (fun x -> use_upstream_qemu := x), (fun () -> string_of_bool !use_upstream_qemu), "True if we want to use upsteam QEMU";
 	"default-vbd-backend-kind", Arg.Set_string default_vbd_backend_kind, (fun () -> !default_vbd_backend_kind), "Default backend for VBDs";
+	"ca-140252-workaround", Arg.Bool (fun x -> ca_140252_workaround := x), (fun () -> string_of_bool !ca_140252_workaround), "Workaround for evtchn misalignment for legacy PV tools";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -473,6 +473,8 @@ let get_action_request ~xs domid =
 
 (** create store and console channels *)
 let create_channels ~xc uuid domid =
+	if !Xenopsd.ca_140252_workaround
+	then ignore_int (Xenctrl.evtchn_alloc_unbound xc domid 0);
 	let store = Xenctrl.evtchn_alloc_unbound xc domid 0 in
 	let console = Xenctrl.evtchn_alloc_unbound xc domid 0 in
 	debug "VM = %s; domid = %d; store evtchn = %d; console evtchn = %d" (Uuid.to_string uuid) domid store console;

--- a/xenopsd.conf
+++ b/xenopsd.conf
@@ -70,3 +70,6 @@ disable-logging-for=http
 
 # Default backend for VBDs (used in XenStore)
 # default-vbd-backend-kind=vbd
+
+# Workaround for ca-140252: evtchn misalignment workaround for legacy PV tools
+# ca-140252-workaround=false


### PR DESCRIPTION
Since the new ioreq server in Xen, one of its event channels is now allocated
on-demand rather than eagerly at start-of-day. Therefore, when the toolstack
comes to allocate event channels for Xenstore and the console, they are
shuffled down by one.

This is fine for HVM guests with modern PV tools since they re-read this
information upon each resume. However, legacy PV tools do not and rely on these
to be the same across suspend/resume.

This patch adds an explicit workaround to realign the event channels as they
were on previous versions by having Xenopsd allocating another channel before
the two it needs. As this is done with evtchn_allocate_unbound and the guest
will not bind it, it should not affect event channel scalability in dom0.

The workaround has been made explicit and a configuration option in Xenopsd so
that we can only carry it until such a time that we no longer support HVM
guests using these legacy PV tools, at which point it can be removed.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
