### PR TITLE
CA-217921: VBD.unplug must destroy the datapath if a VBD was already shut down

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2085,7 +2085,9 @@ module VBD = struct
 						)
 						(fun () ->
 							match domid, backend with
-							| Some x, Some (VDI _) -> Storage.dp_destroy task (Storage.id_of (string_of_int x) vbd.Vbd.id)
+							| Some x, None
+							| Some x, Some (VDI _)
+								-> Storage.dp_destroy task (Storage.id_of (string_of_int x) vbd.Vbd.id)
 							| _ -> ()
 						)
 				with 


### PR DESCRIPTION
The comment on top of the `VBD.unplug` function says:

1. if the device has already been shutdown and deactivated (as in suspend) we
must call DP.destroy here to avoid leaks

However, recent commit d723d4b0 had regressed this.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>