### PR TITLE
CA-227626: pvsproxy is not caching data for VM following cross pool migration 

### DIFF
--- a/scripts/setup-pvs-proxy-rules
+++ b/scripts/setup-pvs-proxy-rules
@@ -22,6 +22,7 @@ OFCTL=/usr/bin/ovs-ofctl
 XSREAD=/usr/bin/xenstore-read
 XSWRITE=/usr/bin/xenstore-write
 XSRM=/usr/bin/xenstore-rm
+XSLS=/usr/bin/xenstore-ls
 
 LOG_TAG="setup-pvs-proxy-rules"
 
@@ -52,7 +53,11 @@ if [ $? -ne 0 ] || [ -z "$VIF" ]; then
 fi
 
 # Only continue if the proxy state is "started".
-path="/xapi/pvs-proxy/$PVS_SITE/$VIF/state"
+# According to comments in CA-227626:
+#   The VIF UUID is maintained across the migration.
+#   Furthermore, a proxied VIF can be in only one PVS site at once.
+pvs_prefix="/xapi/pvs-proxy"
+path=$($XSLS -f "$pvs_prefix" | egrep -o "$pvs_prefix/[^/]+/$VIF/state")
 PVS_PROXY_STATE=$($XSREAD "$path")
 if [ "$PVS_PROXY_STATE" != "started" ]; then
     handle_error "PVS proxy daemon not configured for this proxy - not installing OVS rules."

--- a/scripts/setup-pvs-proxy-rules
+++ b/scripts/setup-pvs-proxy-rules
@@ -59,7 +59,7 @@ fi
 pvs_prefix="/xapi/pvs-proxy"
 path=$($XSLS -f "$pvs_prefix" | egrep -o "$pvs_prefix/[^/]+/$VIF/state")
 PVS_PROXY_STATE=$($XSREAD "$path")
-if [ "$PVS_PROXY_STATE" != "started" ]; then
+if [ -z "$path" ] || [ "$PVS_PROXY_STATE" != "started" ]; then
     handle_error "PVS proxy daemon not configured for this proxy - not installing OVS rules."
 fi
 

--- a/scripts/setup-pvs-proxy-rules
+++ b/scripts/setup-pvs-proxy-rules
@@ -40,12 +40,6 @@ handle_xs_error()
 
 logger -t "$LOG_TAG" "Called as $0 $*"
 
-path="${PRIVATE_PATH}/pvs-site"
-PVS_SITE=$($XSREAD "$path")
-if [ $? -ne 0 ] || [ -z "$PVS_SITE" ]; then
-    handle_xs_error "$path"
-fi
-
 path="${PRIVATE_PATH}/vif-uuid"
 VIF=$($XSREAD "$path")
 if [ $? -ne 0 ] || [ -z "$VIF" ]; then


### PR DESCRIPTION
The problem is that we used the wrong PVS site UUID: xenopsd was using the one from the sending pool, while xapi was using the one from the present (destination) pool.

The fix changes `setup-pvs-proxy-rules` to look for any `/xapi/pvs-proxy/*/$VIF/state` (where `$VIF` is the VIF UUID). The VIF UUID is maintained across the migration and that a proxied VIF can be in only one PVS site at once.

This was tested by attempting cross pool migrations of PVS-cached VMs between two pools (I first reproduced the bug with the old script and then observed that it did not happen again with the new version).