### PR TITLE
CP-9229: Use new path for convert-legacy-stream

### DIFF
--- a/lib/path.ml
+++ b/lib/path.ml
@@ -19,7 +19,7 @@ let chgrp = ref "chgrp"
 let hvmloader = ref "hvmloader"
 let pygrub = ref "pygrub"
 let eliloader = ref "eliloader"
-let legacy_conv_tool = ref "legacy.py"
+let legacy_conv_tool = ref "convert-legacy-stream"
 let verify_libxc_v2 = ref "verify-stream-v2"
 
 open Unix
@@ -45,7 +45,7 @@ let essentials = [
 ]
 
 let nonessentials = [
-	X_OK, "legacy.py", legacy_conv_tool, "path to legacy.py conversion tool"
+	X_OK, "convert-legacy-stream", legacy_conv_tool, "path to convert-legacy-stream tool"
 ]
 
 let make_resources ~essentials ~nonessentials =

--- a/lib/suspend_image.ml
+++ b/lib/suspend_image.ml
@@ -186,7 +186,7 @@ let with_conversion_script task name hvm fd f =
 		(thread, status)
 	in
 	let (conv_th, conv_st) =
-		spawn_thread_and_close_fd "legacy.py" pipe_w (fun () ->
+		spawn_thread_and_close_fd "convert-legacy-stream" pipe_w (fun () ->
 			Cancellable_subprocess.run task
 				[ fd_uuid, fd; pipe_w_uuid, pipe_w; ] conv_script args
 		)


### PR DESCRIPTION
The previous path (.../legacy.py) was a symlink for backwards compatibility
with development and we would like to remove it before release.

Signed-off-by: Si Beaumont simon.beaumont@citrix.com
