### PR TITLE
CA-259579: Introduce ballooning timeout before migration

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1500,6 +1500,10 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : unit
 			let atomic = VM_set_memory_dynamic_range(id, vm.Vm.memory_dynamic_min, vm.Vm.memory_dynamic_min) in
 			let (_: unit) = perform_atomic ~subtask:(string_of_atomic atomic) ~progress_callback:(fun _ -> ()) atomic t in
 
+			(* Waiting here is not essential but adds a degree of safety
+			 * and reducess unnecessary memory copying. *)
+			(try B.VM.wait_ballooning t vm with Internal_error _ -> ());
+
 			(* Find out the VM's current memory_limit: this will be used to allocate memory on the receiver *)
 			let state = B.VM.get_state vm in
 			info "VM %s has memory_limit = %Ld" id state.Vm.memory_limit;

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -790,14 +790,6 @@ let pci_plug_order pcis =
 let vgpu_plug_order vgpus =
 	List.sort (fun a b -> compare a.Vgpu.position b.Vgpu.position) vgpus
 
-let uses_mxgpu id =
-	List.exists (fun vgpu_id ->
-		let vgpu = VGPU_DB.read_exn vgpu_id in
-		match vgpu.Vgpu.implementation with
-		| Vgpu.MxGPU _ -> true
-		| _ -> false
-	) (VGPU_DB.ids id)
-
 let simplify f =
 	let module B = (val get_backend () : S) in
 	if B.simplified then [] else f
@@ -1336,46 +1328,15 @@ let rec immediate_operation dbg id op =
 			Xenops_task.run task
 		) ();
 	match Xenops_task.get_state task with
-	| Task.Pending _ -> assert false
-	| Task.Completed _ -> ()
-	| Task.Failed e ->
-		let e = e |> Exception.exnty_of_rpc |> exn_of_exnty in
-		raise e
-
-and queue_operation_int dbg id op =
-	let task = Xenops_task.add tasks dbg (let r = ref None in fun t -> perform ~result:r op t; !r) in
-	let tag = if uses_mxgpu id then "mxgpu" else id in
-	Redirector.push Redirector.default tag (op, task);
-	task
-
-and queue_operation dbg id op =
-	debug "queue_operation: %s" dbg;
-	let task = queue_operation_int dbg id op in
-	Xenops_task.id_of_handle task
-
-and queue_operation_and_wait dbg id op =
-	debug "queue_operation_and_wait: %s" dbg;
-	let from = Updates.last_id dbg updates in
-	let task = queue_operation_int dbg id op in
-	let task_id = Xenops_task.id_of_handle task in
-	event_wait updates task ~from 1200.0 (task_finished_p task_id) |> ignore;
-	task
-
-(* CA-254911: delay the cleanups checks and move them to a different
- * thread to try and mitigate the risk of stack overflow due to 
- * exceptional issues *)
-and deferred_operation dbg id op =
-	let task = queue_operation_and_wait dbg id op in
-	match Xenops_task.get_state task with
-	| Task.Pending _ -> assert false
-	| Task.Completed _ -> ()
-	| Task.Failed e ->
-		let e = e |> Exception.exnty_of_rpc |> exn_of_exnty in
-		raise e
+		| Task.Pending _ -> assert false
+		| Task.Completed _ -> ()
+		| Task.Failed e ->
+			let e = e |> Exception.exnty_of_rpc |> exn_of_exnty in
+			raise e
 
 (* At all times we ensure that an operation which partially fails
- * leaves the system in a recoverable state. All that should be
- * necessary is to call the {VM,VBD,VIF,PCI}_check_state function. *)
+   leaves the system in a recoverable state. All that should be
+   necessary is to call the {VM,VBD,VIF,PCI}_check_state function. *)
 and trigger_cleanup_after_failure op t =
 	let dbg = (Xenops_task.to_interface_task t).Task.dbg in
 	match op with
@@ -1393,18 +1354,18 @@ and trigger_cleanup_after_failure op t =
 	| VM_restore_devices (id, _)
 	| VM_resume (id, _)
 	| VM_receive_memory (id, _, _) ->
-		deferred_operation dbg id (VM_check_state id);
+		immediate_operation dbg id (VM_check_state id);
 	| VM_migrate (id, _, _, _) ->
-		deferred_operation dbg id (VM_check_state id);
-		deferred_operation dbg id (VM_check_state id);
+		immediate_operation dbg id (VM_check_state id);
+		immediate_operation dbg id (VM_check_state id);
 
 	| VBD_hotplug id
 	| VBD_hotunplug (id, _) ->
-		deferred_operation dbg (fst id) (VBD_check_state id)
+		immediate_operation dbg (fst id) (VBD_check_state id)
 
 	| VIF_hotplug id
 	| VIF_hotunplug (id, _) ->
-		deferred_operation dbg (fst id) (VIF_check_state id)
+		immediate_operation dbg (fst id) (VIF_check_state id)
 
 	| Atomic op -> trigger_cleanup_after_failure_atom op t
 
@@ -1736,6 +1697,31 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : unit
 	match subtask with
 		| None -> one op
 		| Some name -> Xenops_task.with_subtask t name (fun () -> one op)
+
+let uses_mxgpu id =
+	List.exists (fun vgpu_id ->
+		let vgpu = VGPU_DB.read_exn vgpu_id in
+		match vgpu.Vgpu.implementation with
+		| Vgpu.MxGPU _ -> true
+		| _ -> false
+	) (VGPU_DB.ids id)
+
+let queue_operation_int dbg id op =
+	let task = Xenops_task.add tasks dbg (let r = ref None in fun t -> perform ~result:r op t; !r) in
+	let tag = if uses_mxgpu id then "mxgpu" else id in
+	Redirector.push Redirector.default tag (op, task);
+	task
+
+let queue_operation dbg id op =
+	let task = queue_operation_int dbg id op in
+	Xenops_task.id_of_handle task
+
+let queue_operation_and_wait dbg id op =
+	let from = Updates.last_id dbg updates in
+	let task = queue_operation_int dbg id op in
+	let task_id = Xenops_task.id_of_handle task in
+	event_wait updates task ~from 1200.0 (task_finished_p task_id) |> ignore;
+	task
 
 module PCI = struct
 	open Pci

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1502,7 +1502,7 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : unit
 
 			(* Waiting here is not essential but adds a degree of safety
 			 * and reducess unnecessary memory copying. *)
-			(try B.VM.wait_ballooning t vm with Internal_error _ -> ());
+			(try B.VM.wait_ballooning t vm with Ballooning_timeout_before_migration -> ());
 
 			(* Find out the VM's current memory_limit: this will be used to allocate memory on the receiver *)
 			let state = B.VM.get_state vm in

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -97,6 +97,8 @@ module type S = sig
 		val get_internal_state: (string * string) list -> (string * Network.t) list -> Vm.t -> string
 		val set_internal_state: Vm.t -> string -> unit
 
+		val wait_ballooning: Xenops_task.task_handle -> Vm.t -> unit
+
 		val minimum_reboot_delay: float
 	end
 	module PCI : sig

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -393,6 +393,8 @@ module VM = struct
 	let set_internal_state vm s =
 		DB.write vm.Vm.id (s |> Jsonrpc.of_string |> Domain.t_of_rpc)
 
+	let wait_ballooning _ _ = ()
+
 	let minimum_reboot_delay = 0.
 end
 

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -77,6 +77,7 @@ module VM = struct
 	let generate_state_string _ = ""
 	let get_internal_state _ _ _ = ""
 	let set_internal_state _ _ = ()
+	let wait_ballooning _ _ = ()
 	let minimum_reboot_delay = 0.
 end
 module PCI = struct

--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -37,6 +37,8 @@ let watch_queue_length = ref 1000
 let default_vbd_backend_kind = ref "vbd"
 let ca_140252_workaround = ref false
 
+let additional_ballooning_timeout = ref 120.
+
 let options = [
     "queue", Arg.Set_string Xenops_interface.queue_name, (fun () -> !Xenops_interface.queue_name), "Listen on a specific queue";
     "sockets-path", Arg.Set_string sockets_path, (fun () -> !sockets_path), "Directory to create listening sockets";
@@ -52,6 +54,7 @@ let options = [
     "use-upstream-qemu", Arg.Bool (fun x -> use_upstream_qemu := x), (fun () -> string_of_bool !use_upstream_qemu), "True if we want to use upsteam QEMU";
     "default-vbd-backend-kind", Arg.Set_string default_vbd_backend_kind, (fun () -> !default_vbd_backend_kind), "Default backend for VBDs";
     "ca-140252-workaround", Arg.Bool (fun x -> ca_140252_workaround := x), (fun () -> string_of_bool !ca_140252_workaround), "Workaround for evtchn misalignment for legacy PV tools";
+    "additional-ballooning-timeout", Arg.Set_float additional_ballooning_timeout, (fun () -> string_of_float !additional_ballooning_timeout), "Time we allow the guests to do additional memory ballooning before live migration";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1490,10 +1490,7 @@ module VM = struct
 						cancellable_watch (Domain domid) watches [] task ~xs ~timeout:!Xenopsd.additional_ballooning_timeout ()
 						|> ignore
 					with Watch.Timeout _ ->
-						let msg = Printf.sprintf 
-							"Ballooning Timeout: unable to balloon down the memory of vm %s, please increase the value of memory-dynamic-min"
-							vm.Vm.id
-						in raise (Xenops_interface.Internal_error msg)
+						raise Xenops_interface.Ballooning_timeout_before_migration
 			) Oldest task vm
 
 	let save task progress_callback vm flags data =

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -13,7 +13,6 @@
  *)
 
 open Xenops_interface
-open Memory_interface
 open Xenops_utils
 open Xenops_server_plugin
 open Xenops_helpers
@@ -1225,7 +1224,7 @@ module VM = struct
 			let dbg = Xenops_task.get_dbg task in
 			let reservation_id = Mem.query_reservation_of_domain dbg domid in
 			Mem.delete_reservation dbg (reservation_id, None)
-                with MemoryError No_reservation ->
+                with Memory_interface.MemoryError Memory_interface.No_reservation ->
                         error "Please check if memory reservation for domain %d is present, if so manually remove it" domid
 
 	let build_domain_exn xc xs domid task vm vbds vifs vgpus extras force =
@@ -1494,7 +1493,7 @@ module VM = struct
 						let msg = Printf.sprintf 
 							"Ballooning Timeout: unable to balloon down the memory of vm %s, please increase the value of memory-dynamic-min"
 							vm.Vm.id
-						in raise (Internal_error msg)
+						in raise (Xenops_interface.Internal_error msg)
 			) Oldest task vm
 
 	let save task progress_callback vm flags data =

--- a/xenopsd.conf
+++ b/xenopsd.conf
@@ -98,3 +98,12 @@ disable-logging-for=http
 
 # Workaround for ca-140252: evtchn misalignment workaround for legacy PV tools
 # ca-140252-workaround=false
+
+# Xenopsd does not have a way to pause a ballooning process that is being too
+# slow or has reached a "good enough" memory level.
+# The following tiemout indicates the time that we allow the guests drivers to
+# do additional memory ballooning before live migration if we detect that
+# the ballooning is still in progress or has suddenly restarted.
+# Reaching the timeout will cancel the migration but leave the VM in a usable
+# running state.
+# additional-ballooning-timeout=120.0


### PR DESCRIPTION
This PR goes with:
- https://github.com/xapi-project/xcp-idl/pull/167
- https://github.com/xapi-project/xen-api/pull/3138

Before migration we balloon the memory down to dynamic_memory_min. On windows the driver can sometimes persist ballooning when xenopsd believes it has completed its job (also it can restart ballooning when additional memory gets freed). The ballooning driver ignores suspend requests and this can make the migration timeout leaving the vms in a bad state.

This mitigates the issue by monitoring the ballooning key in xenstore and issuing the suspend request only after it is done. It also adds a configurable timeout to cancel the migration if the additional ballooning is taking too long, raising an error that provides a meaningful suggestion in xapi (Increase the memory dynamic min value to reduce ballooning).

This PR also fixes CA-260226 and a deadlock situation that has not yet appeared in system tests but I could replicate with manual testing (both fixed by the revert a2a8618bb5a8c5799f868f4e7b7d78d8e8f6aa99)