### PR TITLE
Treat watchdog (4) the same as reboot(1)

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1565,6 +1565,7 @@ module VM = struct
 							| 1 -> Needs_reboot
 							| 2 -> Needs_suspend
 							| 3 -> Needs_crashdump
+							| 4 -> Needs_reboot
 							| _ -> Needs_poweroff) (* unexpected *)
 						else begin match Domain.get_action_request ~xs d.Xenctrl.domid with
 							| Some "poweroff" -> Some Needs_poweroff

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2602,6 +2602,7 @@ module VM = struct
 							| Xenlight.SHUTDOWN_REASON_REBOOT -> Needs_reboot
 							| Xenlight.SHUTDOWN_REASON_SUSPEND -> Needs_suspend
 							| Xenlight.SHUTDOWN_REASON_CRASH -> Needs_crashdump
+							| Xenlight.SHUTDOWN_REASON_WATCHDOG -> Needs_reboot
 							| _ -> Needs_poweroff) (* unexpected *)
 						else begin match Domain.get_action_request ~xs d.domid with
 							| Some "poweroff" -> Some Needs_poweroff


### PR DESCRIPTION
According to the Xen header SHUTDOWN_watchdog indicates the domain
should be restarted due to the watchdog timing out.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>