### PR TITLE
CA-118195: xenlight: set O_CLOEXEC when opening a file for libxl

### DIFF
--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2284,20 +2284,20 @@ module VM = struct
 			with_disk ~xs task disk write (fun path ->
 				let with_fd_of_path p f =
 					let is_raw_image =
-						Unixext.with_file path [Unix.O_RDONLY] 0o400 (fun fd ->
+						Unixext.with_file path [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o400 (fun fd ->
 							match Suspend_image.read_save_signature fd with
 							| `Ok _ -> true | _ -> false
 						)
 					in
 					match (write, is_raw_image) with
 					| true, _ -> (* Always write raw *)
-						Unixext.with_file path [Unix.O_WRONLY] 0o600 f
+						Unixext.with_file path [Unix.O_WRONLY; Unix.O_CLOEXEC] 0o600 f
 					| false, true -> (* We're reading raw *)
-						Unixext.with_file path [Unix.O_RDONLY] 0o600 f
+						Unixext.with_file path [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o600 f
 					| false, false -> (* Assume reading from filesystem *)
 						with_mounted_dir p (fun dir ->
 							let filename = dir ^ "/suspend-image" in
-							Unixext.with_file filename [Unix.O_RDONLY] 0o600 f
+							Unixext.with_file filename [Unix.O_RDONLY; Unix.O_CLOEXEC] 0o600 f
 						)
 				in
 				with_fd_of_path path (fun fd ->


### PR DESCRIPTION
This change was lost in the recent suspend image conversion work.

Signed-off-by: David Scott dave.scott@citrix.com
