### PR TITLE
Correct the use of Xenctrl.Halt

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -291,7 +291,7 @@ let shutdown_to_xc_shutdown = function
 	| Reboot   -> Xenctrl.Reboot
 	| Suspend  -> Xenctrl.Suspend
 	| Crash    -> Xenctrl.Crash
-	| Halt     -> Xenctrl.Halt
+	| Halt     -> Xenctrl.Poweroff
 	| S3Suspend -> raise (Invalid_argument "unknown")
 	| Unknown _-> raise (Invalid_argument "unknown")
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2602,15 +2602,6 @@ module DEBUG = struct
 						| Some di ->
 							Xenctrl.domain_shutdown xc di.Xenctrl.domid Xenctrl.Reboot
 				)
-		| "halt", [ k ] ->
-			let uuid = uuid_of_string k in
-			with_xc_and_xs
-				(fun xc xs ->
-					match di_of_uuid ~xc ~xs Newest uuid with
-						| None -> raise (Does_not_exist("domain", k))
-						| Some di ->
-							Xenctrl.domain_shutdown xc di.Xenctrl.domid Xenctrl.Halt
-				)
 		| _ ->
 			debug "DEBUG.trigger cmd=%s Unimplemented" cmd;
 			raise (Unimplemented(cmd))


### PR DESCRIPTION
Xenctrl.Halt has always been incorrect in the libxc bindings (and should have
been Watchdog).  This was fixed upstream in
http://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=87a16694248e80195943741bb9f857edd6a6bf51,
but subsequently causes a compilation error in xenopsd.

Instead of shutting the domain down with a Watchdog signal, use the correct
Poweroff instead.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>