### PR TITLE
CA-234037: Fix race in CDROM status checking

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -615,7 +615,7 @@ let media_insert ~xs ~phystype ~params device =
 
 let media_is_ejected ~xs device =
 	let path = (backend_path_of_device ~xs device) ^ "/params" in
-	try xs.Xs.read path = "" with _ -> true
+	try xs.Xs.read path = "" with _ -> raise Device_not_found
 
 end
 


### PR DESCRIPTION
The function `Device.Vbd.media_is_ejected` is meant to return `true` if there is no CDROM present in the given drive, represented by a VBD, and `false` if there is. If the VBD is not plugged, it would also return true. This can cause its caller, `Xenops_server_xen.VBD.get_state`, to return an VBD state as "plugged with an empty drive" rather than "unplugged", if the `get_state` call comes in while the VBD is being unplugged.

This was seen during a VM reboot, where it caused xapi to interpret the VBD state and mark the drive as empty in its database. This meant that the VM had a CDROM in its drive before the reboot, but no longer after the reboot.

This patch makes `media_is_ejected` raise an exception if the VBD is unplugged, such that `get_state` always returns an "unplugged" VBD state.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>