### PR TITLE
CP-17694: Log stdout/stderr from device model

### DIFF
--- a/scripts/qemu-dm-wrapper
+++ b/scripts/qemu-dm-wrapper
@@ -43,6 +43,7 @@ def enable_core_dumps():
 
 def main(argv):
 	import os
+	import sys
 
 	qemu_env = os.environ
 	qemu_dm_list =[]
@@ -77,6 +78,7 @@ def main(argv):
 	xenstore_write("/local/domain/%d/qemu-pid" % domid, "%d" % os.getpid())
 
 	os.dup2(1, 2)
+	sys.stdout.flush()
 	os.execve(qemu_dm, qemu_args, qemu_env)
 
 if __name__ == '__main__':

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1650,7 +1650,9 @@ let prepend_wrapper_args domid args =
  * exception is raised *)
 let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel _ =
 	debug "Starting daemon: %s with args [%s]" path (String.concat "; " args);
-	let pid = Forkhelpers.safe_close_and_exec None None None [] path args in
+	let syslog_key = (Printf.sprintf "%s-%d" name domid) in
+	let syslog_stdout = Forkhelpers.Syslog_WithKey syslog_key in
+	let pid = Forkhelpers.safe_close_and_exec None None None [] ~syslog_stdout path args in
 	debug
 		"%s: should be running in the background (stdout -> syslog); (fd,pid) = %s"
 		name (Forkhelpers.string_of_pidty pid);
@@ -1684,7 +1686,7 @@ let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeo
 		if not !finished then
 			raise (Ioemu_failed (name, "Timeout reached while starting daemon"))
 	end;
-	debug "Daemon initialised: %s" (Printf.sprintf "%s-%d" name domid);
+	debug "Daemon initialised: %s" syslog_key;
 	pid
 
 let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready_timeout) l info domid =


### PR DESCRIPTION
The stderr and stdout output from the device model process should be logged so problems with starting the device model (before it can setup syslog logging) can be diagnosed

Signed-off-by: Liang Dai <liang.dai1@citrix.com>