### PR TITLE
CP-15358: support external ip address setting

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -127,6 +127,8 @@ module type S = sig
 		val move: Xenops_task.t -> Vm.id -> Vif.t -> Network.t -> unit
 		val set_carrier: Xenops_task.t -> Vm.id -> Vif.t -> bool -> unit
 		val set_locking_mode: Xenops_task.t -> Vm.id -> Vif.t -> Vif.locking_mode -> unit
+		val set_static_ip_setting: Xenops_task.t -> Vm.id -> Vif.t -> Vif.static_ip_setting -> unit
+		val unset_static_ip_setting: Xenops_task.t -> Vm.id -> Vif.t -> string -> unit
 
 		val get_state: Vm.id -> Vif.t -> Vif.state
 

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -104,6 +104,8 @@ module VIF = struct
 	let move _ _ _ _ = unimplemented "VIF.move"
 	let set_carrier _ _ _ _ = unimplemented "VIF.set_carrier"
 	let set_locking_mode _ _ _ _ = unimplemented "VIF.set_locking_mode"
+	let set_static_ip_setting _ _ _ _ = unimplemented "VIF.set_static_ip_setting"
+	let unset_static_ip_setting _ _ _ _ = unimplemented "VIF.unset_static_ip_setting"
 	let get_state _ _ = unplugged_vif
 	let get_device_action_request _ _ = None
 end

--- a/simulator/xenops_server_simulator.ml
+++ b/simulator/xenops_server_simulator.ml
@@ -307,6 +307,18 @@ let set_locking_mode vm vif mode () =
 	let vifs = List.map (fun vif -> { vif with Vif.locking_mode = if this_one vif then mode else vif.Vif.locking_mode }) d.Domain.vifs in
 	DB.write vm { d with Domain.vifs = vifs }
 
+let set_static_ip_setting vm vif static_ip_setting () =
+	let d = DB.read_exn vm in
+	let this_one x = x.Vif.id = vif.Vif.id in
+	let vifs = List.map (fun vif -> { vif with Vif.static_ip_setting = if this_one vif then static_ip_setting else vif.Vif.static_ip_setting }) d.Domain.vifs in
+	DB.write vm { d with Domain.vifs = vifs }
+
+let unset_static_ip_setting vm vif key () =
+	let d = DB.read_exn vm in
+	let this_one x = x.Vif.id = vif.Vif.id in
+	let vifs = List.map (fun vif -> { vif with Vif.static_ip_setting = if this_one vif then [] else vif.Vif.static_ip_setting }) d.Domain.vifs in
+	DB.write vm { d with Domain.vifs = vifs }
+
 let remove_pci vm pci () =
 	let d = DB.read_exn vm in
 	let this_one x = x.Pci.id = pci.Pci.id in
@@ -415,6 +427,8 @@ module VIF = struct
 	let move _ vm vif network = Mutex.execute m (move_vif vm vif network)
 	let set_carrier _ vm vif carrier = Mutex.execute m (set_carrier vm vif carrier)
 	let set_locking_mode _ vm vif mode = Mutex.execute m (set_locking_mode vm vif mode)
+	let set_static_ip_setting _ vm vif static_ip_setting = Mutex.execute m (set_static_ip_setting vm vif static_ip_setting)
+	let unset_static_ip_setting _ vm vif key = Mutex.execute m (unset_static_ip_setting vm vif key)
 
 	let get_state vm vif = Mutex.execute m (vif_state vm vif)
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -614,6 +614,7 @@ module VifDeviceTests = DeviceTests(struct
 			rate = Some(1L, 2L);
 			backend = Network.Local "xenbr0";
 			other_config = [ "other", "config" ];
+			static_ip_setting = [ ("address", "192.168.1.10/24") ];
 			locking_mode = Vif.Unlocked;
 			extra_private_keys = [ "private", "keys" ];
 		}
@@ -633,6 +634,7 @@ module VifDeviceTests = DeviceTests(struct
 		assert_equal ~msg:"rate" ~printer:(function Some (a, b) -> Printf.sprintf "Some %Ld %Ld" a b | None -> "None") vif.rate vif'.rate;
 		assert_equal ~msg:"backend" ~printer:(fun x -> x |> Network.rpc_of_t |> Jsonrpc.to_string) vif.backend vif'.backend;
 		assert_equal ~msg:"other_config" ~printer:sl vif.other_config vif'.other_config;
+		assert_equal ~msg:"other_config" ~printer:sl vif.static_ip_setting vif'.static_ip_setting;
 		assert_equal ~msg:"extra_private_keys" ~printer:sl vif.extra_private_keys vif'.extra_private_keys
 end)
 

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -645,11 +645,15 @@ module Vif = struct
 let write_extra_config ~xs device extra_config mac =
 	let domid = device.frontend.domid in
 	let devid = string_of_int device.frontend.devid in
-	let xenstore_path = Printf.sprintf "/local/domain/%d/xenserver/device/vif/%s" domid devid in	
+	let xenstore_path = Printf.sprintf "/local/domain/%d/xenserver/device/vif/%s" domid devid in
+	let perms = Xs_protocol.ACL.({owner = domid; other = NONE; acl = []}) in
 
 	Xs.transaction xs (fun t ->
 		t.Xst.mkdir xenstore_path;
+		t.Xst.setperms xenstore_path perms;
 		t.Xst.write (Printf.sprintf "%s/static-ip-setting/%s" xenstore_path "mac") mac;
+		t.Xst.write (Printf.sprintf "%s/static-ip-setting/%s" xenstore_path "error-code") "0";
+		t.Xst.write (Printf.sprintf "%s/static-ip-setting/%s" xenstore_path "error-msg") "";
 		List.iter (fun (x, y) ->
 			let ip_setting_path = Printf.sprintf "%s/static-ip-setting/%s" xenstore_path x in
 			debug "xenstore-write %s <- %s" ip_setting_path y;

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -80,7 +80,8 @@ sig
 	       -> mac:string -> carrier:bool 
 	       -> ?mtu:int -> ?rate:(int64 * int64) option
 	       -> ?protocol:protocol -> ?backend_domid:Xenctrl.domid 
-	       -> ?other_config:((string * string) list) 
+	       -> ?other_config:((string * string) list)
+	       -> ?static_ip_setting:((string * string) list)
 	       -> ?extra_private_keys:(string * string) list -> Xenctrl.domid
 	       -> device
 	val set_carrier : xs:Xenstore.Xs.xsh -> device -> bool -> unit

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1327,7 +1327,11 @@ module VIF = struct
 			let xenstore_path = Printf.sprintf "/local/domain/%d/xenserver/device/vif/%s" domid devid in
 			Xs.transaction xs (fun t ->
 				t.Xst.mkdir xenstore_path;
+				t.Xst.setperms xenstore_path
+					Xs_protocol.ACL.({owner = domid; other = NONE; acl = []});
 				t.Xst.write (Printf.sprintf "%s/static-ip-setting/%s" xenstore_path "mac") mac;
+				t.Xst.write (Printf.sprintf "%s/static-ip-setting/%s" xenstore_path "error-code") "0";
+				t.Xst.write (Printf.sprintf "%s/static-ip-setting/%s" xenstore_path "error-msg") "";
 				List.iter (fun (x, y) ->
 					let ip_setting_path = Printf.sprintf "%s/static-ip-setting/%s" xenstore_path x in
 					debug "xenstore-write %s <- %s" ip_setting_path y;

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1319,6 +1319,34 @@ module VIF = struct
 			)
 		)
 
+	let write_extra_config device extra_config mac =
+		let open Device_common in
+		with_xs (fun xs ->
+			let domid = device.frontend.domid in
+			let devid = string_of_int device.frontend.devid in
+			let xenstore_path = Printf.sprintf "/local/domain/%d/xenserver/device/vif/%s" domid devid in
+			Xs.transaction xs (fun t ->
+				t.Xst.mkdir xenstore_path;
+				t.Xst.write (Printf.sprintf "%s/static-ip-setting/%s" xenstore_path "mac") mac;
+				List.iter (fun (x, y) ->
+					let ip_setting_path = Printf.sprintf "%s/static-ip-setting/%s" xenstore_path x in
+					debug "xenstore-write %s <- %s" ip_setting_path y;
+					t.Xst.write ip_setting_path y
+				) extra_config
+			)
+		)
+
+	let remove_extra_config device =
+		let open Device_common in
+		with_xs (fun xs ->
+			let domid = device.frontend.domid in
+			let devid = string_of_int device.frontend.devid in
+			let xenstore_path = Printf.sprintf "/local/domain/%d/xenserver/device/vif/%s" domid devid in
+			Xs.transaction xs (fun t ->
+				t.Xst.rm xenstore_path
+			)
+		)
+
 	let pre_plug vm hvm vif =
 		debug "VIF.pre_plug";
 		let backend_domid = with_xs (fun xs -> backend_domid_of xs vif) in
@@ -1389,11 +1417,14 @@ module VIF = struct
 						(* wait for plug (to be removed if possible) *)
 						let open Device_common in
 						let devid = vif.position in
+						let static_ip_setting = vif.static_ip_setting in
+						let mac = vif.mac in
 						let backend_domid = with_xs (fun xs -> backend_domid_of xs vif) in
 						let frontend = { domid = frontend_domid; kind = Vif; devid = devid } in
 						let backend = { domid = backend_domid; kind = Vif; devid = devid } in
 						let device = { backend = backend; frontend = frontend } in
 						with_xs (fun xs -> Hotplug.wait_for_plug task ~xs device);
+						write_extra_config device static_ip_setting mac;
 
 						(* add disconnect flag *)
 						let disconnect_path, flag = disconnect_flag device vif.locking_mode in
@@ -1419,7 +1450,8 @@ module VIF = struct
 					);
 					let device = device_by_id xs vm Device_common.Vif Oldest (id_of vif) in
 					Xenops_task.with_subtask task (Printf.sprintf "Vif.release %s" (id_of vif))
-						(fun () -> Hotplug.release' task ~xs device vm "vif" vif.position)
+						(fun () -> Hotplug.release' task ~xs device vm "vif" vif.position);
+					remove_extra_config device
 				with
 					| _ ->
 						debug "VM = %s; Ignoring missing device" (id_of vif)
@@ -1504,6 +1536,35 @@ module VIF = struct
 				let di = with_ctx (fun ctx -> Xenlight.Dominfo.get ctx device.frontend.domid) in
 				if di.Xenlight.Dominfo.domain_type = Xenlight.DOMAIN_TYPE_HVM
  				then ignore (run !Xl_path.setup_vif_rules ["xenlight"; tap_interface_name; vm; devid; "filter"])
+			)
+
+	let set_static_ip_setting task vm vif static_ip_setting =
+		let open Device_common in
+		with_xs
+			(fun xs ->
+				let device = device_by_id xs vm Vif Newest (id_of vif) in
+				let domid = device.frontend.domid in
+				let devid = string_of_int device.frontend.devid in
+				let xenstore_path = Printf.sprintf "/local/domain/%d/xenserver/device/vif/%s/static-ip-setting" domid devid in
+				List.iter (fun (x, y) ->
+					let ip_setting_path = Printf.sprintf "%s/%s" xenstore_path x in
+					debug "xenstore-write %s <- %s" ip_setting_path y;
+					xs.Xs.write ip_setting_path y
+				) static_ip_setting
+			)
+
+	let unset_static_ip_setting task vm vif key =
+		let open Device_common in
+		with_xs
+			(fun xs ->
+				let device = device_by_id xs vm Vif Newest (id_of vif) in
+				let domid = device.frontend.domid in
+				let devid = string_of_int device.frontend.devid in
+				let xenstore_path = Printf.sprintf "/local/domain/%d/xenserver/device/vif/%s/static-ip-setting" domid devid in
+
+				let ip_setting_path = Printf.sprintf "%s/%s" xenstore_path key in
+				debug "xenstore-rm <- %s" ip_setting_path;
+				xs.Xs.rm ip_setting_path
 			)
 
 	let get_state vm vif =


### PR DESCRIPTION
extend vif-param-set to set following xenstore keys, then windows guest agent reads these keys to write static ip setting to windows guest os

xenserver
device = ""
vif = ""
0 = ""
static-ip-setting = ""
mac = "ae:0e:ad:e7:a5:6e"
error-code = "0"
error-msg = ""
address6 = "2001:0DB8:02de:1000::0e13/64"
gateway6 = "2001:0DB8:02de:1000::1"
address = "10.158.180.45/24"
gateway = "10.158.180.1"
enabled = "0"