### PR TITLE
CA-168029: Using xl pci for plug/unplug in xenopsd-xc

### DIFF
--- a/xc/device.mli
+++ b/xc/device.mli
@@ -143,14 +143,11 @@ sig
 
 	exception Cannot_use_pci_with_no_pciback of t list
 
-	val add : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
-	val release : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> hvm:bool
-		-> address list -> Xenctrl.domid -> int -> unit
+	val add : xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
+	val release : address list -> Xenctrl.domid -> unit
 	val reset : xs:Xenstore.Xs.xsh -> address -> unit
 	val bind : address list -> supported_driver -> unit
-	val plug : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> address -> Xenctrl.domid -> unit
-	val unplug : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> address -> Xenctrl.domid -> unit
-	val list : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid -> (int * address) list
+	val list : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> (int * address) list
 end
 
 module Vfs :

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -372,7 +372,7 @@ let destroy (task: Xenops_task.t) ~xc ~xs ~qemu_domid domid =
         (List.map (fun x -> string_of_int x.Xenctrl.domid) other_domains);
 
 	(* reset PCI devices before xc.domain_destroy otherwise we lot all IOMMU mapping *)
-	let _, all_pci_devices = List.split (Device.PCI.list xc xs domid) in
+	let _, all_pci_devices = List.split (Device.PCI.list xs domid) in
 	List.iter
 		(fun pcidev ->
 			let open Xenops_interface.Pci in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1538,7 +1538,7 @@ module PCI = struct
 		with_xc_and_xs
 			(fun xc xs ->
 				let all = match domid_of_uuid ~xc ~xs Newest (uuid_of_string vm) with
-					| Some domid -> Device.PCI.list ~xc ~xs domid |> List.map snd
+					| Some domid -> Device.PCI.list ~xs domid |> List.map snd
 					| None -> [] in
 				let address = pci.address in
 				{
@@ -1571,7 +1571,7 @@ module PCI = struct
 				end;
 
 				Device.PCI.bind [ pci.address ] Device.PCI.Pciback;
-				Device.PCI.add xc xs [ pci.address ] frontend_domid
+				Device.PCI.add xs [ pci.address ] frontend_domid
 			) Newest vm
 
 	let unplug task vm pci =
@@ -1580,7 +1580,7 @@ module PCI = struct
 				(fun xc xs frontend_domid hvm ->
 					try
 						if hvm
-						then Device.PCI.unplug task ~xc ~xs pci.address frontend_domid
+						then Device.PCI.release [ pci.address ] frontend_domid
 						else error "VM = %s; PCI.unplug for PV guests is unsupported" vm
 					with Not_found ->
 						debug "VM = %s; PCI.unplug %s.%s caught Not_found: assuming device is unplugged already" vm (fst pci.id) (snd pci.id)


### PR DESCRIPTION
This xl pci-attach and pci-detach are working now and this
patch makes xenopsd-xc to use them.
Also removing some dead code paths

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>