### PR TITLE
CA-260220: Put vnc port into xenstore after querying

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1457,21 +1457,22 @@ type info = {
 
 
 let get_vnc_port ~xs domid =
-	if not (Qemu.is_running ~xs domid)
-	then None
-	else begin
-		if is_upstream_qemu domid then begin
-			let open Qmp in
-			let qmp_cmd = Command (None, Query_vnc) in
-			let qmp_cmd_result = qmp_write_and_read domid  qmp_cmd in
-			match qmp_cmd_result with
-			| Some qmp_message -> (match qmp_message with
-				| Success (None, Vnc vnc) -> (try Some vnc.service with _ -> None)
-				| _ -> raise (Internal_error (Printf.sprintf "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd))))
-			| None -> raise (Internal_error (Printf.sprintf "Fail to get result after sending Qmp message: %s" (string_of_message qmp_cmd)))
-		end
-		else (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
-	end
+	let is_running = Qemu.is_running ~xs domid in
+	let is_upstream = is_upstream_qemu domid in
+	match is_running, is_upstream with
+	| true, false -> (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
+	| true, true  -> (
+		let open Qmp in
+		let qmp_cmd = Command (None, Query_vnc) in
+		let parse_qmp_message = function
+			| Success (None, Vnc vnc) -> (try Some vnc.service with _ -> None)
+			| _ -> debug "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd); None
+		in
+		let qmp_cmd_result = qmp_write_and_read domid qmp_cmd in
+		match qmp_cmd_result with
+		| Some qmp_message -> parse_qmp_message qmp_message
+		| None -> debug "Fail to get result after sending Qmp message: %s" (string_of_message qmp_cmd); None)
+	| _, _  -> None
 
 let get_tc_port ~xs domid =
 	if not (Qemu.is_running ~xs domid)


### PR DESCRIPTION
When shutdown a VM, QEMU is killed before domain is down. Some test cases
will check domain status including VNC port, so save vnc port into xenstore
once got it.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>