### PR TITLE
CP-9227: Safeguard against malicious suspend images

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -786,6 +786,11 @@ let restore_libxc_record (task: Xenops_task.t) ~hvm ~store_port ~console_port ~e
 		raise Domain_restore_failed
 
 let consume_qemu_record fd limit domid uuid =
+	if limit > 1_048_576L then begin (* 1MB *)
+		error "VM = %s; domid = %d; QEMU record length in header too large (%Ld bytes)"
+			(Uuid.to_string uuid) domid limit;
+		raise Suspend_image_failure
+	end;
 	let file = sprintf qemu_restore_path domid in
 	let fd2 = Unix.openfile file
 		[ Unix.O_WRONLY; Unix.O_CREAT; Unix.O_TRUNC; ] 0o640
@@ -793,7 +798,15 @@ let consume_qemu_record fd limit domid uuid =
 	finally (fun () ->
 		debug "VM = %s; domid = %d; reading %Ld bytes from %s"
 			(Uuid.to_string uuid) domid limit file;
-		if Unixext.copy_file ~limit fd fd2 <> limit
+		let bytes =
+			try
+				Unixext.copy_file ~limit fd fd2
+			with Unix.Unix_error (e, s1, s2) ->
+				error "VM = %s; domid = %d; %s, %s, %s" (Uuid.to_string uuid) domid (Unix.error_message e) s1 s2;
+				Unixext.unlink_safe file;
+				raise Suspend_image_failure
+		in
+		if bytes <> limit
 		then begin
 			error "VM = %s; domid = %d; qemu save file was truncated"
 				(Uuid.to_string uuid) domid;


### PR DESCRIPTION
During VM.resume, as part of Domain.restore in Xenopsd, when a Qemu record in
the suspend image is detected, the header is parsed (with a length) and then
this number of bytes is written out to a file in dom0's filesystem to be passed
to Qemu.

This patch:
- Catches any error that may occur when writing the file for qemu.
- Puts some sanity checks when parsing the length in the Qemu record header.
  This should be large enough that we won't need to change it if/when we
  upgrade Qemu to future versions but small enough to avoid a DoS. Qemu save
  records are currently around 7-8k. We have chosen to read a max of 1M and
  raise an exception if we parse a suspend image that claims to have a Qemu
  record bigger than this.

Signed-off-by: Rob Hoes rob.hoes@citrix.com
