### PR TITLE
CP-9366: Use HVM feature-flags instead of checking PV drivers

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -819,8 +819,6 @@ module VM = struct
 	) Newest task vm
 
 	let set_vcpus task vm target = on_domain (fun xc xs _ _ di ->
-		if di.Xenctrl.hvm_guest then raise (Unimplemented("vcpu hotplug for HVM domains"));
-
 		let domid = di.Xenctrl.domid in
 		(* Returns the instantaneous CPU number from xenstore *)
 		let current =

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1812,8 +1812,6 @@ module VM = struct
 
 	let set_vcpus task vm target = on_domain (fun _ xs _ _ di _ ->
 		let open Xenlight.Dominfo in
-		if di.domain_type = Xenlight.DOMAIN_TYPE_HVM then
-			raise (Unimplemented("vcpu hotplug for HVM domains"));
 
 		let set ~xs ~devid domid online =
 			let path = Printf.sprintf "/local/domain/%d/cpu/%d/availability" domid devid in


### PR DESCRIPTION
Goes with xapi-project/xen-api#1894
