### PR TITLE
[CP-18781] Add device information in VIF.state

### DIFF
--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -568,6 +568,7 @@ let unplugged_vif = {
      plugged = false;
      kthread_pid = 0;
      media_present = false;
+     domid = None;
 }
 
 let unplugged_vgpu = {

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -568,7 +568,7 @@ let unplugged_vif = {
      plugged = false;
      kthread_pid = 0;
      media_present = false;
-     domid = None;
+     device = None;
 }
 
 let unplugged_vgpu = {

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2591,12 +2591,13 @@ module VIF = struct
 					   is finally deleted from xenstore, can we remove bridges or
 					   switch configuration. *)
 					let domid = d.Device_common.frontend.Device_common.domid in
+					let device = "vif" ^ (string_of_int domid) ^ "." ^ (string_of_int vif.position) in
 					{
 						Vif.active = true;
 						plugged = true;
 						media_present = true;
 						kthread_pid = kthread_pid;
-						domid = Some domid
+						device = Some device
 					}
 				with
 					| (Does_not_exist(_,_))

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2590,11 +2590,13 @@ module VIF = struct
 					   from xenstore. The corrolary is that: only when the device
 					   is finally deleted from xenstore, can we remove bridges or
 					   switch configuration. *)
+					let domid = d.Device_common.frontend.Device_common.domid in
 					{
 						Vif.active = true;
 						plugged = true;
 						media_present = true;
-						kthread_pid = kthread_pid
+						kthread_pid = kthread_pid;
+						domid = Some domid
 					}
 				with
 					| (Does_not_exist(_,_))

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1652,12 +1652,13 @@ module VIF = struct
 					   is finally deleted from xenstore, can we remove bridges or
 					   switch configuration. *)
 					let domid = d.Device_common.frontend.Device_common.domid in
+					let device = "vif" ^ (string_of_int domid) ^ "." ^ (string_of_int vif.position) in
 					{
 						Vif.active = true;
 						plugged = true;
 						media_present = true;
 						kthread_pid = kthread_pid;
-						domid = Some domid
+						device = Some device
 					}
 				with
 					| (Does_not_exist(_,_))

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1657,7 +1657,7 @@ module VIF = struct
 						plugged = true;
 						media_present = true;
 						kthread_pid = kthread_pid;
-						domid = Some (domid)
+						domid = Some domid
 					}
 				with
 					| (Does_not_exist(_,_))

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -1651,11 +1651,13 @@ module VIF = struct
 					   from xenstore. The corrolary is that: only when the device
 					   is finally deleted from xenstore, can we remove bridges or
 					   switch configuration. *)
+					let domid = d.Device_common.frontend.Device_common.domid in
 					{
 						Vif.active = true;
 						plugged = true;
 						media_present = true;
-						kthread_pid = kthread_pid
+						kthread_pid = kthread_pid;
+						domid = Some (domid)
 					}
 				with
 					| (Does_not_exist(_,_))


### PR DESCRIPTION
When updating the MTU of a VIF it can happen that the VM `domid` is still out of sync. We can use the correct `domid` value passing it via `xenopsd` as a field in `VIF.stat`.

See also https://github.com/xapi-project/xcp-idl/pull/131

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>