### PR TITLE
VDI.epoch_begin now takes a `persistent` argument

### DIFF
--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -37,10 +37,10 @@ let transform_exception f x =
 (* Used to identify this VBD to the storage layer *)
 let id_of frontend vbd = Printf.sprintf "vbd/%s/%s" frontend (snd vbd)
 
-let epoch_begin task sr vdi =
+let epoch_begin task sr vdi persistent =
 	transform_exception
 		(fun () ->
-			Client.VDI.epoch_begin task.Xenops_task.dbg sr vdi
+			Client.VDI.epoch_begin task.Xenops_task.dbg sr vdi persistent
 		) ()
 
 let epoch_end task sr vdi =

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -105,7 +105,7 @@ module type S = sig
 	end
 	module VBD : sig
 		val set_active: Xenops_task.t -> Vm.id -> Vbd.t -> bool -> unit
-		val epoch_begin: Xenops_task.t -> Vm.id -> disk -> unit
+		val epoch_begin: Xenops_task.t -> Vm.id -> disk -> bool -> unit
 		val epoch_end: Xenops_task.t -> Vm.id -> disk -> unit
 		val plug: Xenops_task.t -> Vm.id -> Vbd.t -> unit
 		val unplug: Xenops_task.t -> Vm.id -> Vbd.t -> bool -> unit

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -85,7 +85,7 @@ module PCI = struct
 end
 module VBD = struct
 	let set_active _ _ _ _ = ()
-	let epoch_begin _ _ _ = ()
+	let epoch_begin _ _ _ _ = ()
 	let epoch_end _ _ _ = ()
 	let plug _ _ _ = unimplemented "VBD.plug"
 	let unplug _ _ _ _ = unimplemented "VBD.unplug"

--- a/simulator/xenops_server_simulator.ml
+++ b/simulator/xenops_server_simulator.ml
@@ -371,7 +371,7 @@ end
 
 module VBD = struct
 	let set_active _ (vm: Vm.id) (vbd: Vbd.t) (b: bool) = ()
-	let epoch_begin _ (vm: Vm.id) (disk: disk) = ()
+	let epoch_begin _ (vm: Vm.id) (disk: disk) (persistent: bool) = ()
 	let epoch_end _ (vm: Vm.id) (disk: disk) = ()
 	let plug _ (vm: Vm.id) (vbd: Vbd.t) = Mutex.execute m (add_vbd vm vbd)
 	let unplug _ vm vbd _ = Mutex.execute m (remove_vbd vm vbd)

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1662,10 +1662,10 @@ module VBD = struct
 			with_xs (fun xs -> xs.Xs.read (active_path vm vbd)) = "1"
 		with _ -> false
 
-	let epoch_begin task vm disk = match disk with
+	let epoch_begin task vm disk persistent = match disk with
 		| VDI path ->
 			let sr, vdi = Storage.get_disk_by_name task path in
-			Storage.epoch_begin task sr vdi
+			Storage.epoch_begin task sr vdi persistent
 		| _ -> ()
 
 	let epoch_end task vm disk = match disk with

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -706,10 +706,10 @@ module VBD = struct
 			with_xs (fun xs -> xs.Xs.read (active_path vm vbd)) = "1"
 		with _ -> false
 
-	let epoch_begin task vm disk = match disk with
+	let epoch_begin task vm disk persistent = match disk with
 		| VDI path ->
 			let sr, vdi = Storage.get_disk_by_name task path in
-			Storage.epoch_begin task sr vdi
+			Storage.epoch_begin task sr vdi persistent
 		| _ -> ()
 
 	let epoch_end task vm disk = match disk with


### PR DESCRIPTION
The Vbd metadata from xapi says whether we want to open the
device in persistent mode or not. We pass this along to the
SMAPIv2 layer via `VDI.epoch_begin`.

This depends on [xapi-project/xcp-idl#83]

Signed-off-by: David Scott <dave.scott@eu.citrix.com>