### PR TITLE
CA-159588: use synchronous libxl domain destroy rather than async

### DIFF
--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1811,7 +1811,7 @@ module VM = struct
 			if DB.exists vm.Vm.id then DB.remove vm.Vm.id;
 		end;
 		debug "Calling Xenlight.domain_destroy domid=%d" domid;
-		with_ctx (fun ctx -> Xenlight_events.async (Xenlight.Domain.destroy ctx domid)); 
+		with_ctx (fun ctx -> Xenlight.Domain.destroy ctx domid ());
 		debug "Call Xenlight.domain_destroy domid=%d completed" domid;
 
 		let log_exn_continue msg f x = try f x with e -> debug "Safely ignoring exception: %s while %s" (Printexc.to_string e) msg in


### PR DESCRIPTION
The async version was failing part of the way through with a timeout,
after killing the qemu but before killing the domain.

The synchronous version seems to work ok.

Signed-off-by: David Scott <dave.scott@eu.citrix.com>