### PR TITLE
CA-151613: Pass -priv flag to qemu when doing PCI passthrough

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1809,6 +1809,7 @@ let cmdline_of_info info restore domid =
 	@ (if info.acpi then [ "-acpi" ] else [])
 	@ (if restore then [ "-loadvm"; restorefile ] else [])
 	@ (List.fold_left (fun l pci -> "-pciemulation" :: pci :: l) [] (List.rev info.pci_emulations))
+	@ (if info.pci_passthrough then ["-priv"] else [])
 	@ (List.fold_left (fun l (k, v) -> ("-" ^ k) :: (match v with None -> l | Some v -> v :: l)) [] info.extras)
 	@ (Opt.default [] (Opt.map (fun x -> [ "-monitor"; x ]) info.monitor))
 	@ (Opt.default [] (Opt.map (fun x -> [ "-parallel"; x]) info.parallel))


### PR DESCRIPTION
This was originally removed on the xs64bit branch as CA-133523, but the
removal was reverted.
