### PR TITLE
CP-16049: create rw xenstore node "feature" for guest

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -241,7 +241,7 @@ let make ~xc ~xs vm_info uuid =
 				t.Xst.setperms ent rwperm
 			) (
 				let dev_kinds = [ "vbd"; "vif"; "vfb"; "vkb"; "vfs"; "pci" ] in
-				[ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data"; "hvmloader"; "rrd" ]
+				[ "feature"; "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data"; "hvmloader"; "rrd" ]
 				@ List.map (fun dev_kind -> "device/"^dev_kind) dev_kinds
 			);
 		);

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2257,7 +2257,7 @@ module VM = struct
 					)
 				) (
 					let dev_kinds = [ "vbd"; "vif"; "vfb"; "vkb"; "vfs"; "pci" ] in
-					[ "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data" ]
+					[ "feature"; "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data" ]
 					@ List.map (fun dev_kind -> "device/"^dev_kind) dev_kinds
 				);
 				(* Write extra VBD XS keys *)


### PR DESCRIPTION
Add "/domain/N/feature" to the list of nodes that we create (with
read-write permission for the guest) on creation of domain N.

This will be used by the guest to announce whether it
supports various features, for example by writing 1 or 0
to /domain/N/feature/hotplug/vbd to indicate whether or
not it supports vbd hotplug.
