### PR TITLE
CP-15276: Create xenstore nodes device/[vbd,vif] etc.

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -239,7 +239,11 @@ let make ~xc ~xs vm_info uuid =
 				let ent = sprintf "%s/%s" dom_path dir in
 				t.Xst.mkdir ent;
 				t.Xst.setperms ent rwperm
-			) [ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data"; "hvmloader"; "rrd" ];
+			) (
+				let dev_kinds = [ "vbd"; "vif"; "vfb"; "vkb"; "vfs"; "pci" ] in
+				[ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data"; "hvmloader"; "rrd" ]
+				@ List.map (fun dev_kind -> "device/"^dev_kind) dev_kinds
+			);
 		);
 
 		xs.Xs.writev dom_path (filtered_xsdata vm_info.xsdata);

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2255,8 +2255,11 @@ module VM = struct
 						xs.Xs.mkdir ent;
 						xs.Xs.setperms ent rwperm
 					)
-				) [ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data" ];
-
+				) (
+					let dev_kinds = [ "vbd"; "vif"; "vfb"; "vkb"; "vfs"; "pci" ] in
+					[ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data" ]
+					@ List.map (fun dev_kind -> "device/"^dev_kind) dev_kinds
+				);
 				(* Write extra VBD XS keys *)
 				List.iter (fun (vbd, devid, extra_backend_keys, backend_domid) ->
 					VBD.write_extra backend_domid domid devid extra_backend_keys;


### PR DESCRIPTION
On domain creation, after creating xenstore node "/domain/N/device",
now we create nodes under it for a list of kinds of device:
[ "vbd"; "vif"; "vfb"; "vkb"; "vfs"; "pci" ]

This is needed now for the VIF and VBD drivers in Windows guests, but
may well be wanted for other guests and device-kinds in the future.