### PR TITLE
CA-213992: update sm-data as part of HVM media insert/eject

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -351,23 +351,6 @@ let devty_of_string = function
 	| "floppy" -> Floppy
 	| _       -> invalid_arg "devty_of_string"
 
-let add_backend_keys ~xs (x: device) subdir keys =
-	let backend_stub = backend_path_of_device ~xs x in
-	let backend = backend_stub ^ "/" ^ subdir in
-	debug "About to write data %s to path %s" (String.concat ";" (List.map (fun (a,b) -> "("^a^","^b^")") keys)) backend;
-	Xs.transaction xs (fun t ->
-		ignore(t.Xst.read backend_stub);
-		t.Xst.writev backend keys
-	)
-
-let remove_backend_keys ~xs (x: device) subdir keys =
-	let backend_stub = backend_path_of_device ~xs x in
-	let backend = backend_stub ^ "/" ^ subdir in
-	Xs.transaction xs (fun t ->
-		List.iter (fun key -> t.Xst.rm (backend ^ "/" ^ key)) keys
-	)
-
-
 let uses_blktap ~phystype = List.mem phystype [ Qcow; Vhd; Aio ]
 
 (** Request either a clean or hard shutdown *)

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -131,6 +131,22 @@ let backend_pause_done_path_of_device ~xs (x: device) =
 let backend_state_path_of_device ~xs (x: device) =
   sprintf "%s/state" (backend_path_of_device ~xs x)
 
+let add_backend_keys ~xs (x: device) subdir keys =
+        let backend_stub = backend_path_of_device ~xs x in
+        let backend = backend_stub ^ "/" ^ subdir in
+        debug "About to write data %s to path %s" (String.concat ";" (List.map (fun (a,b) -> "("^a^","^b^")") keys)) backend;
+        Xs.transaction xs (fun t ->
+                ignore(t.Xst.read backend_stub);
+                t.Xst.writev backend keys
+        )
+
+let remove_backend_keys ~xs (x: device) subdir keys =
+        let backend_stub = backend_path_of_device ~xs x in
+        let backend = backend_stub ^ "/" ^ subdir in
+        Xs.transaction xs (fun t ->
+                List.iter (fun key -> t.Xst.rm (backend ^ "/" ^ key)) keys
+        )
+
 let string_of_device (x: device) = 
   sprintf "frontend %s; backend %s" (string_of_endpoint x.frontend) (string_of_endpoint x.backend)
 

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -79,6 +79,9 @@ val list_devices_between : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Xenctrl.domid 
 
 val device_of_backend : endpoint -> Xenctrl.domid -> device
 
+val add_backend_keys : xs:Xenstore.Xs.xsh -> device -> string -> (string * string) list -> unit
+val remove_backend_keys: xs:Xenstore.Xs.xsh -> device -> string -> string list -> unit
+
 type protocol = Protocol_Native | Protocol_X86_32 | Protocol_X86_64
 val string_of_protocol : protocol -> string
 val protocol_of_string : string -> protocol

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2102,7 +2102,8 @@ module VBD = struct
 					let phystype = Device.Vbd.Phys in
 					(* We store away the disk so we can implement VBD.stat *)
 					xs.Xs.write (vdi_path_of_device ~xs device) (disk |> rpc_of_disk |> Jsonrpc.to_string);
-					Device.Vbd.media_insert ~xs ~phystype ~params:vdi.attach_info.Storage_interface.params device
+					Device.Vbd.media_insert ~xs ~phystype ~params:vdi.attach_info.Storage_interface.params device;
+					Device_common.add_backend_keys ~xs device "sm-data" vdi.attach_info.Storage_interface.xenstore_data
 				end
 			) Newest vm
 
@@ -2112,6 +2113,7 @@ module VBD = struct
 				let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) Oldest (id_of vbd) in
 				Device.Vbd.media_eject ~xs device;
 				safe_rm xs (vdi_path_of_device ~xs device);
+				safe_rm xs (Device_common.backend_path_of_device ~xs device ^ "/sm-data");
 				Storage.dp_destroy task (Storage.id_of (string_of_int (frontend_domid_of_device device)) vbd.Vbd.id)
 			) Oldest vm
 


### PR DESCRIPTION
The change will update the sm-data xenstore keys (under the VBD's backend path) in case when the underlying CD being injected or ejected. This is good for consistency, and more importantly, a necessity for other components that watch these fields for a purpose (e.g rrdd's iostats plugin). 