### PR TITLE
CA-184556: call VBD actions in parallel to speed up VM lifecycle operations

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -776,8 +776,6 @@ let vbd_plug_order vbds =
 	let rw, ro = vbd_plug_sets vbds in
 	rw @ ro
 
-let vbd_unplug_order vbds = List.rev (vbd_plug_order vbds)
-
 let vif_plug_order vifs =
 	List.sort (fun a b -> compare a.Vif.position b.Vif.position) vifs
 
@@ -844,7 +842,7 @@ let rec atomics_of_operation = function
 			(* At this point we have a shutdown domain (ie Needs_poweroff) *)
 			VM_destroy_device_model id;
 		] @ (
-			let vbds = VBD_DB.vbds id |> vbd_unplug_order in
+			let vbds = VBD_DB.vbds id in
 			[
 			Parallel ( id, (Printf.sprintf "VBD.unplug vm=%s" id), List.map (fun vbd->VBD_unplug (vbd.Vbd.id, true)) vbds);
 			]

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -96,6 +96,7 @@ type atomic =
 	| VM_save of (Vm.id * flag list * data)
 	| VM_restore of (Vm.id * data)
 	| VM_delay of (Vm.id * float) (** used to suppress fast reboot loops *)
+	| Parallel of Vm.id * string * atomic list
 
 with rpc
 
@@ -434,6 +435,12 @@ end
 module Redirector = struct
 	(* When a thread is not actively processing a queue, items are placed here: *)
 	let default = Queues.create ()
+	(* We create another queue only for Parallel atoms so as to avoid a situation where
+	   Parallel atoms can not progress because all the workers available for the
+	   default queue are used up by other operations depending on further Parallel
+	   atoms, creating a deadlock.
+	 *)
+	let parallel_queues = Queues.create ()
 
 	(* When a thread is actively processing a queue, items are redirected to a thread-private queue *)
 	let overrides = ref StringMap.empty
@@ -448,19 +455,19 @@ module Redirector = struct
 			not(List.mem op prev')
 		| _ -> true
 
-	let push tag item =
+	let push queues tag item =
 		Debug.with_thread_associated "queue"
 			(fun () ->
 				Mutex.execute m
 					(fun () ->
-						let q, redirected = if StringMap.mem tag !overrides then StringMap.find tag !overrides, true else default, false in
+						let q, redirected = if StringMap.mem tag !overrides then StringMap.find tag !overrides, true else queues, false in
 						debug "Queue.push %s onto %s%s:[ %s ]" (string_of_operation (fst item)) (if redirected then "redirected " else "") tag (String.concat ", " (List.rev (Queue.fold (fun acc (b, _) -> string_of_operation b :: acc) [] (Queues.get tag q))));
 
 						Queues.push_with_coalesce should_keep tag item q
 					)
 			) ()
 
-	let pop =
+	let pop queues =
 		(* We must prevent worker threads all calling Queues.pop before we've
 		   successfully put the redirection in place. Otherwise we end up with
 		   parallel threads operating on the same VM. *)
@@ -468,23 +475,23 @@ module Redirector = struct
 		fun () ->
 			Mutex.execute n
 				(fun () ->
-					let tag, item = Queues.pop default in
+					let tag, item = Queues.pop queues in
 					Mutex.execute m
 						(fun () ->
 							let q = Queues.create () in
-							Queues.transfer_tag tag default q;
+							Queues.transfer_tag tag queues q;
 							overrides := StringMap.add tag q !overrides;
 							(* All items with [tag] will enter queue [q] *)
 							tag, q, item
 						)
 				)
 
-	let finished tag queue =
+	let finished queues tag queue =
 		Mutex.execute m
 			(fun () ->
-				Queues.transfer_tag tag queue default;
+				Queues.transfer_tag tag queue queues;
 				overrides := StringMap.remove tag !overrides
-				(* All items with [tag] will enter the default queue *)
+				(* All items with [tag] will enter the queues queue *)
 			)
 
 	module Dump = struct
@@ -502,7 +509,7 @@ module Redirector = struct
 							(fun t ->
 							{ tag = t; items = List.rev (Queue.fold (fun acc (b, _) -> b :: acc) [] (Queues.get t queue)) }
 							) (Queues.tags queue) in
-					List.concat (List.map one (default :: (List.map snd (StringMap.bindings !overrides))))
+					List.concat (List.map one (default :: parallel_queues :: (List.map snd (StringMap.bindings !overrides))))
 				)
 
 	end
@@ -566,7 +573,7 @@ module Worker = struct
 				end else false
 			)
 
-	let create () =
+	let create queues =
 		let t = {
 			state = Idle;
 			shutdown_requested = false;
@@ -581,7 +588,7 @@ module Worker = struct
 					t.shutdown_requested
 				)) do
 					Mutex.execute t.m (fun () -> t.state <- Idle);
-					let tag, queue, (op, item) = Redirector.pop () in (* blocks here *)
+					let tag, queue, (op, item) = Redirector.pop queues () in (* blocks here *)
 					debug "Queue.pop returned %s" (string_of_operation op);
 					Mutex.execute t.m (fun () -> t.state <- Processing (op, item));
 					begin
@@ -595,7 +602,7 @@ module Worker = struct
 						with e ->
 							debug "Queue caught: %s" (Printexc.to_string e)
 					end;
-					Redirector.finished tag queue;
+					Redirector.finished queues tag queue;
 					(* The task must have succeeded or failed. *)
 					begin match item.Xenops_task.state with
 						| Task.Pending _ ->
@@ -669,13 +676,13 @@ module WorkerPool = struct
 					acc
 				end else w :: acc) [] pool
 
-	let incr () =
+	let incr queues =
 		debug "Adding a new worker to the thread pool";
 		Mutex.execute m
 			(fun () ->
 				pool := gc !pool;
 				if not(find_one Worker.restart !pool)
-				then pool := (Worker.create ()) :: !pool
+				then pool := (Worker.create queues) :: !pool
 			)
 
 	let decr () =
@@ -689,14 +696,16 @@ module WorkerPool = struct
 
 	let start size =
 		for i = 1 to size do
-			incr ()
+			incr Redirector.default;
+			incr Redirector.parallel_queues
 		done
 
 	let set_size size =
 		let active = count_active () in
 		debug "XXX active = %d" active;
 		for i = 1 to max 0 (size - active) do
-			incr ()
+			incr Redirector.default;
+			incr Redirector.parallel_queues
 		done;
 		for i = 1 to max 0 (active - size) do
 			decr ()
@@ -758,10 +767,13 @@ let export_metadata vdi_map vif_map id =
    to upgrade RO -> RW or downgrade RW -> RO on the fly.
    One possible fix is to always attach RW and enforce read/only-ness at the VBD-level.
    However we would need to fix the LVHD "attach provisioning mode". *)
+let vbd_plug_sets vbds =
+	let rw, ro = List.partition (fun vbd -> vbd.Vbd.mode = Vbd.ReadWrite) vbds in
+	rw, ro
 let vbd_plug_order vbds =
 	(* return RW devices first since the storage layer can't upgrade a
 	   'RO attach' into a 'RW attach' *)
-	let rw, ro = List.partition (fun vbd -> vbd.Vbd.mode = Vbd.ReadWrite) vbds in
+	let rw, ro = vbd_plug_sets vbds in
 	rw @ ro
 
 let vbd_unplug_order vbds = List.rev (vbd_plug_order vbds)
@@ -789,11 +801,23 @@ let rec atomics_of_operation = function
 			VM_build id;
 		] @ (List.map (fun vbd -> VBD_set_active (vbd.Vbd.id, true))
 			(VBD_DB.vbds id)
-		) @	(List.concat (List.map (fun vbd -> Opt.default [] (Opt.map
-			(fun x -> [ VBD_epoch_begin (vbd.Vbd.id, x, vbd.Vbd.persistent) ]) vbd.Vbd.backend))
-			(VBD_DB.vbds id |> vbd_plug_order)
-		)) @ simplify (List.map (fun vbd -> VBD_plug vbd.Vbd.id)
-			(VBD_DB.vbds id |> vbd_plug_order)
+		) @ (
+			let vbds_rw, vbds_ro = VBD_DB.vbds id |> vbd_plug_sets in
+			List.map (fun (ty, vbds)-> Parallel ( id, (Printf.sprintf "VBD.epoch_begin %s vm=%s" ty id),
+				(List.concat (List.map (fun vbd -> Opt.default [] (Opt.map
+					(fun x -> [ VBD_epoch_begin (vbd.Vbd.id, x, vbd.Vbd.persistent) ]) vbd.Vbd.backend))
+					vbds
+				)))
+			)
+			(* keeping behaviour of vbd_plug_order: rw vbds must be plugged before ro vbds, see vbd_plug_sets *)
+			[ "RW", vbds_rw; "RO", vbds_ro ]
+		) @ simplify (
+			let vbds_rw, vbds_ro = VBD_DB.vbds id |> vbd_plug_sets in
+			[
+			(* rw vbds must be plugged before ro vbds, see vbd_plug_sets *)
+			Parallel ( id, (Printf.sprintf "VBD.plug RW vm=%s" id), List.map (fun vbd->VBD_plug vbd.Vbd.id) vbds_rw);
+			Parallel ( id, (Printf.sprintf "VBD.plug RO vm=%s" id), List.map (fun vbd->VBD_plug vbd.Vbd.id) vbds_ro);
+			]
 		) @ (List.map (fun vif -> VIF_set_active (vif.Vif.id, true))
 			(VIF_DB.vifs id)
 		) @ simplify (List.map (fun vif -> VIF_plug vif.Vif.id)
@@ -819,8 +843,11 @@ let rec atomics_of_operation = function
 		) @ simplify ([
 			(* At this point we have a shutdown domain (ie Needs_poweroff) *)
 			VM_destroy_device_model id;
-		] @ (List.map (fun vbd -> VBD_unplug (vbd.Vbd.id, true))
-			(VBD_DB.vbds id |> vbd_unplug_order)
+		] @ (
+			let vbds = VBD_DB.vbds id |> vbd_unplug_order in
+			[
+			Parallel ( id, (Printf.sprintf "VBD.unplug vm=%s" id), List.map (fun vbd->VBD_unplug (vbd.Vbd.id, true)) vbds);
+			]
 		) @ (List.map (fun vif -> VIF_unplug (vif.Vif.id, true))
 			(VIF_DB.vifs id)
 		) @ (List.map (fun pci -> PCI_unplug pci.Pci.id)
@@ -842,8 +869,13 @@ let rec atomics_of_operation = function
 		[
 		] @ (List.map (fun vbd -> VBD_set_active (vbd.Vbd.id, true))
 			(VBD_DB.vbds id)
-		) @ (List.map (fun vbd -> VBD_plug vbd.Vbd.id)
-			(VBD_DB.vbds id |> vbd_plug_order)
+		) @ (
+			let vbds_rw, vbds_ro = VBD_DB.vbds id |> vbd_plug_sets in
+			[
+			(* rw vbds must be plugged before ro vbds, see vbd_plug_sets *)
+			Parallel ( id, (Printf.sprintf "VBD.plug RW vm=%s" id), List.map (fun vbd->VBD_plug vbd.Vbd.id) vbds_rw);
+			Parallel ( id, (Printf.sprintf "VBD.plug RO vm=%s" id), List.map (fun vbd->VBD_plug vbd.Vbd.id) vbds_ro);
+			]
 		) @
 			(if restore_vifs
 				then atomics_of_operation (VM_restore_vifs id)
@@ -866,9 +898,15 @@ let rec atomics_of_operation = function
 		[
 			VM_hook_script(id, Xenops_hooks.VM_pre_destroy, reason);
 		] @ (atomics_of_operation (VM_shutdown (id, timeout))
-		) @ (List.concat (List.map (fun vbd -> Opt.default [] (Opt.map (fun x -> [ VBD_epoch_end (vbd.Vbd.id, x)] ) vbd.Vbd.backend))
-			(VBD_DB.vbds id)
-		)) @ (List.map (fun vbd -> VBD_set_active (vbd.Vbd.id, false))
+		) @ (
+			let vbds = VBD_DB.vbds id in
+			[
+			Parallel ( id, (Printf.sprintf "VBD.epoch_end vm=%s" id),
+				(List.concat (List.map (fun vbd -> Opt.default [] (Opt.map (fun x -> [ VBD_epoch_end (vbd.Vbd.id, x)] ) vbd.Vbd.backend))
+					vbds
+				)))
+			]
+		) @ (List.map (fun vbd -> VBD_set_active (vbd.Vbd.id, false))
 			(VBD_DB.vbds id)
 		) @ (List.map (fun vif -> VIF_set_active (vif.Vif.id, false))
 			(VIF_DB.vifs id)
@@ -884,9 +922,15 @@ let rec atomics_of_operation = function
 		) @ [
 			VM_hook_script(id, Xenops_hooks.VM_pre_destroy, reason)
 		] @ (atomics_of_operation (VM_shutdown (id, None))
-		) @ (List.concat (List.map (fun vbd -> Opt.default [] (Opt.map (fun x -> [ VBD_epoch_end (vbd.Vbd.id, x) ]) vbd.Vbd.backend))
-			(VBD_DB.vbds id)
-		)) @ [
+		) @ (
+			let vbds = VBD_DB.vbds id in
+			[
+			Parallel ( id, (Printf.sprintf "VBD.epoch_end vm=%s" id),
+				(List.concat (List.map (fun vbd -> Opt.default [] (Opt.map (fun x -> [ VBD_epoch_end (vbd.Vbd.id, x) ]) vbd.Vbd.backend))
+					vbds
+				)))
+			]
+		) @ [
 			VM_hook_script(id, Xenops_hooks.VM_post_destroy, reason);
 			VM_hook_script(id, Xenops_hooks.VM_pre_reboot, Xenops_hooks.reason__none)
         ] @ (atomics_of_operation (VM_start id)
@@ -935,10 +979,33 @@ let rec atomics_of_operation = function
 		]
 	| _ -> []
 
-let perform_atomic ~progress_callback ?subtask ?result (op: atomic) (t: Xenops_task.t) : unit =
+let rec perform_atomic ~progress_callback ?subtask ?result (op: atomic) (t: Xenops_task.t) : unit =
 	let module B = (val get_backend () : S) in
 	Xenops_task.check_cancelling t;
 	match op with
+		| Parallel (id, description, atoms) ->
+			(* parallel_id is a unused unique name prefix for a parallel worker queue *)
+			let parallel_id = Printf.sprintf "Parallel:task=%s.atoms=%d.(%s)" t.Xenops_task.id (List.length atoms) description in
+			debug "begin_%s" parallel_id;
+			let task_list = queue_atomics_and_wait ~progress_callback ~max_parallel_atoms:10 parallel_id parallel_id atoms in
+			debug "end_%s" parallel_id;
+			(* make sure that we destroy all the parallel tasks that finished *)
+			let errors = List.map (fun task->
+				match task.Xenops_task.state with
+				| Task.Completed _ ->
+					TASK.destroy' task.Xenops_task.id;
+					None
+				| Task.Failed e ->
+					TASK.destroy' task.Xenops_task.id;
+					let e = e |> Exception.exnty_of_rpc |> exn_of_exnty in
+					Some e
+				| Task.Pending _ ->
+					error "Parallel: queue_atomics_and_wait returned a pending task";
+					Xenops_task.cancel tasks task.Xenops_task.id;
+					Some (Cancelled task.Xenops_task.id)
+			) task_list in
+			(* if any error was present, raise first one, so that trigger_cleanup_after_failure is called *)
+			List.iter (fun err->match err with None->() |Some e->raise e) errors
 		| VIF_plug id ->
 			debug "VIF.plug %s" (VIF_DB.string_of_id id);
 			B.VIF.plug t (VIF_DB.vm_of id) (VIF_DB.read_exn id);
@@ -1154,6 +1221,38 @@ let perform_atomic ~progress_callback ?subtask ?result (op: atomic) (t: Xenops_t
 			debug "VM %s: waiting for %.2f before next VM action" id t;
 			Thread.delay t
 
+and queue_atomic_int ~progress_callback dbg id op =
+	let task = Xenops_task.add tasks dbg (let r = ref None in fun t -> perform_atomic ~progress_callback ~result:r op t; !r) in
+	Redirector.push Redirector.parallel_queues id ((Atomic op), task);
+	task
+
+and queue_atomics_and_wait ~progress_callback ~max_parallel_atoms dbg id ops =
+	let from = Updates.last_id dbg updates in
+	let chunks size lst =
+		List.fold_left (fun acc op ->
+			match acc with
+			| [] -> [[op]]
+			| xs::xss ->
+				if List.length xs < size
+				then (op::xs)::xss
+				else [op]::xs::xss
+		) [] lst
+		|> List.map (fun xs -> List.rev xs) |> List.rev
+	in
+	chunks max_parallel_atoms ops
+	|> List.mapi (fun chunk_idx ops ->
+		debug "queue_atomics_and_wait: %s: chunk of %d atoms" dbg (List.length ops);
+		let task_list = List.mapi (fun atom_idx op->
+			(* atom_id is a unique name for a parallel atom worker queue *)
+			let atom_id = Printf.sprintf "%s.chunk=%d.atom=%d" id chunk_idx atom_idx in
+			queue_atomic_int ~progress_callback dbg atom_id op
+			) ops
+		in
+		let timeout_start = Unix.gettimeofday () in
+		List.iter (fun task-> event_wait updates task ~from ~timeout_start 1200.0 (task_finished_p task.Xenops_task.id) |> ignore) task_list;
+		task_list
+	) |> List.concat
+
 (* Used to divide up the progress (bar) amongst atomic operations *)
 let weight_of_atomic = function
 	| VM_save (_, _, _) -> 10.
@@ -1225,7 +1324,9 @@ and trigger_cleanup_after_failure op t = match op with
 	| VIF_hotunplug (id, _) ->
 		immediate_operation t.Xenops_task.dbg (fst id) (VIF_check_state id)
 
-	| Atomic op -> begin match op with
+	| Atomic op -> trigger_cleanup_after_failure_atom op t
+
+and trigger_cleanup_after_failure_atom op t = match op with
 		| VBD_eject id
 		| VBD_plug id
 		| VBD_set_active (id, _)
@@ -1271,7 +1372,8 @@ and trigger_cleanup_after_failure op t = match op with
 		| VM_restore (id, _)
 		| VM_delay (id, _) ->
 			immediate_operation t.Xenops_task.dbg id (VM_check_state id)
-	end
+		| Parallel (id, description, ops) ->
+			List.iter (fun op->trigger_cleanup_after_failure_atom op t) ops
 
 and perform ?subtask ?result (op: operation) (t: Xenops_task.t) : unit =
 	let module B = (val get_backend () : S) in
@@ -1546,7 +1648,7 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.t) : unit =
 
 let queue_operation_int dbg id op =
 	let task = Xenops_task.add tasks dbg (let r = ref None in fun t -> perform ~result:r op t; !r) in
-	Redirector.push id (op, task);
+	Redirector.push Redirector.default id (op, task);
 	task
 
 let queue_operation dbg id op =

--- a/lib/xenops_task.ml
+++ b/lib/xenops_task.ml
@@ -6,8 +6,10 @@ module Updates = Updates.Updates(Xenops_interface)
 let updates = Updates.empty ()
 let tasks = Xenops_task.empty ()
 
-let event_wait local_updates task ?from timeout p =
-	let start = Unix.gettimeofday () in
+let event_wait local_updates task ?from ?timeout_start timeout p =
+	let start = match timeout_start with
+	| Some s -> s
+	| None -> Unix.gettimeofday () in
 	let rec inner remaining event_id =
 		if (remaining > 0.0) then begin
 			let _, deltas, next_id = Updates.get (Printf.sprintf "event_wait task %s" task.Xenops_task.id)

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -618,3 +618,14 @@ let detect_hypervisor () =
 			Some (Xen(major, minor))
 		| x -> Some (Other x)
 	end else None
+
+let chunks size lst =
+	List.fold_left (fun acc op ->
+		match acc with
+		| [] -> [[op]]
+		| xs::xss ->
+			if List.length xs < size
+			then (op::xs)::xss
+			else [op]::xs::xss
+	) [] lst
+	|> List.map (fun xs -> List.rev xs) |> List.rev


### PR DESCRIPTION
such as vm-start, vm-shutdown, vm-restore, vm-poweroff, vm-reboot.

In this patch, a new composable Parallel atom in xenopsd is created. Any
atoms inside Parallel will be executed concurrently in a new independent
pool of worker threads specific for the Parallel atoms. A new pool of
parallel worker threads is used to avoid a deadlock where an operation
needs to wait for a Parallel atom to run but the Parallel atom cannot run
because all the default worker thread slots are being used by other
operations also waiting for Parallel atoms to run.

The Parallel atom is used to execute in parallel all the VBD-related atoms
that are otherwise taking a long time to execute as a sequence during the
VM lifecycle operations, which are:

    VBD.epoch_begin
    VBD.plug
    VBD.unplug
    VBD.epoch_end

The SM layer supports the parallel execution of these operations, since
this is already the case during the parallel execution of VM lifecycle
operations. We strived to achieve safety in xenopsd by limiting the
concurrency to only inside the Parallel atoms, and by carefully looking
the code inside the xc/VBD.{plug,unplug,epoch_begin,epoch_end} which are
related to accessing potentially shared datastructures.

Signed-off-by: Marcus Granado marcus.granado@citrix.com