### PR TITLE
CA-223506: setup-pvs-proxy-rules: handle localhost migration

### DIFF
--- a/scripts/setup-pvs-proxy-rules
+++ b/scripts/setup-pvs-proxy-rules
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-if [[ $# -ne 4 ]]
+if [[ $# -ne 5 ]]
 then
-    echo "Usage: $0 <action> <type> <interface> <private_xs_path>" >&2
+    echo "Usage: $0 <action> <type> <interface> <private_xs_path> <hotplug_xs_path>" >&2
     echo "where <action> is [add|remove|reset]"
     echo "where <type> is [vif|tap]"
     echo "where <interface> is the VIF's device name, e.g. vif2.1"
     echo "where <private_xs_path> is the private xenstore path for the VIF"
+    echo "where <hotplug_xs_path> is the xenstore path for the VIF used by the udev script"
     exit 1;
 fi
 
@@ -14,6 +15,7 @@ ACTION=$1
 TYPE=$2
 PVS_VM_INTERFACE=$3
 PRIVATE_PATH=$4
+HOTPLUG_PATH=$5
 
 VSCTL=/usr/bin/ovs-vsctl
 OFCTL=/usr/bin/ovs-ofctl
@@ -167,10 +169,10 @@ case $ACTION in
             unset IFS
         done
         # Announce that on the OVS we have set up the rules for this VIF's pvs-proxy
-        $XSWRITE "${PRIVATE_PATH}/pvs-rules-active" ''
+        $XSWRITE "${HOTPLUG_PATH}/pvs-rules-active" ''
         ;;
     remove)
-        path="${PRIVATE_PATH}/$TYPE-ifindex"
+        path="${HOTPLUG_PATH}/$TYPE-ifindex"
         PVS_IF_ID=$($XSREAD "$path")
         if [ $? -ne 0 ] || [ -z "$PVS_IF_ID" ]; then
             handle_error "The $PVS_VM_INTERFACE's ID[$PVS_IF_ID] not found"
@@ -184,7 +186,7 @@ case $ACTION in
             # vif may still be there.
 
             # Announce that on the OVS we have removed the rules for this VIF's pvs-proxy.
-            $XSRM "${PRIVATE_PATH}/pvs-rules-active"
+            $XSRM "${HOTPLUG_PATH}/pvs-rules-active"
         fi
         ;;
     reset)

--- a/scripts/vif-real
+++ b/scripts/vif-real
@@ -193,7 +193,7 @@ add_to_bridge()
             handle_error "$dev interface not found on the bridge"
         fi
 
-        xenstore-write "${PRIVATE}/$TYPE-ofport" "$ofport"
+        xenstore-write "${HOTPLUG}/${TYPE}-ofport" "$ofport"
         ;;
     esac
 
@@ -202,14 +202,14 @@ add_to_bridge()
         handle_error "$dev ifindex not found"
     fi
 
-    xenstore-write "${PRIVATE}/$TYPE-ifindex" "$ifindex"
+    xenstore-write "${HOTPLUG}/${TYPE}-ifindex" "$ifindex"
 
     # PVS proxy rules are only setup if the pvs-interface xenstore node exists
     xenstore-read ${PRIVATE}/pvs-interface 2>/dev/null
     if [ $? -eq 0 ]; then
         local setup_pvs_proxy_rules=$(xenstore-read "${PRIVATE}/setup-pvs-proxy-rules" 2>/dev/null)
-        $setup_pvs_proxy_rules add "${TYPE}" "${dev}" "$PRIVATE" \
-            || logger -t scripts-vif "Failed to ${setup_pvs_proxy_rules} add ${TYPE} ${dev} ${PRIVATE}"
+        $setup_pvs_proxy_rules add "${TYPE}" "${dev}" "$PRIVATE" "$HOTPLUG" \
+            || logger -t scripts-vif "Failed to ${setup_pvs_proxy_rules} add ${TYPE} ${dev} ${PRIVATE} ${HOTPLUG}"
 	fi
 
     local setup_vif_rules=$(xenstore-read "${PRIVATE}/setup-vif-rules" 2>/dev/null)
@@ -224,8 +224,8 @@ remove_from_bridge()
     xenstore-read ${PRIVATE}/pvs-interface 2>/dev/null
     if [ $? -eq 0 ]; then
         local setup_pvs_proxy_rules=$(xenstore-read "${PRIVATE}/setup-pvs-proxy-rules" 2>/dev/null)
-        /usr/libexec/xenopsd/setup-pvs-proxy-rules remove "${TYPE}" "${dev}" "${PRIVATE}" \
-            || logger -t scripts-vif "Failed to ${setup_pvs_proxy_rules} remove ${TYPE} ${dev} ${PRIVATE}"
+        /usr/libexec/xenopsd/setup-pvs-proxy-rules remove "${TYPE}" "${dev}" "${PRIVATE}" "${HOTPLUG}" \
+            || logger -t scripts-vif "Failed to ${setup_pvs_proxy_rules} remove ${TYPE} ${dev} ${PRIVATE} ${HOTPLUG}"
     fi
 
     local setup_vif_rules=$(xenstore-read "${PRIVATE}/setup-vif-rules" 2>/dev/null)
@@ -240,11 +240,11 @@ remove_from_bridge()
         # port.  Use --if-exists to suppress the error that would otherwise
         # arise in that case.
         $vsctl --timeout=30 -- --if-exists del-port $dev
-        xenstore-rm ${PRIVATE}/"$TYPE"-ofport
+        xenstore-rm "${HOTPLUG}/${TYPE}-ofport"
         ;;
     esac
 
-    xenstore-rm ${PRIVATE}/"$TYPE"-ifindex
+    xenstore-rm "${HOTPLUG}/${TYPE}-ifindex"
 }
 
 call_hook_script() {

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -181,11 +181,6 @@ let get_private_path_by_uuid uuid =
 let get_private_data_path_of_device (x: device) =
 	sprintf "%s/private/%s/%d" (get_private_path x.frontend.domid) (string_of_kind x.backend.kind) x.backend.devid
 
-(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
-  * script indicates whether the OVS rules are set up. *)
-let vif_pvs_rules_active_path_of_device ~xs (x: device) =
-	sprintf "%s/pvs-rules-active" (get_private_data_path_of_device x)
-
 (** Location of the device node's extra xenserver xenstore keys *)
 let extra_xenserver_path_of_device ~xs (x: device) =
 	sprintf "%s/xenserver/device/%s/%d"

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -41,7 +41,6 @@ val frontend_rw_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val frontend_ro_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val disconnect_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val kthread_pid_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
-val vif_pvs_rules_active_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val error_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 val backend_error_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
 

--- a/xc/hotplug.ml
+++ b/xc/hotplug.ml
@@ -66,6 +66,11 @@ let error_path_written_by_hotplug_scripts (x: device) =
 	sprintf "/local/domain/%d/backend/%s/%d/%d/hotplug-error"
 	x.backend.domid (string_of_kind x.backend.kind) x.frontend.domid x.frontend.devid
 
+(** Only useful for a VIF device, this is where the "setup-pvs-proxy-rules"
+  * script indicates whether the OVS rules are set up. *)
+let vif_pvs_rules_active_path_of_device ~xs (x: device) =
+	sprintf "%s/pvs-rules-active" (get_hotplug_path x)
+
 let vif_disconnect_path (x: device) =
 	sprintf "/local/domain/%d/device/vif/%d/disconnect" x.frontend.domid x.frontend.devid
 


### PR DESCRIPTION
Localhost migration failed, because the vif-real and setup-pvs-proxy-rules
scripts use xenstore keys to pass information between each other and xenopsd,
but the keys were in the VM-UUID-based private tree. During a localhost
migration, the sender writes keys that are soon after removed by the receiver.

We solve this by moving the xenstore keys from the private path to the hotplug
path, which is indexed by domid.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>