### PR TITLE
Revert "Use only -std-vga for Qemu when using dummy vGPU"

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -889,8 +889,6 @@ module VM = struct
 					| Cirrus -> Device.Dm.Cirrus, None
 					| Standard_VGA -> Device.Dm.Std_vga, None
 					| IGD_passthrough -> Device.Dm.IGD_passthrough, None
-					| Vgpu when List.assoc vgpu_config_key vm.Vm.platformdata = "dummy" ->
-						Device.Dm.Std_vga, Some {Device.Dm.pci_id = "dummy"; config = "dummy"}
 					| Vgpu ->
 						let vgpu =
 							try


### PR DESCRIPTION
This reverts commit b0b2e425637f9facc2a06fe812ec3dbb32c52ce9.

This option is no longer needed with the new demu