### PR TITLE
CA-173686: Write passed-through PCI's address to xenstore

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -998,6 +998,29 @@ let add_xl = xl_pci "pci-attach"
 
 let release_xl = xl_pci "pci-detach"
 
+let device_model_pci_device_path xs be_domid fe_domid =
+	let be_path = xs.Xs.getdomainpath be_domid in
+	Printf.sprintf "%s/backend/pci/%d/0" be_path fe_domid
+
+(* Given a domid, return a list of [ X, (domain, bus, dev, func) ] where X indicates the order in
+   which the device was plugged. *)
+let read_pcidir ~xc ~xs domid =
+	let path = device_model_pci_device_path xs 0 domid in
+	let prefix = "dev-" in
+	let all = List.filter (String.startswith prefix) (try xs.Xs.directory path with Xs_protocol.Enoent _ -> []) in
+	(* The values are the PCI device (domain, bus, dev, func) strings *)
+	let device_number_of_string x =
+		(* remove the silly prefix *)
+		int_of_string (String.sub x (String.length prefix) (String.length x - (String.length prefix))) in
+	let pairs = List.map
+		(fun x ->
+			device_number_of_string x,
+			Xenops_interface.Pci.address_of_string (xs.Xs.read (path ^ "/" ^ x)))
+		all
+	in
+	(* Sort into the order the devices were plugged *)
+	List.sort (fun a b -> compare (fst a) (fst b)) pairs
+
 let add pcidevs domid =
 	try add_xl pcidevs domid
 	with exn -> raise (Cannot_add (pcidevs, exn))
@@ -1202,11 +1225,6 @@ let hard_shutdown (task: Xenops_task.t) ~xs (x: device) =
 let device_model_state_path xs be_domid fe_domid =
   Printf.sprintf "%s/device-model/%d/state" (xs.Xs.getdomainpath be_domid) fe_domid
 
-let device_model_pci_device_path xs be_domid fe_domid =
-  let be_path = xs.Xs.getdomainpath be_domid in
-  Printf.sprintf "%s/backend/pci/%d/0" be_path fe_domid
-
-
 let signal_device_model ~xc ~xs domid cmd parameter = 
 	debug "Device.Pci.signal_device_model domid=%d cmd=%s param=%s" domid cmd parameter;
 	let be_domid = 0 in (* XXX: assume device model is in domain 0 *)
@@ -1234,25 +1252,6 @@ let wait_device_model (task: Xenops_task.t) ~xc ~xs domid =
 	  info "wait_device_model: qemu has shutdown";
 	  None
   end
-							
-(* Given a domid, return a list of [ X, (domain, bus, dev, func) ] where X indicates the order in
-   which the device was plugged. *)
-let read_pcidir ~xc ~xs domid = 
-  let path = device_model_pci_device_path xs 0 domid in
-  let prefix = "dev-" in
-  let all = List.filter (String.startswith prefix) (try xs.Xs.directory path with Xs_protocol.Enoent _ -> []) in
-  (* The values are the PCI device (domain, bus, dev, func) strings *)
-  let device_number_of_string x =
-    (* remove the silly prefix *)
-    int_of_string (String.sub x (String.length prefix) (String.length x - (String.length prefix))) in
-  let pairs = List.map
-    (fun x ->
-      device_number_of_string x,
-      Xenops_interface.Pci.address_of_string (xs.Xs.read (path ^ "/" ^ x)))
-    all
-  in
-  (* Sort into the order the devices were plugged *)
-  List.sort (fun a b -> compare (fst a) (fst b)) pairs
 
 (* Return a list of PCI devices *)
 let list ~xc ~xs domid = 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -136,7 +136,7 @@ sig
 
 	exception Cannot_use_pci_with_no_pciback of t list
 
-	val add : address list -> Xenctrl.domid -> unit
+	val add : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
 	val release : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> hvm:bool
 		-> address list -> Xenctrl.domid -> int -> unit
 	val reset : xs:Xenstore.Xs.xsh -> address -> unit

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1571,7 +1571,7 @@ module PCI = struct
 				end;
 
 				Device.PCI.bind [ pci.address ] Device.PCI.Pciback;
-				Device.PCI.add [ pci.address ] frontend_domid
+				Device.PCI.add xc xs [ pci.address ] frontend_domid
 			) Newest vm
 
 	let unplug task vm pci =


### PR DESCRIPTION
Device.PCI.list relies on this key being present - without it, plugged PCIs will be reported to xapi as unplugged.