### PR TITLE
Update .travis.yml: Build against Ely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ script: bash travis-build-repo.sh
 sudo: true
 env:
     global:
+        - GIT_BRANCH=ely-bugfix
         - REPO_PACKAGE_NAME=xenopsd
         - REPO_CONFIGURE_CMD=./configure
         - REPO_BUILD_CMD=make


### PR DESCRIPTION
This will get the new xenopsd Ely lcm branch (0.17-lcm) working with Travis by using the RPMs from Ely instead of master.