### PR TITLE
Remove unused trigger_power and trigger_sleep functions

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1138,15 +1138,6 @@ let send_s3resume ~xc domid =
 	debug "VM = %s; domid = %d; send_s3resume" (Uuid.to_string uuid) domid;
 	Xenctrlext.domain_send_s3resume xc domid
 
-let trigger_power ~xc domid =
-	let uuid = get_uuid ~xc domid in
-	debug "VM = %s; domid = %d; domain_trigger_power" (Uuid.to_string uuid) domid;
-	Xenctrlext.domain_trigger_power xc domid
-let trigger_sleep ~xc domid =
-	let uuid = get_uuid ~xc domid in
-	debug "VM = %s; domid = %d; domain_trigger_sleep" (Uuid.to_string uuid) domid;
-	Xenctrlext.domain_trigger_sleep xc domid
-
 let vcpu_affinity_set ~xc domid vcpu cpumap =
 	(*
 	let bitmap = ref Int64.zero in

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -162,12 +162,6 @@ val suspend: Xenops_task.Xenops_task.t -> xc: Xenctrl.handle -> xs: Xenstore.Xs.
 (** send a s3resume event to a domain *)
 val send_s3resume: xc: Xenctrl.handle -> domid -> unit
 
-(** send a power button push to a domain *)
-val trigger_power: xc: Xenctrl.handle -> domid -> unit
-
-(** send a sleep button push to a domain *)
-val trigger_sleep: xc: Xenctrl.handle -> domid -> unit
-
 (** Set cpu affinity of some vcpus of a domain using an boolean array *)
 val vcpu_affinity_set: xc: Xenctrl.handle -> domid -> int -> bool array -> unit
 

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -21,9 +21,6 @@ external domain_set_timer_mode: handle -> domid -> int -> unit = "stub_xenctrlex
 external domain_send_s3resume: handle -> domid -> unit = "stub_xenctrlext_domain_send_s3resume"
 external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_domain_get_acpi_s_state"
 
-external domain_trigger_power: handle -> domid -> unit = "stub_xenctrlext_domain_trigger_power"
-external domain_trigger_sleep: handle -> domid -> unit = "stub_xenctrlext_domain_trigger_sleep"
-
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
 type runstateinfo = {

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -21,9 +21,6 @@ external domain_set_timer_mode: handle -> domid -> int -> unit = "stub_xenctrlex
 external domain_send_s3resume: handle -> domid -> unit = "stub_xenctrlext_domain_send_s3resume"
 external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_domain_get_acpi_s_state"
 
-external domain_trigger_power: handle -> domid -> unit = "stub_xenctrlext_domain_trigger_power"
-external domain_trigger_sleep: handle -> domid -> unit = "stub_xenctrlext_domain_trigger_sleep"
-
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
 type runstateinfo = {

--- a/xc/xenctrlext_stubs.c
+++ b/xc/xenctrlext_stubs.c
@@ -156,24 +156,6 @@ CAMLprim value stub_xenctrlext_domain_set_timer_mode(value xch, value id, value 
 	CAMLreturn(Val_unit);
 }
 
-CAMLprim value stub_xenctrlext_domain_trigger_power(value xch, value domid)
-{
-	CAMLparam2(xch, domid);
-#if defined(XENCTRL_HAS_TRIGGER_POWER)
-	xc_domain_trigger_power(_H(xch), _D(domid));
-#endif
-	CAMLreturn(Val_unit);
-}
-
-CAMLprim value stub_xenctrlext_domain_trigger_sleep(value xch, value domid)
-{
-	CAMLparam2(xch, domid);
-#if defined(XENCTRL_HAS_TRIGGER_SLEEP)
-	xc_domain_trigger_sleep(_H(xch), _D(domid));
-#endif
-	CAMLreturn(Val_unit);
-}
-
 CAMLprim value stub_xenctrlext_domain_suppress_spurious_page_faults(value xch,
                                                            value domid)
 {


### PR DESCRIPTION
This is dead code, not called by anything high-level in xenopsd.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>