### PR TITLE
CA-187017: VM.get_state: don't try to recurse into non-directories in xenstore

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1424,7 +1424,7 @@ module VM = struct
 						let rtc = try xs.Xs.read (Printf.sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string uuid)) with Xs_protocol.Enoent _ -> "" in
 						let rec ls_lR root dir =
 							let this = try [ dir, xs.Xs.read (root ^ "/" ^ dir) ] with _ -> [] in
-							let subdirs = try List.map (fun x -> dir ^ "/" ^ x) (xs.Xs.directory (root ^ "/" ^ dir)) with _ -> [] in
+							let subdirs = try xs.Xs.directory (root ^ "/" ^ dir) |> List.filter (fun x -> x <> "") |> List.map (fun x -> dir ^ "/" ^ x) with _ -> [] in
 							this @ (List.concat (List.map (ls_lR root) subdirs)) in
 						let guest_agent =
 							[ "drivers"; "attr"; "data"; "control"; "device" ] |> List.map (ls_lR (Printf.sprintf "/local/domain/%d" di.Xenctrl.domid)) |> List.concat |> List.map (fun (k,v) -> (k,Xenops_utils.utf8_recode v)) in

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2519,7 +2519,7 @@ module VM = struct
 						let rtc = try xs.Xs.read (Printf.sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string uuid)) with Xs_protocol.Enoent _ -> "" in
 						let rec ls_lR root dir =
 							let this = try [ dir, xs.Xs.read (root ^ "/" ^ dir) ] with _ -> [] in
-							let subdirs = try List.map (fun x -> dir ^ "/" ^ x) (xs.Xs.directory (root ^ "/" ^ dir)) with _ -> [] in
+							let subdirs = try xs.Xs.directory (root ^ "/" ^ dir) |> List.filter (fun x -> x <> "") |> List.map (fun x -> dir ^ "/" ^ x) with _ -> [] in
 							this @ (List.concat (List.map (ls_lR root) subdirs)) in
 						let guest_agent =
 							[ "drivers"; "attr"; "data"; "control"; "device" ] |> List.map (ls_lR (Printf.sprintf "/local/domain/%d" di.domid)) |> List.concat in


### PR DESCRIPTION
Work around strange behaviour in the OCaml xenstore client library so that
VM.get_state doesn't try to read invalid paths from xenstore, each of which is
guaranteed to result in EINVAL from xenstored. This behaviour causes unnecessary
load on xenstore.

The behaviour is as follows. Consider the following xenstore tree:

  /local/domain/1/dir0 = ""
  /local/domain/1/dir0/key0 = "a"
  /local/domain/1/dir0/key1 = "b"
  /local/domain/1/key1 = "c"

Here's the behaviour of two xenstore commands:

  1. xs.Xs.directory "/local/domain/1/dir0"
      -> ["key0"; "key1"]

  2. xs.Xs.directory "/local/domain/1/key1"
      -> [""]

Perhaps more appropriate behaviour would be to return [] in the second example.

But the existing [""] behaviour means that xenopsd's ls_lR function thinks that
there's a sub-directory called "", so tries to recurse into
("/local/domain/1/dir0" ^ "/" ^ "") i.e. "/local/domain/1/dir0/" which is
invalid.

This patch squashes any reported entry that matches the empty string.

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>