### PR TITLE
CP-12148:  Replace platform: pvi_pv to new field auto_update_drivers

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -90,6 +90,7 @@ module type S = sig
 		val request_rdp: Vm.t -> bool -> unit
 		val set_domain_action_request: Vm.t -> domain_action_request option -> unit
 		val get_domain_action_request: Vm.t -> domain_action_request option
+		val set_auto_update_drivers: Vm.t -> bool -> unit
 
 		val generate_state_string: Vm.t -> string
 		val get_internal_state: (string * string) list -> (string * Network.t) list -> Vm.t -> string

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -75,6 +75,7 @@ module VM = struct
 	let generate_state_string _ = ""
 	let get_internal_state _ _ _ = ""
 	let set_internal_state _ _ = ()
+	let set_auto_update_drivers _ _ = ()
 	let minimum_reboot_delay = 0.
 end
 module PCI = struct

--- a/libvirt/xenops_server_libvirt.ml
+++ b/libvirt/xenops_server_libvirt.ml
@@ -423,6 +423,7 @@ module VM = struct
 		| Some { D.state = D.InfoShutdown } -> Some Needs_poweroff
 		| Some { D.state = D.InfoShutoff } -> Some Needs_poweroff
 		| _ -> None
+	let set_domain_action_request vm enabled = ()
 	let minimum_reboot_delay = 0.
 end
 

--- a/qemu/xenops_server_qemu.ml
+++ b/qemu/xenops_server_qemu.ml
@@ -362,6 +362,7 @@ module VM = struct
 			let path = Filename.concat Qemu.qmp_dir vm.Vm.id in
 			if Sys.file_exists path then None else Some Needs_poweroff
 		end else None
+	let set_domain_action_request vm enabled = ()
 	let minimum_reboot_delay = 0.
 end
 

--- a/simulator/xenops_server_simulator.ml
+++ b/simulator/xenops_server_simulator.ml
@@ -357,6 +357,8 @@ module VM = struct
 	let set_internal_state vm s =
 		DB.write vm.Vm.id (s |> Jsonrpc.of_string |> Domain.t_of_rpc)
 
+	let set_auto_update_drivers vm enabled = ()
+
 	let minimum_reboot_delay = 0.
 end
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1456,6 +1456,17 @@ module VM = struct
 						)
 			)
 
+	let set_auto_update_drivers vm enabled =
+		let uuid = uuid_of_vm vm in
+		with_xc_and_xs
+			(fun xc xs ->
+				match di_of_uuid ~xc ~xs Newest uuid with
+					| None -> raise (Does_not_exist("domain", vm.Vm.id))
+					| Some di ->
+						let path = Printf.sprintf "/local/domain/%d/control/auto-update-drivers" di.Xenctrl.domid in
+						xs.Xs.write path (if enabled then "1" else "0")
+			)
+
 	let get_domain_action_request vm =
 		let uuid = uuid_of_vm vm in
 		with_xc_and_xs

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2565,6 +2565,18 @@ module VM = struct
 						)
 			)
 
+	let set_auto_update_drivers vm enabled =
+		let open Xenlight.Dominfo in
+		let uuid = uuid_of_vm vm in
+		with_xs
+			(fun xs ->
+				match di_of_uuid Newest uuid with
+					| None, _ -> raise (Does_not_exist("domain", vm.Vm.id))
+					| Some di, _ ->
+						let path = Printf.sprintf "/local/domain/%d/control/auto-update-drivers" di.domid in
+						xs.Xs.write path (if enabled then "1" else "0")
+			)
+			
 	let get_domain_action_request vm =
 		let open Xenlight.Dominfo in
 		let uuid = uuid_of_vm vm in


### PR DESCRIPTION

Add bool VM.auto_update_drivers (DynamicRO) to replace the usage of pci_pv in VM.platform
Add key: "/local/domain/%d/control/auto-update-drivers" for new field

Signed-off-by: chengz <cheng.zhang@citrix.com>