### PR TITLE
Add hooks for post-resume and post-migrate

### DIFF
--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -23,9 +23,11 @@ let hooks_dir = "/etc/xapi.d/"
 (* Names of VM script hooks *)
 let scriptname__vm_pre_destroy  = "vm-pre-shutdown"
 let scriptname__vm_pre_migrate  = "vm-pre-migrate"
+let scriptname__vm_post_migrate = "vm-post-migrate"
 let scriptname__vm_pre_start    = "vm-pre-start"
 let scriptname__vm_pre_reboot   = "vm-pre-reboot"
 let scriptname__vm_pre_resume   = "vm-pre-resume"
+let scriptname__vm_post_resume   = "vm-post-resume"
 let scriptname__vm_post_destroy  = "vm-post-destroy"
 
 (* VM Script hook reason codes *)
@@ -35,6 +37,7 @@ let reason__clean_reboot   = "clean-reboot"
 let reason__hard_reboot    = "hard-reboot"
 let reason__suspend        = "suspend"
 let reason__migrate_source = "source" (* passed to pre-migrate hook on source host *)
+let reason__migrate_dest   = "destination" (* passed to post-migrate hook on destination host *)
 let reason__none = "none"
 
 (* Exit codes: *)
@@ -77,21 +80,27 @@ let vm_pre_destroy ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_destroy ~reason ~id
 let vm_pre_migrate ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_migrate ~reason ~id
+let vm_post_migrate ~reason ~id =
+  execute_vm_hook ~script_name:scriptname__vm_post_migrate ~reason ~id
 let vm_pre_start ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_start ~reason ~id
 let vm_pre_reboot ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_reboot ~reason ~id
 let vm_pre_resume ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_resume ~reason ~id
+let vm_post_resume ~reason ~id =
+  execute_vm_hook ~script_name:scriptname__vm_post_resume ~reason ~id
 let vm_post_destroy ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_post_destroy ~reason ~id
 
 type script =
 	| VM_pre_destroy
 	| VM_pre_migrate
+	| VM_post_migrate
 	| VM_pre_start
 	| VM_pre_reboot
 	| VM_pre_resume
+	| VM_post_resume
 	| VM_post_destroy
 with rpc
 
@@ -99,8 +108,10 @@ let vm ~script ~reason ~id =
 	let script_name = match script with
 		| VM_pre_destroy  -> scriptname__vm_pre_destroy
 		| VM_pre_migrate  -> scriptname__vm_pre_migrate
+		| VM_post_migrate -> scriptname__vm_post_migrate
 		| VM_pre_start    -> scriptname__vm_pre_start
 		| VM_pre_reboot   -> scriptname__vm_pre_reboot
 		| VM_pre_resume   -> scriptname__vm_pre_resume
+		| VM_post_resume  -> scriptname__vm_post_resume
 		| VM_post_destroy -> scriptname__vm_post_destroy in
 	execute_vm_hook ~script_name ~reason ~id

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -862,7 +862,8 @@ let rec atomics_of_operation = function
 		] @ (atomics_of_operation (VM_restore_devices id)
 		) @ [
 			(* At this point the domain is considered survivable. *)
-			VM_set_domain_action_request(id, None)			
+			VM_set_domain_action_request(id, None);
+			VM_hook_script(id, Xenops_hooks.VM_post_resume, Xenops_hooks.reason__none);
 		]
 	| VBD_hotplug id ->
 		[
@@ -1348,7 +1349,8 @@ and perform ?subtask (op: operation) (t: Xenops_task.t) : unit =
 				perform_atomics ([
 				] @ (atomics_of_operation (VM_restore_devices id)) @ [
 					VM_unpause id;
-					VM_set_domain_action_request(id, None)
+					VM_set_domain_action_request(id, None);
+					VM_hook_script(id, Xenops_hooks.VM_post_migrate, Xenops_hooks.reason__migrate_dest);
 				]) t;
 
 				Handshake.send s Handshake.Success;


### PR DESCRIPTION
These hooks are necessary in environments where post-VM start operations
are needed, such as setup of VM firewall rules