### PR TITLE
CP-12148:  Replace platform: pci_pv to new field auto_update_drivers

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -191,6 +191,7 @@ let create_vm id =
 		on_reboot = [ Vm.Start ];
 		pci_msitranslate = true;
 		pci_power_mgmt = false;
+		auto_update_drivers = false;
 	}
 
 let sl x = Printf.sprintf "[ %s ]" (String.concat "; " (List.map (fun (k, v) -> k ^ ":" ^ v) x))
@@ -213,6 +214,7 @@ let vm_assert_equal vm vm' =
 	assert_equal ~msg:"on_crash" ~printer:(fun x -> String.concat ", " (List.map (fun x -> x |> Vm.rpc_of_action |> Jsonrpc.to_string) x)) vm.on_crash vm'.on_crash;
 	assert_equal ~msg:"on_shutdown" ~printer:(fun x -> String.concat ", " (List.map (fun x -> x |> Vm.rpc_of_action |> Jsonrpc.to_string) x)) vm.on_shutdown vm'.on_shutdown;
 	assert_equal ~msg:"on_reboot" ~printer:(fun x -> String.concat ", " (List.map (fun x -> x |> Vm.rpc_of_action |> Jsonrpc.to_string) x)) vm.on_reboot vm'.on_reboot;
+	assert_equal ~msg:"auto_update_drivers" ~printer:(fun x -> String.concat ", " (List.map (fun x -> x |> Vm.rpc_of_action |> Jsonrpc.to_string) x)) vm.auto_update_drivers vm'.auto_update_drivers;
 	let is_hvm vm = match vm.ty with
 		| HVM _ -> true | PV _ -> false in
 	assert_equal ~msg:"HVM-ness" ~printer:string_of_bool (is_hvm vm) (is_hvm vm');

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -33,6 +33,7 @@ type create_info = {
 	xsdata: (string * string) list;
 	platformdata: (string * string) list;
 	bios_strings: (string * string) list;
+	auto_update_drivers: bool;
 } with rpc
 
 type build_hvm_info = {
@@ -250,6 +251,8 @@ let make ~xc ~xs vm_info uuid =
 		xs.Xs.write (dom_path ^ "/action-request") "poweroff";
 
 		xs.Xs.write (dom_path ^ "/control/platform-feature-multiprocessor-suspend") "1";
+
+		xs.Xs.write (dom_path ^ "/control/auto-update-drivers") (if vm_info.auto_update_drivers then "1" else "0");
 
 		(* CA-30811: let the linux guest agent easily determine if this is a fresh domain even if
 		   the domid hasn't changed (consider cross-host migrate) *)

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -34,6 +34,7 @@ type create_info = {
 	xsdata: (string * string) list;
 	platformdata: (string * string) list;
 	bios_strings: (string * string) list;
+	auto_update_drivers: bool;
 }
 val create_info_of_rpc: Rpc.t -> create_info
 val rpc_of_create_info: create_info -> Rpc.t

--- a/xc/stubdom.ml
+++ b/xc/stubdom.ml
@@ -38,6 +38,7 @@ let create ~xc ~xs domid =
  		Domain.platformdata = [];
  		Domain.xsdata = [];
 		Domain.bios_strings = [];
+                Domain.auto_update_drivers = false;
 	} in
     let stubdom_domid = Domain.make ~xc ~xs info stubdom_uuid in
     debug "jjd27: created stubdom with domid %d" stubdom_domid;

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -622,6 +622,7 @@ module VM = struct
 			xsdata = vm.xsdata;
 			platformdata = platformdata @ vcpus;
 			bios_strings = vm.bios_strings;
+			auto_update_drivers = vm.auto_update_drivers;
 		} in
 		{
 			VmExtra.create_info = create_info;

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -125,6 +125,7 @@ module Domain = struct
 		xsdata: (string * string) list;
 		platformdata: (string * string) list;
 		bios_strings: (string * string) list;
+		auto_update_drivers: bool;
 	} with rpc
 
 	type build_hvm_info = {
@@ -1721,6 +1722,7 @@ module VM = struct
 			xsdata = vm.xsdata;
 			platformdata = vm.platformdata @ vcpus;
 			bios_strings = vm.bios_strings;
+			auto_update_drivers = vm.auto_update_drivers;
 		} in
 		{
 			VmExtra.create_info = create_info;

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -115,7 +115,9 @@ type attached_vdi = {
 	attach_info: Storage_interface.attach_info;
 } with rpc
 
-(* The following module contains left-overs from the "classic" domain.ml *)
+(* The following module contains left-overs from the "classic" domain.ml 
+   Note: "auto_update_drivers" parameter won't do anything for the libxl backend
+	(i.e. the xenstore key won't be written) *)
 module Domain = struct
 	type create_info = {
 		ssidref: int32;


### PR DESCRIPTION
Add bool VM.auto_update_drivers (DynamicRO) to replace the usage of pci_pv in VM.platform
Add key: "/local/domain/%d/control/auto-update-drivers" for new field

Signed-off-by: chengz <cheng.zhang@citrix.com>