### PR TITLE
CP-18289 add booleans to VM state: nomigrate, nested_virt

### DIFF
--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -1,0 +1,34 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+
+type platformdata = (string * string) list
+
+let is_valid ~key ~platformdata =
+	(not (List.mem_assoc key platformdata)) ||
+	(match List.assoc key platformdata |> String.lowercase with
+	| "true" | "1" | "false" | "0" -> true
+	| v -> false
+	)
+
+let is_true ~key ~platformdata ~default =
+	try
+		match List.assoc key platformdata |> String.lowercase with
+		| "true"  | "1" -> true
+		| "false" | "0" -> false
+		| _ -> default (* Check for validity using is_valid if required *)
+	with Not_found ->
+		default
+
+

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -1,0 +1,36 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+(* This module defines interpretation of boolean platform values. It
+ * matches the interpretation implemented in XenAPI for these values.
+ *)
+
+type platformdata = (string * string) list
+
+(** [is_valid key platformdata] returns true if:
+	* 1. The key is _not_ in platformdata (absence of key is valid) or
+	* 2. The key is in platformdata, associated with a booleanish value *)
+val is_valid: key:string -> platformdata:platformdata -> bool
+
+(** [is_true key platformdata default] returns true, if the platformdata
+	*  contains a value for key that is "true" or "1". It returns false, if
+	* a value "0" or "false" exists. If the key doesn't exist or contains
+	* none of the values above, [default] is returned.
+	*)
+val is_true:
+	key:string ->
+	platformdata:platformdata ->
+	default:bool ->
+	bool
+

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -548,6 +548,8 @@ let halted_vm = {
 	last_start_time = 0.;
 	shadow_multiplier_target = 1.;
 	hvm = false;
+	nomigrate=false;
+	nested_virt=false;
 }
 
 let unplugged_pci = {


### PR DESCRIPTION
These values are initialised from the VM's platformdata. A new module `platform.{ml,mli}` contains an interpretation of platform values that matches  the one used by Xen API (in vm_platform.ml).

The context of this PR is that we want to give XAPI access to the platform flags from the time when a VM first boots. This is used to decide about permissions of migration operations later in the life of a VM. Only xenopsd knows about these flags and we communicate them to Xapi using xcp-idl.



