### PR TITLE
CA-191040: Ensure vm's frontend's backend key is correct

### DIFF
--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -160,6 +160,9 @@ let get_private_path_by_uuid uuid =
 let get_private_data_path_of_device (x: device) =
 	sprintf "%s/private/%s/%d" (get_private_path x.frontend.domid) (string_of_kind x.backend.kind) x.backend.devid
 
+let string_uuid_of_domid domid =
+	sprintf "%s" (uuid_of_domid domid)	
+
 let device_of_backend (backend: endpoint) (domu: Xenctrl.domid) = 
   let frontend = { domid = domu;
 		   kind = (match backend.kind with

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -60,6 +60,8 @@ val string_of_device : device -> string
 val string_of_kind : kind -> string
 val kind_of_string : string -> kind
 
+val string_uuid_of_domid : Xenctrl.domid -> string
+
 (** [list_backends xs domid] returns a list of devices where there is a
 	backend in [domid]. This function only reads data stored in the backend
     directory.*)

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -455,8 +455,13 @@ let device_by_id xc xs vm kind domain_selection id =
 			debug "VM = %s; does not exist in domain list" vm;
 			raise (Does_not_exist("domain", vm))
 		| Some frontend_domid ->
-			let devices = Device_common.list_frontends ~xs frontend_domid in
+			(* Ensure that the frontend belongs to the same vm to counter a misbehaving guest *)
+			if (Device_common.string_uuid_of_domid frontend_domid) <> vm then begin
+				let err = Printf.sprintf "xenstore frontend-backend mismatch for vm = %s" vm in
+				raise (Internal_error err)
+			end;
 
+			let devices = Device_common.list_frontends ~xs frontend_domid in
 			let key = _device_id kind in
 			let id_of_device device =
 				let path = Device_common.get_private_data_path_of_device device in


### PR DESCRIPTION
A malicious guest can get the vdi id/uuid, qos and vbd device of other guests
by replacing its frontend's backend key with the backend key of other guests.
This patch tries to put a defensive check to make sure that the backend key
maps to the vm that is trying to read it.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>