### PR TITLE
CA-223802 Determine network ID by vif ID rather than NIC name

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1634,7 +1634,10 @@ module VM = struct
 							let subdirs = try xs.Xs.directory (root ^ "/" ^ dir) |> List.filter (fun x -> x <> "") |> List.map (fun x -> dir ^ "/" ^ x) with _ -> [] in
 							this @ (List.concat (List.map (ls_lR root) subdirs)) in
 						let guest_agent =
-							[ "drivers"; "attr"; "data"; "control"; "feature" ] |> List.map (ls_lR (Printf.sprintf "/local/domain/%d" di.Xenctrl.domid)) |> List.concat |> List.map (fun (k,v) -> (k,Xenops_utils.utf8_recode v)) in
+							[ "drivers"; "attr"; "data"; "control"; "feature"; "device" ] 
+							|> List.map (ls_lR (Printf.sprintf "/local/domain/%d" di.Xenctrl.domid))
+							|> List.concat
+							|> List.map (fun (k,v) -> (k,Xenops_utils.utf8_recode v)) in
 						let xsdata_state =
 							Domain.allowed_xsdata_prefixes |> List.map (ls_lR (Printf.sprintf "/local/domain/%d" di.Xenctrl.domid)) |> List.concat in
 						let shadow_multiplier_target =


### PR DESCRIPTION
This change should be merged with another change xapi-project/xen-api together.
https://github.com/xapi-project/xen-api/pull/3017

In xenopsd, "device" is added into guest_agent, so that in the change on xapi-project/xen-api, xapi could get the xenstore info under "/local/domain/11/device".
Especially, info under "/local/domain/11/device/vif" is used to get the corresponding vif ID for the mac addresses which is read from "/local/domain/11/eth0/mac/".