### PR TITLE
CA-197635: Only create vif/vbd device guest Xenstore entries

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -240,7 +240,7 @@ let make ~xc ~xs vm_info uuid =
 				t.Xst.mkdir ent;
 				t.Xst.setperms ent rwperm
 			) (
-				let dev_kinds = [ "vbd"; "vif"; "vfb"; "vkb"; "vfs"; "pci" ] in
+				let dev_kinds = [ "vbd"; "vif" ] in
 				[ "feature"; "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data"; "hvmloader"; "rrd" ]
 				@ List.map (fun dev_kind -> "device/"^dev_kind) dev_kinds
 			);

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2256,7 +2256,7 @@ module VM = struct
 						xs.Xs.setperms ent rwperm
 					)
 				) (
-					let dev_kinds = [ "vbd"; "vif"; "vfb"; "vkb"; "vfs"; "pci" ] in
+					let dev_kinds = [ "vbd"; "vif" ] in
 					[ "feature"; "device"; "error"; "drivers"; "control"; "attr"; "data"; "messages"; "vm-data" ]
 					@ List.map (fun dev_kind -> "device/"^dev_kind) dev_kinds
 				);


### PR DESCRIPTION
At start of day these are required for the guest to advertise the
ability to hotplug VIFs and VBDs and their creation by the toolstack is
outlined in the Xen docs: "Xenstore paths for hotplug features"[1].

When support was originally added for this in commit e894ebfd, it also
created vfb, vkb, vfs and pci nodes under the guest's device tree. At
least the first two of these are problematic and cause the guest's
console to be redirected incorrectly.

This patch removes the four additional Xenstore nodes from the guest
that were only added originally for symmetry.

[1]: http://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=e8f98cb2

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>