### PR TITLE
CA-217805: Prefer asking newer guests to poweroff rather than halt

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1360,7 +1360,18 @@ module VM = struct
 		let reason = shutdown_reason reason in
 		on_domain
 			(fun xc xs task vm di ->
+
 				let domid = di.Xenctrl.domid in
+
+				(* As per comment on CA-217805 *)
+				let use_poweroff =
+					try
+						xs.Xs.read (xs.Xs.getdomainpath domid ^ "/control/feature-poweroff") = "1"
+					with _ -> false
+				in
+
+				let reason = match reason, use_poweroff with Domain.Halt, true -> Domain.PowerOff | x, _ -> x in
+
 				try
 					Domain.shutdown ~xc ~xs domid reason;
 					Domain.shutdown_wait_for_ack task ~timeout:ack_delay ~xc ~xs domid reason;


### PR DESCRIPTION
There is now a spec of how the shutdown protocol should work:

http://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=docs/misc/xenstore-paths.markdown#l378

This patch changes xenopsd to prefer the `poweroff` shutdown command
over the `halt` command, but only when the guest advertises
`feature-poweroff`. Note that libxl has used `poweroff` exclusively
for several years now:

http://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=79e162885078a9daaaf9679d547aaa65c78e3559

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>