### PR TITLE
CP-22500: support clean suspend,shutdown etc for HVM Linux using upstream qemu

### DIFF
--- a/xc/device.mli
+++ b/xc/device.mli
@@ -233,6 +233,8 @@ sig
 	val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
+
+	val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
 end
 
 val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2753,6 +2753,7 @@ module Actions = struct
 							let non_persistent = { non_persistent with VmExtra.pv_drivers_detected = true } in
 							debug "VM = %s; found PV driver evidence on %s (value = %s)" vm path value;
 							DB.write vm { VmExtra.persistent; non_persistent };
+							Device.Dm.maybe_write_pv_feature_flags ~xs domid;
 							Updates.add (Dynamic.Vm vm) internal_updates
 						end
 					with Xs_protocol.Enoent _ ->


### PR DESCRIPTION
The original qemu-trad patch added as part of CP-9364 was split into two:

- a small upstream qemu patch that implements the xen platform io-port 0x10 and
collects the product-num and build-num for the PV driver, and exposes them via
the new query-xen-platform-pv-driver-info QMP command, see qemu.pg PR 34:
  . CP-23471: Expose product number and build number of XEN PV driver

- this xenopsd patch, which collects product-num and build-num for the PV
driver using the QMP command above, and using the original algorithm in
qemu-trad, decides if the PV driver belongs to a HVM Linux guest. In this case,
it writes to xenstore as qemu-trad would have done, see qemu-trad.pg patches:
  . CP-9364: write feature-flags to xenstore when HVM guest stops using
    emulated devices
  . CP-9364: xapi expects data/updated to exist

This patch keeps the same behaviour present in the original qemu-trad patch,
in order to maintain the the support for clean suspend, shutdown etc for the
same set of HVM Linux guests.

It depends on https://github.com/xapi-project/ocaml-qmp/pull/16

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>