### PR TITLE
CP-12982: Changes for i915 driver binding/unbinding

### DIFF
--- a/lib/path.ml
+++ b/lib/path.ml
@@ -16,6 +16,8 @@ let network_conf = ref "/etc/xcp/network.conf"
 let qemu_dm_wrapper = ref "qemu-dm-wrapper"
 let qemu_system_i386 = ref "qemu-system-i386"
 let chgrp = ref "chgrp"
+let modprobe = ref "/usr/sbin/modprobe"
+let rmmod = ref "/usr/sbin/rmmod"
 let hvmloader = ref "hvmloader"
 let pygrub = ref "pygrub"
 let eliloader = ref "eliloader"
@@ -42,6 +44,8 @@ let network_configuration = [
 
 let essentials = [
 	X_OK, "chgrp", chgrp, "path to the chgrp binary";
+	X_OK, "modprobe", modprobe, "path to the modprobe binary";
+	X_OK, "rmmod", rmmod, "path to the rmmod binary";
 ]
 
 let nonessentials = [

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1121,6 +1121,11 @@ let unbind devstr driver =
 	let unbind = Filename.concat sysfs_driver "unbind" in
 	write_string_to_file unbind devstr
 
+let unbind_from_i915 devstr =
+	unbind devstr (Supported I915);
+	let (_:string * string) =
+		Forkhelpers.execute_command_get_output !Path.rmmod ["i915"] in ()
+
 let procfs_nvidia = "/proc/driver/nvidia/gpus"
 let bus_id_key = "Bus Location"
 
@@ -1192,6 +1197,10 @@ let bind devices new_driver =
 				(* No driver is bound, so just bind the one we want. *)
 				| None, new_driver ->
 					debug "pci: device %s not bound" devstr;
+					bind_to devstr new_driver
+				(* Unbinding from i915 and binding to another driver. *)
+				| Some (Supported I915), new_driver ->
+					unbind_from_i915 devstr;
 					bind_to devstr new_driver
 				(* Unbinding from nvidia and binding to another driver. *)
 				| Some (Supported Nvidia), new_driver ->

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1182,6 +1182,7 @@ let bind devices new_driver =
 					do_flr devstr
 				(* No driver is bound, so just bind the one we want. *)
 				| None, I915 ->
+					debug "pci: device %s not bound" devstr;
 					bind_to_i915 devstr
 				| None, Nvidia ->
 					debug "pci: device %s not bound" devstr;

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1104,9 +1104,10 @@ let bind_to_pciback devstr =
 	write_string_to_file bind devstr
 
 let bind_to_i915 devstr =
+	(* No need to explicitly bind, as the driver will auto-bind on load. *)
 	debug "pci: binding device %s to i915" devstr;
-	let bind = Filename.concat sysfs_i915 "bind" in
-	write_string_to_file bind devstr
+	let (_:string * string) =
+		Forkhelpers.execute_command_get_output !Path.modprobe ["i915"] in ()
 
 let bind_to_nvidia devstr =
 	debug "pci: binding device %s to nvidia" devstr;


### PR DESCRIPTION
When switching an Intel GPU from GVT-g mode to passthrough mode, simply unbinding the device from the i915 driver isn't enough - we need to rmmod the i915 module completely. Consequently we need to modprobe the i915 driver when switching back to GVT-g mode.