### PR TITLE
Remove coverage from default build tags

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,9 +1,3 @@
-# START_COVERAGE
-# coverage analysis with bisect_ppx
-# compile and link with package bisect_ppx
-<**/*.ml{,i,y}>: pkg_bisect_ppx
-<**/*.native>:   pkg_bisect_ppx
-# END_COVERAGE
 # OASIS_START
 # DO NOT EDIT (digest: c653a60545f17cb6cbe118337e0e86e4)
 # Ignore VCS directories, you can use the same kind of rule outside


### PR DESCRIPTION
This slipped by mistake in the latest cleanup PR

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>