### PR TITLE
CP-10236: Add watch for data/ts

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2163,6 +2163,7 @@ module Actions = struct
 	let interesting_paths_for_domain domid uuid =
 		let open Printf in [
 			sprintf "/local/domain/%d/data/updated" domid;
+			sprintf "/local/domain/%d/data/ts" domid;
 			sprintf "/local/domain/%d/memory/target" domid;
 			sprintf "/local/domain/%d/memory/uncooperative" domid;
 			sprintf "/local/domain/%d/console/vnc-port" domid;

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2637,6 +2637,7 @@ let list_different_domains a b =
 let all_domU_watches domid uuid =
 	let open Printf in [
 		sprintf "/local/domain/%d/data/updated" domid;
+		sprintf "/local/domain/%d/data/ts" domid;
 		sprintf "/local/domain/%d/memory/target" domid;
 		sprintf "/local/domain/%d/memory/uncooperative" domid;
 		sprintf "/local/domain/%d/console/vnc-port" domid;


### PR DESCRIPTION
Since RDP status will update to VM guest metrics from data/ts, add watch on such key, so the data will update in time.
Signed-off-by: Cheng Zhang cheng.zhang@citrix.com
