### PR TITLE
CA-225775 fix typo in platform key: nested-virt (was: nested_virt)

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -883,7 +883,7 @@ module VM = struct
 								  ~platformdata:vm.Xenops_interface.Vm.platformdata
 								  ~default:false
 								; nested_virt=Platform.is_true
-								  ~key:"nested_virt"
+								  ~key:"nested-virt"
 								  ~platformdata:vm.Xenops_interface.Vm.platformdata
 								  ~default:false
 								} in

--- a/xl/xenops_server_xenlight.ml
+++ b/xl/xenops_server_xenlight.ml
@@ -2121,7 +2121,7 @@ module VM = struct
 								~platformdata:vm.Xenops_interface.Vm.platformdata
 								~default:false
 							; nested_virt=Platform.is_true
-								~key:"nested_virt"
+								~key:"nested-virt"
 								~platformdata:vm.Xenops_interface.Vm.platformdata
 								~default:false
 							} in


### PR DESCRIPTION
This commit fixes a typo in the "nested-virt" platform key that is
tracked by xenopsd and reported to Xapi.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>