### PR TITLE
Update the example xenopsd.conf to mention the switch and inventory

### DIFF
--- a/xenopsd.conf
+++ b/xenopsd.conf
@@ -3,6 +3,13 @@
 # Default paths to search for binaries
 # search-path=
 
+# The location of the inventory file
+inventory = /etc/xensource-inventory
+
+# True to use the message switch; false for direct Unix domain socket
+# comms
+use-switch = false
+
 # false means use the real xen backend; true the simulation backend
 simulate=false
 


### PR DESCRIPTION
These are the current recommended defaults:
- /etc/xensource-inventory
- direct unix domain socket communication

Signed-off-by: David Scott dave.scott@eu.citrix.com
