### PR TITLE
CA-219763: If the PV drivers have been detected, raise an update

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2648,7 +2648,8 @@ module Actions = struct
 						if value = "4" (* connected *) then begin
 							let non_persistent = { non_persistent with VmExtra.pv_drivers_detected = true } in
 							debug "VM = %s; found PV driver evidence on %s (value = %s)" vm path value;
-							DB.write vm { VmExtra.persistent; non_persistent }
+							DB.write vm { VmExtra.persistent; non_persistent };
+							Updates.add (Dynamic.Vm vm) internal_updates
 						end
 					with Xs_protocol.Enoent _ ->
 						warn "Watch event on %s fired but couldn't read from it" path;


### PR DESCRIPTION
Since this is an update to a VIF or VBD, the usual logic only causes
an update for the relevant device. Thus xapi didn't know to look at
the VM again, and hence might not update the pv_drivers_detected
field. This commit adds an explicit update to the VM if the
pv_drivers_detected field changes from false to true.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>