### PR TITLE
Reinstate "CP-9366: Use HVM feature-flags instead of checking PV drivers"

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -819,8 +819,6 @@ module VM = struct
 	) Newest task vm
 
 	let set_vcpus task vm target = on_domain (fun xc xs _ _ di ->
-		if di.Xenctrl.hvm_guest then raise (Unimplemented("vcpu hotplug for HVM domains"));
-
 		let domid = di.Xenctrl.domid in
 		(* Returns the instantaneous CPU number from xenstore *)
 		let current =
@@ -2169,6 +2167,7 @@ module Actions = struct
 			sprintf "/local/domain/%d/memory/uncooperative" domid;
 			sprintf "/local/domain/%d/console/vnc-port" domid;
 			sprintf "/local/domain/%d/console/tc-port" domid;
+			sprintf "/local/domain/%d/control" domid;
 			sprintf "/local/domain/%d/device" domid;
 			sprintf "/local/domain/%d/rrd" domid;
 			sprintf "/local/domain/%d/vm-data" domid;

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1833,8 +1833,6 @@ module VM = struct
 
 	let set_vcpus task vm target = on_domain (fun _ xs _ _ di _ ->
 		let open Xenlight.Dominfo in
-		if di.domain_type = Xenlight.DOMAIN_TYPE_HVM then
-			raise (Unimplemented("vcpu hotplug for HVM domains"));
 
 		let set ~xs ~devid domid online =
 			let path = Printf.sprintf "/local/domain/%d/cpu/%d/availability" domid devid in
@@ -2610,6 +2608,7 @@ let all_domU_watches domid uuid =
 		sprintf "/local/domain/%d/memory/uncooperative" domid;
 		sprintf "/local/domain/%d/console/vnc-port" domid;
 		sprintf "/local/domain/%d/console/tc-port" domid;
+		sprintf "/local/domain/%d/control" domid;
 		sprintf "/local/domain/%d/device" domid;
 		sprintf "/local/domain/%d/vm-data" domid;
 		sprintf "/vm/%s/rtc/timeoffset" uuid;


### PR DESCRIPTION
Reverts xapi-project/xenopsd#127
i.e. re-does xapi-project/xenopsd#113
This is needed for xapi-project/xen-api#1978
