### PR TITLE
CA 248130 eliminate one xenstore transaction, reduce another to write ops

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1178,12 +1178,13 @@ let suspend (task: Xenops_task.t) ~xc ~xs ~hvm xenguest_path vm_str domid fd fla
 	(* Suspend image signature *)
 	debug "Writing save signature: %s" save_signature;
 	Io.write fd save_signature;
-	(* Xenops record *)
-	let xs_subtree =
-		Xs.transaction xs (fun t ->
-			xenstore_read_dir t (xs.Xs.getdomainpath domid)
-		)
-	in
+	(* CA-248130: originally, [xs_subtree] contained [xenstore_read_dir t
+	 * (xs.Xs.getdomainpath domid)] and this data was written to [fd].
+	 * However, on the receiving side this data is never used. As a
+	 * short-term fix, we sent nothing but keep the write to maintain the
+	 * protocol.
+	 *)
+	let xs_subtree = [] in
 	let xenops_record = Xenops_record.(to_string (make ~xs_subtree ~vm_str ())) in
 	let xenops_rec_len = String.length xenops_record in
 	let res =

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -90,7 +90,7 @@ let log_exn_rm ~xs x = log_exn_continue ("xenstore-rm " ^ x) xs.Xs.rm x
 
 let set_difference a b = List.filter (fun x -> not(List.mem x b)) a
 
-let assert_file_is_readable filename = 
+let assert_file_is_readable filename =
 	try Unix.access filename [ Unix.F_OK; Unix.R_OK ]
 	with _ ->
 		error "Cannot read file %s" filename;
@@ -178,7 +178,7 @@ let make ~xc ~xs vm_info uuid =
                 [ Xenctrl.CDF_HVM ]
             end else if hap = "true" then begin
                 info "VM = %s; Hardware Assisted Paging (HAP) will be enabled." (Uuid.to_string uuid);
-                [ Xenctrl.CDF_HVM; Xenctrl.CDF_HAP ] 
+                [ Xenctrl.CDF_HVM; Xenctrl.CDF_HAP ]
             end else begin
                 warn "VM = %s; Unrecognized value platform/hap=\"%s\".  Hardware Assisted Paging will be %s." (Uuid.to_string uuid) hap (if List.mem Xenctrl.CDF_HAP default_flags then "enabled" else "disabled");
                 default_flags
@@ -267,7 +267,7 @@ let make ~xc ~xs vm_info uuid =
 
 		xs.Xs.writev dom_path (filtered_xsdata vm_info.xsdata);
 		xs.Xs.writev (dom_path ^ "/platform") vm_info.platformdata;
-	
+
 		xs.Xs.writev (dom_path ^ "/bios-strings") vm_info.bios_strings;
 
 		(* If a toolstack sees a domain which it should own in this state then the
@@ -319,7 +319,7 @@ let shutdown_to_xc_shutdown = function
 	| Unknown _-> raise (Invalid_argument "unknown")
 
 (** Immediately change the domain state to shutdown *)
-let hard_shutdown ~xc domid req = 
+let hard_shutdown ~xc domid req =
 	Xenctrl.domain_shutdown xc domid (shutdown_to_xc_shutdown req)
 
 (** Return the path in xenstore watched by the PV shutdown driver *)
@@ -380,7 +380,7 @@ let destroy (task: Xenops_task.t) ~xc ~xs ~qemu_domid domid =
 	(* These are the devices with a frontend in [domid] and a well-formed backend
 	   in some other domain *)
 	let all_devices = list_frontends ~xs domid in
-	
+
 	debug "VM = %s; domid = %d; Domain.destroy: all known devices = [ %a ]"
 		(Uuid.to_string uuid) domid
 		(fun () -> String.concat "; ")
@@ -423,7 +423,7 @@ let destroy (task: Xenops_task.t) ~xc ~xs ~qemu_domid domid =
 	                 (fun () -> Device.PV_Vnc.stop ~xs domid) ();
 
 	(* Forcibly shutdown every backend *)
-	List.iter 
+	List.iter
 	  (fun device ->
 	     try
 	       Device.hard_shutdown task ~xs device
@@ -482,12 +482,12 @@ let destroy (task: Xenops_task.t) ~xc ~xs ~qemu_domid domid =
 	Cancel_utils.cleanup_for_domain ~xs domid;
 
 	(* Block waiting for the dying domain to disappear: aim is to catch shutdown errors early*)
-	let still_exists () = 
+	let still_exists () =
 	  try
 	    let _ = Xenctrl.domain_getinfo xc domid in
 	    debug "VM = %s; domid = %d; Domain still exist, waiting for it to disappear." (Uuid.to_string uuid) domid;
 	    true
-	  with 
+	  with
 	  | Xenctrl.Error err ->
 		  debug "VM = %s; domid = %d; Domain nolonger exists (%s)" (Uuid.to_string uuid) domid err;
 	      false
@@ -751,7 +751,7 @@ let build_hvm (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~static_
 	if actual_shadow_mib < requested_shadow_mib then begin
 		warn
 			"VM = %s; domid = %d; HVM domain builder reduced our \
-			shadow memory from %d to %d MiB; reverting" 
+			shadow memory from %d to %d MiB; reverting"
 			(Uuid.to_string uuid) domid
 			requested_shadow_mib actual_shadow_mib;
 		Xenctrl.shadow_allocation_set xc domid requested_shadow_mib;
@@ -766,7 +766,7 @@ let build_hvm (task: Xenops_task.t) ~xc ~xs ~store_domid ~console_domid ~static_
 			debug "VM = %s; domid = %d; store_mfn = %s; console_mfn = %s" (Uuid.to_string uuid) domid store_mfn console_mfn;
 			Nativeint.of_string store_mfn, Nativeint.of_string console_mfn
 		| _ ->
-			error "VM = %s; domid = %d; domain builder returned invalid result: \"%s\"" (Uuid.to_string uuid) domid line;			
+			error "VM = %s; domid = %d; domain builder returned invalid result: \"%s\"" (Uuid.to_string uuid) domid line;
 			raise Domain_build_failed in
 
 	let local_stuff = [
@@ -1085,8 +1085,8 @@ let write_libxc_record (task: Xenops_task.t) ~xc ~xs ~hvm xenguest_path domid uu
 						progress_callback (float_of_int percent /. 100.)
 					with e ->
 						error "VM = %s; domid = %d; failed to parse progress update: \"%s\"" (Uuid.to_string uuid) domid percent;
-                        (* MTC: catch exception by progress_callback, for example, 
-                           an abort request, and re-raise them *) 
+                        (* MTC: catch exception by progress_callback, for example,
+                           an abort request, and re-raise them *)
                         raise e
 					)
 				| _ -> ()
@@ -1142,7 +1142,7 @@ let write_qemu_record domid uuid legacy_libxc fd =
 		if Unixext.copy_file ~limit:size fd2 fd <> size
 		then failwith "Failed to write whole qemu-dm state file";
 		return ()
-	) (fun () -> 
+	) (fun () ->
 		Unix.unlink file;
 		Unix.close fd2
 	)

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -178,9 +178,9 @@ let di_of_uuid ~xc ~xs domain_selection uuid =
 	let possible = List.filter (fun x -> uuid_of_di x = uuid) all in
 	let oldest_first = List.sort
 		(fun a b ->
-			let create_time x = 
-			  try 
-			    xs.Xs.read (Printf.sprintf "/vm/%s/domains/%d/create-time" uuid' x.domid) |> Int64.of_string 
+			let create_time x =
+			  try
+			    xs.Xs.read (Printf.sprintf "/vm/%s/domains/%d/create-time" uuid' x.domid) |> Int64.of_string
 			  with e ->
                             warn "Caught exception trying to find creation time of domid %d (uuid %s)" x.domid uuid';
                             warn "Defaulting to 'now'";
@@ -266,7 +266,7 @@ let destroy_vbd_frontend ~xc ~xs task disk =
 					Device.Vbd.clean_shutdown_async ~xs device;
 					Device.Vbd.clean_shutdown_wait task ~xs ~ignore_transients:true device
 				)
-		
+
 
 module Storage = struct
 	open Storage
@@ -437,7 +437,7 @@ module Mem = struct
 	let transfer_reservation_to_domain dbg domid r =
 		let (_: unit option) = wrap (fun () -> transfer_reservation_to_domain_exn dbg domid r) in
 		()
-        
+
         let query_reservation_of_domain dbg domid =
                 match get_session_id dbg with
                         | Some session_id ->
@@ -616,16 +616,16 @@ module HOST = struct
 				let p = physinfo xc in
 				let cpu_count = p.nr_cpus in
 				let socket_count = p.nr_cpus / (p.threads_per_core * p.cores_per_socket) in
-				
+
 				let features = get_featureset xc Featureset_host in
 				let features_pv = get_featureset xc Featureset_pv in
 				let features_hvm = get_featureset xc Featureset_hvm in
 				let features_oldstyle = oldstyle_featuremask xc in
-				
+
 				let v = version xc in
 				let xen_version_string = Printf.sprintf "%d.%d%s" v.major v.minor v.extra in
 				let xen_capabilities = version_capabilities xc in
-				
+
 				{
 					Host.cpu_info = {
 						Host.cpu_count;
@@ -648,7 +648,7 @@ module HOST = struct
 					}
 				}
 			)
-			
+
 	let get_console_data () =
 		with_xc_and_xs
 			(fun xc xs ->
@@ -802,7 +802,7 @@ module VM = struct
 		let hvm = match vm.ty with HVM _ -> true | _ -> false in
 		(* XXX add per-vcpu information to the platform data *)
 		(* VCPU configuration *)
-		let pcpus = Xenctrlext.get_max_nr_cpus xc in							
+		let pcpus = Xenctrlext.get_max_nr_cpus xc in
 		let all_pcpus = mkints pcpus in
 		let all_vcpus = mkints vm.vcpu_max in
 		let masks = match vm.scheduler_params.affinity with
@@ -814,7 +814,7 @@ module VM = struct
 				let defaults = List.map (fun _ -> m) all_vcpus in
 				take vm.vcpu_max (m :: ms @ defaults) in
 		(* convert a mask into a binary string, one char per pCPU *)
-		let bitmap cpus: string = 
+		let bitmap cpus: string =
 			let cpus = List.filter (fun x -> x >= 0 && x < pcpus) cpus in
 			let result = String.make pcpus '0' in
 			List.iter (fun cpu -> result.[cpu] <- '1') cpus;
@@ -1038,8 +1038,8 @@ module VM = struct
 		end;
 		Domain.destroy task ~xc ~xs ~qemu_domid domid;
 		(* Detach any remaining disks *)
-		List.iter (fun dp -> 
-			try 
+		List.iter (fun dp ->
+			try
 				Storage.dp_destroy task dp
 			with e ->
 		        warn "Ignoring exception in VM.destroy: %s" (Printexc.to_string e)) dps
@@ -1129,7 +1129,7 @@ module VM = struct
 		},{
 			VmExtra.qemu_vbds = qemu_vbds
 		} ->
-			let make ?(boot_order="cd") ?(serial="pty") ?(monitor="null") 
+			let make ?(boot_order="cd") ?(serial="pty") ?(monitor="null")
 					?(nics=[]) ?(disks=[]) ?(vgpus=[])
 					?(pci_emulations=[]) ?(usb=Device.Dm.Disabled)
 					?(parallel=None)
@@ -1258,9 +1258,9 @@ module VM = struct
 					| PV { boot = Indirect ( { devices = d :: _ } as i ) } ->
 						with_disk ~xc ~xs task d false
 							(fun dev ->
-								let b = Bootloader.extract task ~bootloader:i.bootloader 
+								let b = Bootloader.extract task ~bootloader:i.bootloader
 									~legacy_args:i.legacy_args ~extra_args:i.extra_args
-									~pv_bootloader_args:i.bootloader_args 
+									~pv_bootloader_args:i.bootloader_args
 									~disk:dev ~vm:vm.Vm.id () in
 								kernel_to_cleanup := Some b;
 								let builder_spec_info = Domain.BuildPV {
@@ -1613,7 +1613,7 @@ module VM = struct
 						let memory_target = try xs.Xs.read (local "memory/target") |> Int64.of_string |> Int64.mul 1024L with Xs_protocol.Enoent _ -> 0L in
 						let memory_actual =
 							let pages = Int64.of_nativeint di.Xenctrl.total_memory_pages in
-							let kib = Xenctrl.pages_to_kib pages in 
+							let kib = Xenctrl.pages_to_kib pages in
 							Memory.bytes_of_kib kib in
 
 						let memory_limit =
@@ -1648,9 +1648,9 @@ module VM = struct
 							    (* CA-104562: Work around probable bug in bindings *)
 							    if result > 1000.0 then begin
 							      warn "CA-104562: Got value '%d' from shadow_allocation_get" actual_shadow_mib_int;
-							      -1.0 
+							      -1.0
 							    end else result
-							  with e -> 
+							  with e ->
 							    warn "Caught exception in getting shadow allocation: %s" (Printexc.to_string e);
 							    -1.0
 							end
@@ -1973,7 +1973,7 @@ module VBD = struct
 		| VDI path ->
 			let sr, vdi = Storage.get_disk_by_name task path in
 			Storage.epoch_end task sr vdi
-		| _ -> ()		
+		| _ -> ()
 
 	let _backend_kind = "backend-kind"
 
@@ -2018,7 +2018,7 @@ module VBD = struct
 					let dp_id = _dp_id, Storage.id_of (string_of_int frontend_domid) vbd.Vbd.id in
 					let x = {
 						Device.Vbd.mode = (match vbd.mode with
-							| ReadOnly -> Device.Vbd.ReadOnly 
+							| ReadOnly -> Device.Vbd.ReadOnly
 							| ReadWrite -> Device.Vbd.ReadWrite
 						);
 						device_number = vbd.position;
@@ -2053,7 +2053,7 @@ module VBD = struct
 						| Device_number.Ide, n, _ when n < 4 ->
 							begin match vbd.Vbd.backend with
 								| None -> None
-								| Some _ -> 
+								| Some _ ->
 									let bd = create_vbd_frontend ~xc ~xs task qemu_domid vdi in
 									let index = Device_number.to_disk_number device_number in
 									Some (index, bd)
@@ -2061,7 +2061,7 @@ module VBD = struct
 						| _, _, _ -> None in
 					(* Remember what we've just done *)
 					Mutex.execute dB_m (fun () ->
-					(* Dom0 doesn't have a vm_t - we don't need this currently, but when we have storage driver domains, 
+					(* Dom0 doesn't have a vm_t - we don't need this currently, but when we have storage driver domains,
 					   we will. Also this causes the SMRT tests to fail, as they demand the loopback VBDs *)
 					let vm_t = DB.read_exn vm in
 					Opt.iter (fun q ->
@@ -2122,7 +2122,7 @@ module VBD = struct
 							(* If we have a qemu frontend, detach this too. *)
 							Mutex.execute dB_m (fun () ->
 							let vm_t = DB.read vm in
-							Opt.iter (fun vm_t -> 
+							Opt.iter (fun vm_t ->
 								let non_persistent = vm_t.VmExtra.non_persistent in
 								if List.mem_assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds then begin
 									let _, qemu_vbd = List.assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds in
@@ -2141,7 +2141,7 @@ module VBD = struct
 								-> Storage.dp_destroy task (Storage.id_of (string_of_int x) vbd.Vbd.id)
 							| _ -> ()
 						)
-				with 
+				with
 					| Device_common.Device_error(_, s) ->
 						debug "Caught Device_error: %s" s;
 						raise (Device_detach_rejected("VBD", id_of vbd, s))
@@ -2442,7 +2442,7 @@ module VIF = struct
 							(fun () -> Device.Vif.release task ~xc ~xs device) in
 					destroy device;
 
-					Opt.iter (fun vm_t -> 
+					Opt.iter (fun vm_t ->
 						(* If we have a qemu frontend, detach this too. *)
 						if List.mem_assoc vif.Vif.id vm_t.VmExtra.non_persistent.VmExtra.qemu_vifs then begin
 							match (List.assoc vif.Vif.id vm_t.VmExtra.non_persistent.VmExtra.qemu_vifs) with
@@ -2537,7 +2537,7 @@ module VIF = struct
 				if di.Xenctrl.hvm_guest
 				then ignore (run !Xc_resources.setup_vif_rules ["classic"; tap_interface_name; vm; devid; "filter"])
 			)
-	
+
 	let set_ip_unspecified xs xenstore_path suffix =
 		Xs.transaction xs (fun t ->
 			let ip_setting_enabled = Printf.sprintf "%s/%s%s" xenstore_path "enabled" suffix in
@@ -2549,7 +2549,7 @@ module VIF = struct
 			let ip_setting_gateway = Printf.sprintf "%s/%s%s" xenstore_path "gateway" suffix in
 			t.Xst.rm ip_setting_gateway
 		)
-	
+
 	let set_ip_static xs xenstore_path suffix address gateway =
 		Xs.transaction xs (fun t ->
 			let ip_setting_enabled = Printf.sprintf "%s/%s%s" xenstore_path "enabled" suffix in
@@ -2566,7 +2566,7 @@ module VIF = struct
 				debug "xenstore-write %s <- %s" ip_setting_gateway value;
 				t.Xst.write ip_setting_gateway value
 		)
-			
+
 	let set_ipv4_configuration task vm vif ipv4_configuration =
 		let open Device_common in
 		with_xc_and_xs


### PR DESCRIPTION
   d00a6df7 2017-03-22 CA-248130 run_script: limit transaction to .. ..ian Lindig
    7ca10361 2017-03-22 CA-248130 remove trailing spaces              ..ian Lindig
    9529705e 2017-03-22 CA-248130 Domain.suspend: eliminate subtree.. ..ian Lindig
    55fac751 2017-03-22 CA-248130 remove trailing spaces in the sou.. ..ian Lindig

(A) Originally, Xenops_server_xen.VM.run_script bundles in one transaction:

(1) read state from XenStore
(2) do nothing, raise exception, or remove path in XenStore
(3) write two paths in XenStore

This commit limits the transaction to writing the two paths in XenStore
in (3) but takes (1) and (2) out of it. This is safe:

The state read in (1) is acted upon but the writes in (3) have no data
or control dependency on the state being written.

The path being removed in (2) is expected not to exist in the first
place. Now, if the state indicates it does exist and (2) is reached to
remove it, the only thing that could happen in between is that it
is already removed. No harm is done when trying to remove it again. In
fact, it would be safe to remove the path unconditionally.

The two writes in (3) need to be kept together to ensure the update is
consistent.

(B) Function Domain.suspend originally reads a domain's subtree in a
transactions from XenStore and writes it to fd. However, this data is
never used by the receiver. This commit eliminates the read and the
transaction, and writes an empty subtree to maintain the protocol.

(C) Remove trailing white space.

Signed-off-by: Christian Lindig christian.lindig@citrix.com