### PR TITLE
Cleanup shutdown cancel path after use

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -445,6 +445,8 @@ let destroy (task: Xenops_task.t) ~xc ~xs ~qemu_domid domid =
 		else
 			log_exn_rm ~xs (Hotplug.get_hotplug_base_by_uuid uuid domid)
 	end;
+	(* Also zap any remaining cancellation paths in xenstore *)
+	Cancel_utils.cleanup_for_domain ~xs domid;
 
 	(* Block waiting for the dying domain to disappear: aim is to catch shutdown errors early*)
 	let still_exists () = 


### PR DESCRIPTION
Since private xenstore paths are now UUID-based, a shutdown cancel path persist
across a localhost migration. This causes a following localhost migration to
fail: the cancel path that still exists causes the cancellable watch that waits
for the domain to ack the shutdown request to fire immediately, and cancel the
migration.

We solve this by moving all cancel-related xenstore keys out of the
"/xapi/<uuid>" tree and into its own domid-based xenstore tree. We then zap
this tree on domain destroy.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
