### PR TITLE
CP-17694: Log stdout/stderr from device model

### DIFF
--- a/scripts/qemu-dm-wrapper
+++ b/scripts/qemu-dm-wrapper
@@ -43,6 +43,7 @@ def enable_core_dumps():
 
 def main(argv):
 	import os
+	import sys
 
 	qemu_env = os.environ
 	qemu_dm_list =[]
@@ -77,6 +78,7 @@ def main(argv):
 	xenstore_write("/local/domain/%d/qemu-pid" % domid, "%d" % os.getpid())
 
 	os.dup2(1, 2)
+	sys.stdout.flush()
 	os.execve(qemu_dm, qemu_args, qemu_env)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The stderr and stdout output from the device model process (QEMU) should be
logged so problems with starting the device model (before it can setup
syslog logging) can be diagnosed.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>