### PR TITLE
CP23043: Send xen-set-global-dirty-log from xenopsd

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1051,7 +1051,7 @@ let restore (task: Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid 
 
 type suspend_flag = Live | Debug
 
-let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
+let write_libxc_record' (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
 	let fd_uuid = Uuid.(to_string (create `V4)) in
 
 	let cmdline_to_flag flag =
@@ -1113,7 +1113,7 @@ let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_pat
 			debug "VM = %s; domid = %d; suspending qemu-dm" (Uuid.to_string uuid) domid;
 			Device.Dm.suspend task ~xs ~qemu_domid domid;
 		);
- 		XenguestHelper.send cnx "done\n";
+		XenguestHelper.send cnx "done\n";
 
 		let msg = XenguestHelper.non_debug_receive cnx in
 		progress_callback 1.;
@@ -1126,6 +1126,17 @@ let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_pat
 		| _                       ->
 			error "VM = %s; domid = %d; xenguesthelper protocol failure" (Uuid.to_string uuid) domid;
 	)
+
+let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
+	finally
+		(fun() ->
+			if is_upstream_qemu domid
+			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log true));
+			write_libxc_record' task ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback)
+		(fun() ->
+			if is_upstream_qemu domid
+			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log false));
+		)
 
 let write_qemu_record domid uuid legacy_libxc fd =
 	let file = sprintf qemu_save_path domid in


### PR DESCRIPTION
This is a temporary change, create and send xen-set-global-dirty-log
from xenopsd and once emu-manager can send the message, remove this code.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>