### PR TITLE
Fix build: lib/suspend_image.ml needs camlp4

### DIFF
--- a/_tags
+++ b/_tags
@@ -425,6 +425,7 @@
 # OASIS_STOP
 <lib/updates.ml>: syntax_camlp4o, pkg_rpc.syntax
 <lib/scheduler.ml>: syntax_camlp4o, pkg_rpc.syntax
+<lib/suspend_image.ml>: syntax_camlp4o, pkg_sexplib.syntax
 <lib/xenops_migrate.ml>: syntax_camlp4o, pkg_rpc.syntax
 <lib/xenops_hooks.ml>: syntax_camlp4o, pkg_rpc.syntax
 <lib/xenops_server.ml>: syntax_camlp4o, pkg_rpc.syntax


### PR DESCRIPTION
I don't understand why this built for anyone before.

Signed-off-by: David Scott dave.scott@citrix.com
