### PR TITLE
CA-141723: Allocate one evtchn per-VCPU in alignment hack

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -472,9 +472,12 @@ let get_action_request ~xs domid =
 		Some (xs.Xs.read path)
 	with Xs_protocol.Enoent _ -> None
 
-let maybe_ca_140252_workaround ~xc domid =
-	if !Xenopsd.ca_140252_workaround
-	then ignore_int (Xenctrl.evtchn_alloc_unbound xc domid 0)
+let maybe_ca_140252_workaround ~xc ~vcpus domid =
+	if !Xenopsd.ca_140252_workaround then
+		debug "Allocating %d I/O req evtchns in advance for device model" vcpus;
+		for i = 1 to vcpus do
+			ignore_int (Xenctrl.evtchn_alloc_unbound xc domid 0)
+		done
 
 (** create store and console channels *)
 let create_channels ~xc uuid domid =
@@ -679,7 +682,7 @@ let build_hvm (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~static_
 	let required_host_free_mib =
 		Memory.HVM.footprint_mib target_mib static_max_mib vcpus shadow_multiplier in
 
-	maybe_ca_140252_workaround ~xc domid;
+	maybe_ca_140252_workaround ~xc ~vcpus domid;
 	let store_port, console_port = build_pre ~xc ~xs
 		~xen_max_mib ~shadow_mib ~required_host_free_mib ~vcpus domid in
 
@@ -925,7 +928,7 @@ let hvm_restore (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~no_in
 	let required_host_free_mib =
 		Memory.HVM.footprint_mib target_mib static_max_mib vcpus shadow_multiplier in
 
-	maybe_ca_140252_workaround ~xc domid;
+	maybe_ca_140252_workaround ~xc ~vcpus domid;
 	let store_port, console_port = build_pre ~xc ~xs
 		~xen_max_mib ~shadow_mib ~required_host_free_mib ~vcpus domid in
 


### PR DESCRIPTION
When allocating event channels at start-of-day for HVM guests so that they're
backwards-compatible with old PV drivers (see c1a4c42), make sure we allocate
one event channel for each VCPU since each VCPU will have an IO req. event
channel bound.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
