### PR TITLE
CP-11511: allow storage backends to choose a datapath

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -478,14 +478,11 @@ type t = {
 	dev_type: devty;
 	unpluggable: bool;
 	protocol: protocol option;
+	kind: Device_common.kind;
 	extra_backend_keys: (string * string) list;
 	extra_private_keys: (string * string) list;
 	backend_domid: int;
 }
-
-let device_kind_of_backend_keys backend_keys =
-	try Device_common.vbd_kind_of_string (List.assoc "backend-kind" backend_keys)
-	with Not_found -> Device_common.Vbd !Xenopsd.default_vbd_backend_kind
 
 let add_async ~xs ~hvm x domid =
 	let back_tbl = Hashtbl.create 16 and front_tbl = Hashtbl.create 16 in
@@ -496,9 +493,8 @@ let add_async ~xs ~hvm x domid =
 		| None ->
 			make (free_device ~xs hvm domid) in
 	let devid = to_xenstore_key device_number in
-	let kind = device_kind_of_backend_keys x.extra_backend_keys in
 	let device = 
-	  let backend = { domid = x.backend_domid; kind = kind; devid = devid }
+	  let backend = { domid = x.backend_domid; kind = x.kind; devid = devid }
 	  in  device_of_backend backend domid
 	in
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -52,12 +52,11 @@ sig
 		dev_type: devty;
 		unpluggable: bool;
 		protocol: protocol option;
+		kind: Device_common.kind;
 		extra_backend_keys: (string * string) list;
 		extra_private_keys: (string * string) list;
 		backend_domid: int;
 	}
-
-	val device_kind_of_backend_keys : (string * string) list -> kind
 
 	val add : Xenops_task.t -> xs:Xenstore.Xs.xsh -> hvm:bool -> t -> Xenctrl.domid -> device
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -70,7 +70,7 @@ with rpc
 type attached_vdi = {
 	domid: int;
 	attach_info: Storage_interface.attach_info;
-}
+} with rpc
 
 module VmExtra = struct
 	(** Extra data we store per VM. The persistent data is preserved when
@@ -193,6 +193,10 @@ let domid_of_uuid ~xc ~xs domain_selection uuid =
 
 let get_uuid ~xc domid = uuid_of_di (Xenctrl.domain_getinfo xc domid)
 
+let device_kind_of_backend_keys backend_keys =
+	try Device_common.vbd_kind_of_string (List.assoc "backend-kind" backend_keys)
+	with Not_found -> Device_common.Vbd !Xenopsd.default_vbd_backend_kind
+
 let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
 	let frontend_vm_id = get_uuid ~xc frontend_domid |> Uuidm.to_string in
 	let backend_vm_id = get_uuid ~xc vdi.domid |> Uuidm.to_string in
@@ -204,6 +208,7 @@ let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
 			(* There's no need to use a PV disk if we're in the same domain *)
 			Name vdi.attach_info.Storage_interface.params
 		| Some backend_domid ->
+			let kind = device_kind_of_backend_keys vdi.attach_info.Storage_interface.xenstore_data in
 			let t = {
 				Device.Vbd.mode = Device.Vbd.ReadWrite;
 				device_number = None; (* we don't mind *)
@@ -212,6 +217,7 @@ let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
 				dev_type = Device.Vbd.Disk;
 				unpluggable = true;
 				protocol = None;
+				kind;
 				extra_backend_keys = List.map (fun (k, v) -> "sm-data/" ^ k, v) (vdi.attach_info.Storage_interface.xenstore_data);
 				extra_private_keys = [];
 				backend_domid = backend_domid;
@@ -1592,7 +1598,13 @@ module VBD = struct
 
 	let id_of vbd = snd vbd.id
 
-	let attach_and_activate task xc xs frontend_domid vbd = function
+	(* When we attach a VDI we remember the attach result so we can lookup
+	   details such as the device-kind later. *)
+
+	let vdi_attach_path vbd = Printf.sprintf "/xapi/%s/private/vdis/%s" (fst vbd.id) (snd vbd.id)
+
+	let attach_and_activate task xc xs frontend_domid vbd vdi =
+		let attached_vdi = match vdi with
 		| None ->
 			(* XXX: do something better with CDROMs *)
 			{ domid = this_domid ~xs; attach_info = { Storage_interface.params=""; xenstore_data=[]; } }
@@ -1602,7 +1614,9 @@ module VBD = struct
 			let sr, vdi = Storage.get_disk_by_name task path in
 			let dp = Storage.id_of (string_of_int frontend_domid) vbd.id in
 			let vm = fst vbd.id in
-			Storage.attach_and_activate ~xc ~xs task vm dp sr vdi (vbd.mode = ReadWrite)
+			Storage.attach_and_activate ~xc ~xs task vm dp sr vdi (vbd.mode = ReadWrite) in
+		xs.Xs.write (vdi_attach_path vbd) (attached_vdi |> rpc_of_attached_vdi |> Jsonrpc.to_string);
+		attached_vdi
 
 	let frontend_domid_of_device device = device.Device_common.frontend.Device_common.domid
 
@@ -1634,7 +1648,22 @@ module VBD = struct
 			Storage.epoch_end task sr vdi
 		| _ -> ()		
 
-	let device_kind_of vbd = Device.Vbd.device_kind_of_backend_keys vbd.extra_backend_keys
+	let _backend_kind = "backend-kind"
+
+	let device_kind_of ~xs vbd =
+		(* If the user has provided an override then use that *)
+		if List.mem_assoc _backend_kind vbd.extra_backend_keys
+		then Device_common.kind_of_string (List.assoc _backend_kind vbd.extra_backend_keys)
+		else match (try Some(xs.Xs.read (vdi_attach_path vbd) |> Jsonrpc.of_string |> attached_vdi_of_rpc) with _ -> None) with
+		| None ->
+			(* An empty VBD has to be a CDROM: anything will do *)
+			Device_common.Vbd !Xenopsd.default_vbd_backend_kind
+		| Some vdi ->
+			let xenstore_data = vdi.attach_info.Storage_interface.xenstore_data in
+			(* Use the storage manager's preference *)
+			if List.mem_assoc _backend_kind xenstore_data
+			then Device_common.kind_of_string (List.assoc _backend_kind xenstore_data)
+			else Device_common.Vbd !Xenopsd.default_vbd_backend_kind
 
 	let vdi_path_of_device ~xs device = Device_common.backend_path_of_device ~xs device ^ "/vdi"
 
@@ -1652,11 +1681,12 @@ module VBD = struct
 				else begin
 					let vdi = attach_and_activate task xc xs frontend_domid vbd vbd.backend in
 
+					let kind = device_kind_of_backend_keys vdi.attach_info.Storage_interface.xenstore_data in
 					let extra_backend_keys = List.fold_left (fun acc (k,v) ->
 						let k = "sm-data/" ^ k in
 						(k,v)::(List.remove_assoc k acc)) vbd.extra_backend_keys vdi.attach_info.Storage_interface.xenstore_data in
 
-					let device_kind = device_kind_of vbd in
+					let device_kind = device_kind_of ~xs vbd in
 
 					(* Remember the VBD id with the device *)
 					let vbd_id = _device_id device_kind, id_of vbd in
@@ -1678,6 +1708,7 @@ module VBD = struct
 						);
 						unpluggable = vbd.unpluggable;
 						protocol = None;
+						kind;
 						extra_backend_keys;
 						extra_private_keys = dp_id :: vdi_id :: vbd_id :: vbd.extra_private_keys;
 						backend_domid = vdi.domid;
@@ -1732,7 +1763,7 @@ module VBD = struct
 					   to free any storage resources. *)
 					let device =
 						try
-							Some (device_by_id xc xs vm (device_kind_of vbd) Oldest (id_of vbd))
+							Some (device_by_id xc xs vm (device_kind_of ~xs vbd) Oldest (id_of vbd))
 						with
 							| (Does_not_exist(_,_)) ->
 								debug "VM = %s; VBD = %s; Ignoring missing domain" vm (id_of vbd);
@@ -1787,7 +1818,7 @@ module VBD = struct
 				if not hvm
 				then plug task vm { vbd with backend = Some disk }
 				else begin
-					let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of vbd) Newest (id_of vbd) in
+					let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) Newest (id_of vbd) in
 					let vdi = attach_and_activate task xc xs frontend_domid vbd (Some disk) in
 					let phystype = Device.Vbd.Phys in
 					(* We store away the disk so we can implement VBD.stat *)
@@ -1799,7 +1830,7 @@ module VBD = struct
 	let eject task vm vbd =
 		on_frontend
 			(fun xc xs frontend_domid hvm ->
-				let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of vbd) Oldest (id_of vbd) in
+				let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) Oldest (id_of vbd) in
 				Device.Vbd.media_eject ~xs device;
 				safe_rm xs (vdi_path_of_device ~xs device);
 				Storage.dp_destroy task (Storage.id_of (string_of_int (frontend_domid_of_device device)) vbd.Vbd.id)
@@ -1817,7 +1848,7 @@ module VBD = struct
 				Opt.iter (function
 					| Ionice qos ->
 						try
-							let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of vbd) Newest (id_of vbd) in
+							let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) Newest (id_of vbd) in
 							let path = Device_common.kthread_pid_path_of_device ~xs device in
 							let kthread_pid = xs.Xs.read path |> int_of_string in
 							ionice qos kthread_pid
@@ -1851,7 +1882,7 @@ module VBD = struct
 		with_xc_and_xs
 			(fun xc xs ->
 				try
-					let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of vbd) Newest (id_of vbd) in
+					let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) Newest (id_of vbd) in
 					let qos_target = get_qos xc xs vm vbd device in
 
 					let backend_present =
@@ -1876,7 +1907,7 @@ module VBD = struct
 		with_xc_and_xs
 			(fun xc xs ->
 				try
-					let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of vbd) Newest (id_of vbd) in
+					let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) Newest (id_of vbd) in
 					if Hotplug.device_is_online ~xs device
 					then begin
 						let qos_target = get_qos xc xs vm vbd device in


### PR DESCRIPTION
The storage backends should choose the default datapath for a given
VDI, which could be: tapdisk3, blkback or even qdisk.

This patch extends the existing 'backend-kind' mechanism to allow an
SMAPIv1/2 backend to return a choice via the 'xenstore_data'. This is
a port of the existing libxl mechanism in c/s 8fb7bcb4

Signed-off-by: David Scott <dave.scott@eu.citrix.com>