### PR TITLE
CA-225257: Fix XSRM typo in setup-pvs-proxy-rules

### DIFF
--- a/scripts/setup-pvs-proxy-rules
+++ b/scripts/setup-pvs-proxy-rules
@@ -194,7 +194,7 @@ case $ACTION in
                 # vif may still be there.
 
                 # Announce that on the OVS we have removed the rules for this VIF's pvs-proxy.
-                XSRM "${PRIVATE_PATH}/pvs-rules-active"
+                $XSRM "${PRIVATE_PATH}/pvs-rules-active"
             fi
         done
         ;;


### PR DESCRIPTION
As otherwise xe pvs-proxy-destroy fails on running VMs as follows:
   [root@xrtuk-16-04 ~]# xe pvs-proxy-destroy uuid=8d484722-ca9c-487e-b826-f8defa58925b
   The server failed to handle your request, due to an internal error.  The given message may give details useful for debugging the problem.
   message: xenopsd internal error: Forkhelpers.Spawn_internal_error("/usr/libexec/xenopsd/setup-pvs-proxy-rules: line 197: XSRM: command not found\n", "", _)

Signed-off-by: Robert Breker <robert.breker@citrix.com>