### PR TITLE
CP-17693: take action when qemu crashes or exits unexpectedly

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -36,6 +36,7 @@ let watch_queue_length = ref 1000
 
 let default_vbd_backend_kind = ref "vbd"
 let ca_140252_workaround = ref false
+let action_after_qemu_crash = ref None
 
 let options = [
     "queue", Arg.Set_string Xenops_interface.queue_name, (fun () -> !Xenops_interface.queue_name), "Listen on a specific queue";
@@ -52,6 +53,7 @@ let options = [
     "use-upstream-qemu", Arg.Bool (fun x -> use_upstream_qemu := x), (fun () -> string_of_bool !use_upstream_qemu), "True if we want to use upsteam QEMU";
     "default-vbd-backend-kind", Arg.Set_string default_vbd_backend_kind, (fun () -> !default_vbd_backend_kind), "Default backend for VBDs";
     "ca-140252-workaround", Arg.Bool (fun x -> ca_140252_workaround := x), (fun () -> string_of_bool !ca_140252_workaround), "Workaround for evtchn misalignment for legacy PV tools";
+    "action-after-qemu-crash", Arg.String (fun x -> action_after_qemu_crash := if x="" then None else Some x), (fun () -> match !action_after_qemu_crash with None->"" | Some x->x), "Action to take for VMs if QEMU crashes or dies unexpectedly: pause, poweroff. Otherwise, no action (default).";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -115,6 +115,15 @@ end
 
 module Qemu :
 sig
+	module SignalMask: sig
+		type t
+		val create: unit -> t
+		val set: t -> int -> unit
+		val unset: t -> int -> unit
+		val has: t -> int -> bool
+	end
+	val signal_mask : SignalMask.t
+	val pid_path_signal : Xenctrl.domid -> string
 	val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 	val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
 end

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1048,6 +1048,7 @@ module VM = struct
 		(fun ()->
 			(* Finally, discard any device caching for the domid destroyed *)
 			DeviceCache.discard device_cache di.Xenctrl.domid;
+			Device.(Qemu.SignalMask.unset Qemu.signal_mask di.Xenctrl.domid);
 		)
 	) Oldest
 
@@ -2742,6 +2743,7 @@ module Actions = struct
 			sprintf "/local/domain/%d/memory/uncooperative" domid;
 			sprintf "/local/domain/%d/console/vnc-port" domid;
 			sprintf "/local/domain/%d/console/tc-port" domid;
+			Device.Qemu.pid_path_signal domid;
 			sprintf "/local/domain/%d/control" domid;
 			sprintf "/local/domain/%d/device" domid;
 			sprintf "/local/domain/%d/rrd" domid;
@@ -2792,6 +2794,21 @@ module Actions = struct
 		Cancel_utils.on_shutdown ~xs domid;
 		(* Finally, discard any device caching for the domid destroyed *)
 		DeviceCache.discard device_cache domid
+
+	let qemu_disappeared di xc xs =
+		match !Xenopsd.action_after_qemu_crash with
+		| None -> ()
+		| Some action -> begin
+			debug "action-after-qemu-crash=%s" action;
+			match action with
+			| "poweroff" ->
+				(* we do not expect a HVM guest to survive qemu disappearing, so kill the VM *)
+				Domain.set_action_request ~xs di.Xenctrl.domid (Some "poweroff")
+			| "pause" ->
+				(* useful for debugging qemu *)
+				Domain.pause ~xc di.Xenctrl.domid
+			| _ -> ()
+			end
 
 	let add_device_watch xs device =
 		let open Device_common in
@@ -2854,6 +2871,24 @@ module Actions = struct
 						debug "Unknown device kind: '%s'" x;
 						None in
 				Opt.iter (fun x -> Updates.add x internal_updates) update in
+
+		let fire_event_on_qemu domid =
+			let d = int_of_string domid in
+			let open Xenstore_watch in
+			if not(IntMap.mem d domains)
+			then debug "Ignoring qemu-pid-signal watch on shutdown domain %d" d
+			else begin
+				let signal = try Some (xs.Xs.read (Device.Qemu.pid_path_signal d)) with _ -> None in
+				match signal with
+				| None -> ()
+				| Some signal ->
+					debug "Received unexpected qemu-pid-signal %s for domid %d" signal d;
+					let di = IntMap.find d domains in
+					let id = Uuidm.to_string (uuid_of_di di) in
+					qemu_disappeared di xc xs;
+					Updates.add (Dynamic.Vm id) internal_updates
+			end
+		in
 
 		let register_rrd_plugin ~domid ~name ~grant_refs ~protocol =
 			debug
@@ -2928,6 +2963,8 @@ module Actions = struct
 							"Failed to deregister RRD plugin: caught %s"
 							(Printexc.to_string e)
 				end
+			| "local" :: "domain" :: domid :: "qemu-pid-signal" :: [] ->
+				fire_event_on_qemu domid
 			| "local" :: "domain" :: domid :: _ ->
 				fire_event_on_vm domid
 			| "vm" :: uuid :: "rtc" :: "timeoffset" :: [] ->


### PR DESCRIPTION
    The HVM guest is very likely to hang or crash when qemu crashes, but the VM                                                                                           
    will usually stay running until a force shutdown is applied. This patch uses                                                                                           
    the forkexecd waitpid facility in an asynchronous way to signal to xenopsd                                                                                           
    that qemu crashed or ended unexpectedly after the VM started. A signal masking                                                                                           
    system disables the signal if an expected domain destroy event is detected, to                                                                                           
    prevent spurious asynchronous signals propagating during or after a normal                                                                                           
    shutdown.                                                                                           
                                                                                           
    Depending on the value of a new xenopsd.conf option action-after-qemu-crash,                                                                                           
    xenopsd will take one of the following actions after receiving this signal:                                                                                           
    - poweroff: xenopsd will power off the VM                                                                                           
    - pause: xenopsd will pause the VM                                                                                           
    - otherwise, xenopsd reverts to its previous behaviour of not waiting for any                                                                                           
    qemu signal and not taking any action automatically.      

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>