### PR TITLE
fix opam: setup.ml is now a generated file

### DIFF
--- a/opam
+++ b/opam
@@ -3,17 +3,15 @@ maintainer: "xen-api@lists.xen.org"
 authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xenopsd"
 build: [
-	["oasis" "setup"]
 	["./configure"]
-  ["ocaml" "setup.ml" "-configure" "--disable-libvirt"]
 	[make]
 ]
 install: [
- 	["ocaml" "setup.ml" "-install"]
+ 	["./setup.bin" "-install"]
 ]
 remove: [
-        ["oasis" "setup"]
-        ["ocaml" "setup.ml" "-uninstall"]
+        ["make" "setup.data"]
+        ["./setup.bin" "-uninstall"]
         ["ocamlfind" "remove" "xenopsd"]
 ]
 depends: [


### PR DESCRIPTION
Forgot to update `opam` file in my coverage PR, sorry about the breakage.

This fixes the build/install part of an `opam` install.
 `opam remove` complains, but that seems to have been a problem previously as well:
```
# E: Failure("Unable to load environment, the file '/local/home/edwin/.opam/system/build/xenopsd.~unknown/setup.data' doesn't exist.")
```

I dropped the `--disable-libvirt` flag because it is not supported anymore and configure was rejecting it.
