### PR TITLE
scripts/block: use `readlink -f` to canonicalise paths

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -18,7 +18,7 @@ syslog ()
 case "$1" in
 add)
         params=$(xenstore-read "${XENBUS_PATH}/params")
-        params=$(readlink $params || echo $params)
+        params=$(readlink -f $params || echo $params)
         frontend="/local/domain/${DOMID}/device/${TYPE}/${DEVID}"
         syslog "${XENBUS_PATH}: add params=\"${params}\""
         # We don't have PV drivers for CDROM devices, so we prevent blkback


### PR DESCRIPTION
If the `params` comes back as `/dev/mapper/foo` then we might
discover that this is a relative symlink like `../dm-1`. We need
to pass `stat` a full path, so we need to canonicalise to something
like `/dev/dm-1`.

Signed-off-by: David Scott <dave.scott@citrix.com>