### PR TITLE
CA-195652: Cleanup new domain on VM_receive_memory failure

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1211,8 +1211,10 @@ and trigger_cleanup_after_failure op t = match op with
 	| VM_restore_vifs id
 	| VM_restore_devices (id, _)
 	| VM_resume (id, _)
-	| VM_migrate (id, _, _, _)
 	| VM_receive_memory (id, _, _) ->
+		immediate_operation t.Xenops_task.dbg id (VM_check_state id);
+	| VM_migrate (id, _, _, _) ->
+		immediate_operation t.Xenops_task.dbg id (VM_check_state id);
 		immediate_operation t.Xenops_task.dbg id (VM_check_state id);
 
 	| VBD_hotplug id

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1397,32 +1397,25 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.t) : unit =
 			debug "VM.receive_memory %s" id;
 			Sockopt.set_sock_keepalives s;
 			let open Xenops_migrate in
-(*			let state = B.VM.get_state (VM_DB.read_exn id) in
-			debug "VM.receive_memory %s power_state = %s" id (state.Vm.power_state |> rpc_of_power_state |> Jsonrpc.to_string);*)
-
-			(* set up the destination domain *)
-			(try
-				perform_atomics (
-					simplify [VM_create (id, Some memory_limit);] @
-					(* Perform as many operations as possible on the destination domain before pausing the original domain *)
-					(atomics_of_operation (VM_restore_vifs id))
-				) t;
-				Handshake.send s Handshake.Success
-			with e ->
-				Handshake.send s (Handshake.Error (Printexc.to_string e));
-				raise e
-			);
-			debug "Synchronisation point 1";
-
-			debug "VM.receive_memory calling create";
-			perform_atomics (
-			[
-				VM_restore (id, FD s);
-			]) t;
-			debug "VM.receive_memory restore complete";
-			debug "Synchronisation point 2";
-
 			begin try
+				(* set up the destination domain *)
+				debug "VM.receive_memory calling create";
+				perform_atomics (
+					simplify [VM_create (id, Some memory_limit)]
+					(* Perform as many operations as possible on the destination domain
+					 * before pausing the original domain *)
+					@ (atomics_of_operation (VM_restore_vifs id))
+				) t;
+				Handshake.send s Handshake.Success;
+				debug "Synchronisation point 1";
+
+				perform_atomics (
+				[
+					VM_restore (id, FD s);
+				]) t;
+				debug "VM.receive_memory restore complete";
+				debug "Synchronisation point 2";
+
 				(* Receive the all-clear to unpause *)
 				Handshake.recv_success ~verbose:true s;
 				debug "Synchronisation point 3";


### PR DESCRIPTION
Before this patch there was a hole in the exception handling where the
newly-created destination domain wouldn't be cleaned up if the VM_restore into
it failed but it would if later operations failed.

This patch unifies the error handling in VM_receive_memory so that it always
cleans up the domain it creates on failure.

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>