### PR TITLE
libxl: we use 'backend-kind=vbd' to mean 'blkback'

### DIFF
--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -989,7 +989,7 @@ module VBD = struct
 							then format_of_string (List.assoc "format" xd)
 							else Xenlight.DISK_FORMAT_QCOW2 in (* FIXME *)
 						Xenlight.DISK_BACKEND_QDISK, format, None
-					| "blkback" ->
+					| "vbd" ->
 						Xenlight.DISK_BACKEND_PHY, Xenlight.DISK_FORMAT_RAW, Some !Xl_path.vbd_script
 					| x ->
 						failwith (Printf.sprintf "libxl doesn't support backend-kind=%s" x)


### PR DESCRIPTION
We also have

- backend-kind=qdisk: qemu qdisk
- backend-kind=vbd3: tapdisk3

Signed-off-by: David Scott <dave.scott@citrix.com>