### PR TITLE
CA-225971: Bring up all netback devices, regardless the locking mode

### DIFF
--- a/scripts/setup-vif-rules
+++ b/scripts/setup-vif-rules
@@ -126,10 +126,7 @@ def handle_bridge(vif_name, domuuid, devid, action):
             locking_mode = config["locking_mode"]
             if locking_mode == "locked":
                 create_bridge_rules(vif_name, config)
-            if locking_mode in ["locked", "unlocked"]:
-                ip_link_set(vif_name, "up")
-        if action == "clear":
-            ip_link_set(vif_name, "up")
+        ip_link_set(vif_name, "up")
 
 ###############################################################################
 # Creation of openflow rules in the case of openvswitch.
@@ -214,10 +211,7 @@ def handle_vswitch(vif_name, domuuid, devid, action):
             locking_mode = config["locking_mode"]
             if locking_mode == "locked":
                 create_vswitch_rules(bridge_name, port, config)
-            if locking_mode in ["locked", "unlocked"]:
-                ip_link_set(vif_name, "up")
-        if action == "clear":
-            ip_link_set(vif_name, "up")
+        ip_link_set(vif_name, "up")
 
 ###############################################################################
 # Executable entry point.


### PR DESCRIPTION
This now includes VIFs that have `locking_mode=disabled`, because leaving the
interface down can cause VMs that are shutting down to hang.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>