### PR TITLE
CP-10125: Pass IGD passthrough arguments through to QEMU

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1614,6 +1614,7 @@ type disp_intf_opt =
     | Std_vga
     | Cirrus
     | Vgpu
+    | IGD_passthrough
 with rpc
 
 (* Display output / keyboard input *)
@@ -1737,6 +1738,7 @@ let cmdline_of_disp info =
 	    | Vgpu -> ["-vgpu"]
 	    | Std_vga -> ["-std-vga"]
 	    | Cirrus -> []
+	    | IGD_passthrough -> ["-std-vga"; "-gfx_passthru"]
 	in
 	let videoram_opt = ["-videoram"; string_of_int info.video_mib] in
 	let dom0_input_opts = function

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -170,6 +170,7 @@ sig
 	    | Std_vga
 	    | Cirrus
 	    | Vgpu
+	    | IGD_passthrough
 	val disp_intf_opt_of_rpc: Rpc.t -> disp_intf_opt
 	val rpc_of_disp_intf_opt: disp_intf_opt -> Rpc.t
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -888,6 +888,7 @@ module VM = struct
 				let video, vgpu = match video with
 					| Cirrus -> Device.Dm.Cirrus, None
 					| Standard_VGA -> Device.Dm.Std_vga, None
+					| IGD_passthrough -> Device.Dm.IGD_passthrough, None
 					| Vgpu ->
 						let vgpu =
 							try


### PR DESCRIPTION
Pass the appropriate flags to QEMU when the IGD_passthrough video type is specified.  Depends on changes to xcp-idl and xapi.