### PR TITLE
CA-227101: Increase timeout from 0 to 60 seconds when squeezing domains.

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -363,7 +363,7 @@ module Mem = struct
 	let retry f =
 		let start = Unix.gettimeofday () in
 		let interval = 10. in
-		let timeout = 0. in
+		let timeout = 60. in
 		let rec loop () =
 			try
 				f ()


### PR DESCRIPTION
Add missing fix for CA-92842.

Signed-off-by: Sharad Yadav <sharad.yadav@citrix.com>