### PR TITLE
CA-203423: fail to parse ionice, error -> warn

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2205,7 +2205,7 @@ module VBD = struct
 			Opt.map (fun i -> Ionice i) i
 		with
 			| Ionice.Parse_failed x ->
-				error "Failed to parse ionice result: %s" x;
+				warn "Failed to parse ionice result: %s" x;
 				None
 			| _ ->
 				None

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -949,7 +949,7 @@ module VBD = struct
 			Opt.map (fun i -> Ionice i) i
 		with
 			| Ionice.Parse_failed x ->
-				error "Failed to parse ionice result: %s" x;
+				warn "Failed to parse ionice result: %s" x;
 				None
 			| _ ->
 				None


### PR DESCRIPTION
`ionice` errors happens when the VBD qos are unset (the default), marking them as warnings allows us to remove a lot of spurious errors from the logs.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>