### PR TITLE
CA-209511: Don't remove private data path for devices during localhost migration

### DIFF
--- a/xc/device.mli
+++ b/xc/device.mli
@@ -57,9 +57,9 @@ sig
 		backend_domid: int;
 	}
 
-	val add : Xenops_task.t -> xs:Xenstore.Xs.xsh -> hvm:bool -> t -> Xenctrl.domid -> device
+	val add : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> hvm:bool -> t -> Xenctrl.domid -> device
 
-	val release : Xenops_task.t -> xs:Xenstore.Xs.xsh -> device -> unit
+	val release : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> device -> unit
 	val media_eject : xs:Xenstore.Xs.xsh -> device -> unit
 	val media_insert : xs:Xenstore.Xs.xsh -> phystype:physty -> params:string -> device -> unit
 	val media_is_ejected : xs:Xenstore.Xs.xsh -> device -> bool
@@ -84,7 +84,7 @@ sig
 	       -> ?extra_xenserver_keys:(string * string) list -> Xenctrl.domid
 	       -> device
 	val set_carrier : xs:Xenstore.Xs.xsh -> device -> bool -> unit
-	val release : Xenops_task.t -> xs:Xenstore.Xs.xsh -> device -> unit
+	val release : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> device -> unit
 	val move : xs:Xenstore.Xs.xsh -> device -> string -> unit
 end
 

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -132,12 +132,10 @@ let string_of_device (x: device) =
  * to take the UUID as an argument (and change the callers as well...) *)
 let uuid_of_domid domid =
 	try
-		Xenops_helpers.with_xc_and_xs (fun _ xs ->
-			let vm = xs.Xs.getdomainpath domid ^ "/vm" in
-			let vm_dir = xs.Xs.read vm in
-			xs.Xs.read (vm_dir ^ "/uuid")
+		with_xs (fun xs ->
+			Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid)
 		)
-	with _ ->
+	with Xenops_helpers.Domain_not_found ->
 		error "uuid_of_domid failed for domid %d" domid;
 		(* Returning a random string on error is not very neat, but we must avoid
 		 * exceptions here. This patch must be followed soon by a patch that changes the

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -368,8 +368,7 @@ let destroy (task: Xenops_task.t) ~xc ~xs ~qemu_domid domid =
 
 	(* Any other domains with the same UUID as the one we are destroying.
 	 * There can be one during a localhost migration. *)
-	let other_domains = List.filter (fun x -> Xenctrl_uuid.uuid_of_handle x.Xenctrl.handle = uuid)
-		(Xenctrl.domain_getinfolist xc 0) in
+	let other_domains = Xenops_helpers.domains_of_uuid ~xc uuid in
 	debug "VM = %s; domid = %d; Domain.destroy: other domains with the same UUID = [ %a ]"
 		(Uuid.to_string uuid) domid
 		(fun () -> String.concat "; ")
@@ -423,7 +422,7 @@ let destroy (task: Xenops_task.t) ~xc ~xs ~qemu_domid domid =
 	List.iter (fun x ->
 		log_exn_continue ("waiting for hotplug for " ^ (string_of_device x))
 		                 (fun () ->
-			Hotplug.release task ~xs x; released := x :: !released
+			Hotplug.release task ~xc ~xs x; released := x :: !released
 		                 ) ()
 		) all_devices;
 

--- a/xc/xenops_helpers.ml
+++ b/xc/xenops_helpers.ml
@@ -24,3 +24,20 @@ let with_xc_and_xs f =
 let with_xc_and_xs_final f cf =
 	with_xc_and_xs (fun xc xs -> finally (fun () -> f xc xs) cf)
 
+exception Domain_not_found
+
+let uuid_of_domid ~xs domid =
+	try
+		let vm = xs.Xs.getdomainpath domid ^ "/vm" in
+		let vm_dir = xs.Xs.read vm in
+		match Uuidm.of_string (xs.Xs.read (vm_dir ^ "/uuid")) with
+		| Some uuid -> uuid
+		| None -> raise Domain_not_found
+	with _ ->
+		raise Domain_not_found
+
+let domains_of_uuid ~xc uuid =
+	List.filter
+		(fun x -> Xenctrl_uuid.uuid_of_handle x.Xenctrl.handle = uuid)
+		(Xenctrl.domain_getinfolist xc 0)
+

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -228,7 +228,7 @@ let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
 				backend_domid = backend_domid;
 			} in
 			let device = Xenops_task.with_subtask task "Vbd.add"
-				(fun () -> Device.Vbd.add task ~xs ~hvm:false t frontend_domid) in
+				(fun () -> Device.Vbd.add task ~xc ~xs ~hvm:false t frontend_domid) in
 			Device device
 
 let block_device_of_vbd_frontend = function
@@ -1987,7 +1987,7 @@ module VBD = struct
 					} in
 					let device =
 						Xenops_task.with_subtask task (Printf.sprintf "Vbd.add %s" (id_of vbd))
-							(fun () -> Device.Vbd.add task ~xs ~hvm x frontend_domid) in
+							(fun () -> Device.Vbd.add task ~xc ~xs ~hvm x frontend_domid) in
 
 					(* We store away the disk so we can implement VBD.stat *)
 					Opt.iter (fun disk -> xs.Xs.write (vdi_path_of_device ~xs device) (disk |> rpc_of_disk |> Jsonrpc.to_string)) vbd.backend;
@@ -2063,7 +2063,7 @@ module VBD = struct
 							Opt.iter
 								(fun device ->
 									Xenops_task.with_subtask task (Printf.sprintf "Vbd.release %s" (id_of vbd))
-										(fun () -> Device.Vbd.release task ~xs device);
+										(fun () -> Device.Vbd.release task ~xc ~xs device);
 								) device;
 							(* If we have a qemu frontend, detach this too. *)
 							Mutex.execute dB_m (fun () ->
@@ -2356,7 +2356,7 @@ module VIF = struct
 						Xenops_task.with_subtask task (Printf.sprintf "Vif.hard_shutdown %s" (id_of vif))
 							(fun () -> (if force then Device.hard_shutdown else Device.clean_shutdown) task ~xs device);
 						Xenops_task.with_subtask task (Printf.sprintf "Vif.release %s" (id_of vif))
-							(fun () -> Device.Vif.release task ~xs device) in
+							(fun () -> Device.Vif.release task ~xc ~xs device) in
 					destroy device;
 
 					Opt.iter (fun vm_t -> 


### PR DESCRIPTION
There can be multiple domains for a single VM during a localhost migration, and
the private data path is indexed by UUID, not domid. When unplugging the
devices for the old domain during a localhost migration, we must not remove the
private data keys, because they are needed by the new domain.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>