### PR TITLE
[RFC] xc: support floppy disk images

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -330,15 +330,17 @@ let physty_of_string s =
 	| "file" -> File
 	| _      -> invalid_arg "physty_of_string"
 
-type devty = CDROM | Disk
+type devty = CDROM | Disk | Floppy
 
 let string_of_devty = function
 	| CDROM -> "cdrom"
 	| Disk  -> "disk"
+	| Floppy -> "floppy"
 
 let devty_of_string = function
 	| "cdrom" -> CDROM
 	| "disk"  -> Disk
+	| "floppy" -> Floppy
 	| _       -> invalid_arg "devty_of_string"
 
 let add_backend_keys ~xs (x: device) subdir keys =

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -40,7 +40,7 @@ sig
 	val physty_of_string : string -> physty
 	val uses_blktap : phystype:physty -> bool
 
-	type devty = CDROM | Disk
+	type devty = CDROM | Disk | Floppy
 	val string_of_devty : devty -> string
 	val devty_of_string : string -> devty
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1662,6 +1662,7 @@ module VBD = struct
 						dev_type = (match vbd.ty with
 							| CDROM -> Device.Vbd.CDROM
 							| Disk -> Device.Vbd.Disk
+							| Floppy -> Device.Vbd.Floppy
 						);
 						unpluggable = vbd.unpluggable;
 						protocol = None;

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1004,6 +1004,7 @@ module VBD = struct
 		let is_cdrom = match vbd.ty with
 			| CDROM -> 1
 			| Disk -> 0
+			| Floppy -> 0
 		in
 
 		(* Remember the VBD id with the device *)


### PR DESCRIPTION
This relies on qemu traditional understanding the Xenstore key.
There is no PV floppy support.

libxl doesn't support floppies either.

Requires:
- [xapi-project/xcp-idl#46]

Signed-off-by: David Scott <dave.scott@eu.citrix.com>