### PR TITLE
CP-20431: MxGPU: pass -mxgpu-fb-size to qemu

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1902,6 +1902,7 @@ module VGPU = struct
 			(fun _ xs frontend_domid _ ->
 				let emulator_pid =
 					match vgpu.implementation with
+					| MxGPU _
 					| GVT_g _ -> Device.Qemu.pid ~xs frontend_domid
 					| Nvidia _ -> Device.Vgpu.pid ~xs frontend_domid
 				in


### PR DESCRIPTION
Not yet passing -mxgpu-sched-level because of the current state of
qemu and the gim kernel module.