### PR TITLE
CP-23605: Implement script to inject IGMP query

### DIFF
--- a/.travis-python-nosetests.sh
+++ b/.travis-python-nosetests.sh
@@ -1,0 +1,9 @@
+# SUMMARY:
+# Run python unittests using nose
+
+set -uex
+
+sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
+sudo apt-get install -y python-mock python-nose
+
+nosetests scripts 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: c
 services: docker
 install:
     - wget https://raw.githubusercontent.com/xenserver/xenserver-build-env/master/utils/travis-build-repo.sh
-script: bash travis-build-repo.sh
+script:
+    - bash travis-build-repo.sh
+    - bash .travis-python-nosetests.sh
 sudo: true
 env:
     global:
@@ -10,3 +12,4 @@ env:
         - REPO_CONFIGURE_CMD=./configure
         - REPO_BUILD_CMD=make
         - REPO_TEST_CMD=true
+

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ endif
 	install -D ./scripts/setup-vif-rules $(DESTDIR)/$(LIBEXECDIR)/setup-vif-rules
 	install -D ./scripts/setup-pvs-proxy-rules $(DESTDIR)/$(LIBEXECDIR)/setup-pvs-proxy-rules
 	install -D ./scripts/common.py $(DESTDIR)/$(LIBEXECDIR)/common.py
+	install -D ./scripts/igmp_query_injector.py $(DESTDIR)/$(LIBEXECDIR)/igmp_query_injector.py
 	install -D ./set_domain_uuid.native $(DESTDIR)/$(LIBEXECDIR)/set-domain-uuid
 	DESTDIR=$(DESTDIR) SBINDIR=$(SBINDIR) LIBEXECDIR=$(LIBEXECDIR) ETCDIR=$(ETCDIR) ./scripts/make-custom-xenopsd.conf
 
@@ -106,6 +107,7 @@ uninstall:
 	rm -f $(DESTDIR)/$(LIBEXECDIR)/setup-vif-rules
 	rm -f $(DESTDIR)/$(LIBEXECDIR)/setup-pvs-proxy-rules
 	rm -f $(DESTDIR)/$(LIBEXECDIR)/common.py*
+	rm -f $(DESTDIR)/$(LIBEXECDIR)/igmp_query_injector.py*
 
 .PHONY: release
 release:

--- a/scripts/igmp_query_injector.py
+++ b/scripts/igmp_query_injector.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python
+import Queue
+import argparse
+import os
+import socket
+import struct
+import subprocess
+import threading
+from abc import ABCMeta, abstractmethod
+import logging
+import signal
+import resource
+import binascii
+from xcp import logger as log
+import time
+import sys
+import re
+from xen.lowlevel.xs import xs
+
+
+class Cleanup(object):
+    """Ensure xenstore connection closed when exit
+    """
+    CATCH_SIGNALS = [signal.SIGTERM, signal.SIGINT]
+
+    def __enter__(self):
+        self._set_signal_handler(self.CATCH_SIGNALS, self._close_xs_connection)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        XSUtil.close()
+
+    def _set_signal_handler(self, signals, f):
+        for s in signals:
+            signal.signal(s, f)
+
+    def _close_xs_connection(self, signum, frame):
+        log.critical('Catch signal %d, close xenstore connection' % signum)
+        XSUtil.close()
+        sys.exit(ERRNO.SIGNAL_CATCH)
+
+
+class ERRNO(object):
+    SUCC = 0
+    SIGNAL_CATCH = 1
+
+
+class XSUtil(object):
+    """Utilities for access xenstore
+    """
+
+    xs_handler = xs()
+
+    @classmethod
+    def close(cls):
+        cls.xs_handler.close()
+
+    @classmethod
+    def read(cls, path):
+        return cls.xs_handler.read('', path)
+
+    @classmethod
+    def watch(cls, path, token):
+        return cls.xs_handler.watch(path, token)
+
+    @classmethod
+    def unwatch(cls, path, token):
+        return cls.xs_handler.unwatch(path, token)
+
+    @classmethod
+    def read_watch(cls):
+        return cls.xs_handler.read_watch()
+
+    @staticmethod
+    def vif_mac_path(domid, vifid):
+        return '/local/domain/%d/device/vif/%d/mac' % (domid, vifid)
+
+    @staticmethod
+    def vif_state_path(domid, vifid):
+        return '/local/domain/%d/device/vif/%d/state' % (domid, vifid)
+
+
+class XSWatch(object):
+    __metaclass__ = ABCMeta
+    """Tool for watching xenstore
+    """
+    def __init__(self):
+        self.watches = []
+
+    def watch(self, path, token):
+        self.watches.append(path)
+        return XSUtil.watch(path, token)
+
+    def unwatch(self, path, token):
+        self.watches.remove(path)
+        return XSUtil.unwatch(path, token)
+
+    def process_all_watches(self):
+        while self.watches:
+            path, token = XSUtil.read_watch()
+            if self.val_change_to_expected(path, token):
+                self.unwatch(path, token)
+                self.put_task(path, token)
+
+    @abstractmethod
+    def val_change_to_expected(self, path, token):
+        pass
+
+    @abstractmethod
+    def put_task(self, path, token):
+        pass
+
+
+class XSVifStateWatch(XSWatch):
+    def __init__(self, expected_state):
+        super(XSVifStateWatch, self).__init__()
+        self.expected_state = expected_state
+        self.queue = Queue.Queue()
+
+    def val_change_to_expected(self, path, vif):
+        return XSUtil.read(vif.state_path) == self.expected_state
+
+    def put_task(self, path, vif):
+        self.queue.put(InjectTask(vif, len(self.watches) == 0))
+
+    def get_task(self, timeout):
+        return self.queue.get(timeout=timeout)
+
+
+class InjectTask(object):
+    def __init__(self, vif, is_last):
+        self.vif = vif
+        self.is_last = is_last
+
+
+class Vif(object):
+    def __init__(self, vif):
+        self.vif_name = vif
+        ids = self.vif_name.split('vif')[1].split('.')
+        self._domid = int(ids[0])
+        self._vifid = int(ids[1])
+        self.mac = XSUtil.read(XSUtil.vif_mac_path(self._domid, self._vifid))
+        self.state_path = XSUtil.vif_state_path(self._domid, self._vifid)
+        self._injected = False
+
+    def mark_injected(self):
+        self._injected = True
+
+    @property
+    def injected(self):
+        return self._injected
+
+
+class IGMPQueryGenerator(object):
+    """IGMP Query generator.
+    Generate IGMP Query packet with/without vlan
+    """
+    def __init__(self, dst_mac, vlanid, max_resp_time):
+        """
+        :param dst_mac: Destination mac address of this IGMP query packet
+        :param vlanid: Vlan ID of this packet. `-1` means no vlan
+        :param max_resp_time: Max response time of IGMP query. Unit is 100ms
+        """
+        self.src_mac = '00:00:00:00:00:00'
+        self.dst_mac = dst_mac
+        self.vlanid = vlanid
+        self.max_resp_time = max_resp_time
+
+    def mac2binarry(self, mac):
+        return binascii.unhexlify(mac.replace(':', ''))
+
+    def create_ether_layer(self):
+        if self.vlanid == -1:
+            type_field = 0x0800
+        else:
+            type_field = 0x8100
+        return struct.pack('!6s6sH', self.mac2binarry(self.dst_mac), self.mac2binarry(self.src_mac), type_field)
+
+    def create_vlan_layer(self):
+        if self.vlanid == -1:
+            return struct.pack('')
+        else:
+            return struct.pack('!HH', 0x2000 | self.vlanid, 0x0800)
+
+    def create_ip_layer(self):
+        """
+        IP Type: IPv4 (0x0800)
+        Version: 4
+        Total length: 32
+        TTL: 1
+        Source IP: 0.0.0.0
+        Destination IP: 224.0.0.1 (e0:00:00:01)
+        """
+        hex_str = "4600002000010000010244d600000000e000000194040000"
+        s = binascii.unhexlify(hex_str)
+        return struct.pack('!%ds' % len(s), s)
+
+    def create_igmp_layer(self):
+        """
+        IGMP Version: 2
+        IGMP Type: IGMP Query (0x11)
+        Max Resp Time: self.max_resp_time
+        Multicast Address: 0.0.0.0
+        """
+        msg_type = 0x11
+        # MAX_RESP_TIME filed unit is 100ms
+        max_resp_time = self.max_resp_time / 100
+        group_address = socket.inet_aton('0.0.0.0')
+        chksum = self._calc_igmp_checksum(struct.pack('!BBH4s', msg_type, max_resp_time, 0x0000, group_address))
+        return struct.pack('!BBH4s', msg_type, max_resp_time, chksum, group_address)
+
+    def _calc_igmp_checksum(self, packet):
+        def carry_around_add(a, b):
+            c = a + b
+            return (c & 0xffff) + (c >> 16)
+
+        s = 0
+        msg = struct.unpack('%dB' % len(packet), packet)
+        for i in range(0, len(msg), 2):
+            w = (msg[i] << 8) + msg[i+1]
+            s = carry_around_add(s, w)
+        return ~s & 0xffff
+
+    def generate(self):
+        ether_layer = self.create_ether_layer()
+        vlan_layer = self.create_vlan_layer()
+        ip_layer = self.create_ip_layer()
+        igmp_layer = self.create_igmp_layer()
+        packet = ether_layer + vlan_layer + ip_layer + igmp_layer
+        return packet
+
+
+class IGMPQueryInjector(object):
+    __metaclass__ = ABCMeta
+
+    def __init__(self, max_resp_time):
+        self.max_resp_time = max_resp_time
+
+    def inject_to_vif(self, vif, mac):
+        log.info('Inject IGMP query to vif:%s, mac:%s' % (vif, mac))
+        packet = IGMPQueryGenerator(mac, -1, self.max_resp_time).generate()
+        self.inject_query_packet(vif, packet)
+
+    def inject_to_vifs(self, vifs):
+        for vif in vifs:
+            _vif = Vif(vif)
+            self.inject_to_vif(_vif.vif_name, _vif.mac)
+
+    def inject_query_packet(self, interface, packet):
+        s = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, 0)
+        s.bind((interface, 0))
+        s.send(packet)
+        s.close()
+
+    @abstractmethod
+    def inject(self):
+        pass
+
+
+class VifsInjector(IGMPQueryInjector):
+    def __init__(self, max_resp_time, vifs, vif_connected_timeout=0):
+        super(VifsInjector, self).__init__(max_resp_time)
+        self.vifs = vifs
+        self.vif_connected_timeout = vif_connected_timeout
+
+    def inject(self):
+        if not self.vifs:
+            return
+
+        if self.vif_connected_timeout > 0:
+            # should check connection state
+            log.info('Inject IGMP query with connection state check')
+            self._inject_with_connection_state_check()
+        else:
+            log.info('Inject IGMP query without connection state check')
+            self._inject_without_connection_state_check()
+
+    def _inject_with_connection_state_check(self):
+        vifs = [Vif(vif) for vif in self.vifs]
+        expected_vif_state = '4'
+        watch = XSVifStateWatch(expected_vif_state)
+        for vif in vifs:
+            watch.watch(vif.state_path, vif)
+
+        t = threading.Thread(target=watch.process_all_watches)
+        t.daemon = True
+        t.start()
+        remain_time = self.vif_connected_timeout
+
+        while remain_time > 0:
+            start_time = time.time()
+            try:
+                task = watch.get_task(remain_time)
+                vif = task.vif
+                self.inject_to_vif(vif.vif_name, vif.mac)
+                vif.mark_injected()
+                if task.is_last:
+                    return
+            except Queue.Empty as e:
+                # timeout
+                break
+
+            remain_time = remain_time - (time.time() - start_time)
+
+        for vif in vifs:
+            if not vif.injected:
+                log.warning("Value of '%s' does not change to '%s' in %d seconds." %
+                            (vif.state_path, expected_vif_state, self.vif_connected_timeout))
+                log.warning("Don't inject IGMP query to vif: %s, mac: %s" % (vif.vif_name, vif.mac))
+
+    def _inject_without_connection_state_check(self):
+        self.inject_to_vifs(self.vifs)
+
+
+class BridgeInjector(IGMPQueryInjector):
+    RE_VIF = re.compile(r'^vif\d+\.\d+$')
+
+    def __init__(self, max_resp_time, bridges):
+        super(BridgeInjector, self).__init__(max_resp_time)
+        self.bridges = bridges
+
+    def get_vifs_on_bridge(self, bridge):
+        ret = []
+        outs = subprocess.check_output(['ovs-vsctl', 'list-ports', bridge]).strip()
+        for line in outs.split('\n'):
+            if self.RE_VIF.match(line):
+                ret.append(line)
+
+        return ret
+
+    def inject(self):
+        for bridge in self.bridges:
+            log.info('Inject IGMP query to bridge:%s' % bridge)
+            vifs = self.get_vifs_on_bridge(bridge)
+            self.inject_to_vifs(vifs)
+
+
+def inject_to_vifs(args):
+    log.debug('Entry point: Inject IGMP query per pif')
+    injector = VifsInjector(args.max_resp_time, args.vifs, args.vif_connected_timeout)
+    return injector.inject()
+
+
+def inject_to_vifs_on_bridges(args):
+    log.debug('Entry point: Inject IGMP query per bridge')
+    injector = BridgeInjector(args.max_resp_time, args.bridges)
+    return injector.inject()
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog='igmp_query_injector.py', description=
+                                     'Tool for injecting IGMP query packet')
+    parser.add_argument('--detach', dest='detach', required=False, action='store_true',
+                        help='execute this tool as a daemon')
+    parser.add_argument('--max-resp-time', dest='max_resp_time', required=False, metavar='max_resp_time', type=int,
+                        default=100, help='max response time of IGMP query, unit is millisecond')
+    parser.add_argument('--verbose', dest='verbose', required=False, action='store_true',
+                        help='print verbose log')
+
+    subparsers = parser.add_subparsers()
+    to_vif_parser = subparsers.add_parser('vif', help='inject query to vifs',
+                                          description='Inject query to vifs')
+    to_vif_parser.set_defaults(func=inject_to_vifs)
+    to_vif_parser.add_argument('vifs', metavar='vif_name', nargs='+', help='vif interface name in Dom0')
+    to_vif_parser.add_argument('--wait-vif-connected', dest='vif_connected_timeout', metavar='timeout', type=int,
+                               default=0, help='timeout value for waiting vif connected, unit is second')
+
+    to_bridge_parser = subparsers.add_parser('bridge', help='inject query to vifs on the bridge',
+                                             description='Inject query to vifs on the bridge')
+    to_bridge_parser.set_defaults(func=inject_to_vifs_on_bridges)
+    to_bridge_parser.add_argument('bridges', metavar='bridge_name', nargs='+', help='bridge name of OVS')
+
+    return parser
+
+
+def _detach():
+    try:
+        pid = os.fork()
+        if pid > 0:
+            sys.exit(0)
+        else:
+            maxfd = resource.getrlimit(resource.RLIMIT_NOFILE)[1]
+            if maxfd == resource.RLIM_INFINITY:
+                maxfd = 1024
+
+            # Iterate through and close all file descriptors.
+            for fd in range(0, maxfd):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+    except OSError as e:
+        sys.stderr.write("fork failed: %d (%s)\n" % (e.errno, e.strerror))
+        sys.exit(1)
+
+
+def toggle_of_IGMP_snooping_is_enabled():
+    pool_uuid = subprocess.check_output(['/opt/xensource/bin/xe', 'pool-list', '--minimal']).strip()
+    toggle_state = subprocess.check_output(
+        ['/opt/xensource/bin/xe', 'pool-param-get', 'uuid=%s' % pool_uuid, 'param-name=igmp-snooping-enabled']).strip()
+    return toggle_state == 'true'
+
+
+def network_backend_is_openvswitch():
+    bridge_type = subprocess.check_output(['/opt/xensource/bin/xe-get-network-backend']).strip()
+    return bridge_type == 'openvswitch'
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    logging_lvl = logging.INFO
+    if args.verbose:
+        logging_lvl = logging.DEBUG
+
+    log.logToSyslog(level=logging_lvl)
+
+    if args.detach:
+        _detach()
+
+    if not toggle_of_IGMP_snooping_is_enabled():
+        log.info('IGMP snooping is off, no need to inject query')
+        return ERRNO.SUCC
+
+    if not network_backend_is_openvswitch():
+        log.info('Network backend type is not openvswitch, no need to inject query')
+        return ERRNO.SUCC
+
+    # Ensure xenstore connection closed when exception/signal catches
+    with Cleanup():
+        args.func(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/test_igmp_query_injector.py
+++ b/scripts/test_igmp_query_injector.py
@@ -1,0 +1,133 @@
+import unittest
+from contextlib import contextmanager
+import time
+
+import sys
+
+import binascii
+from mock import patch, MagicMock
+
+# mock modules since this repo does not contain them
+sys.modules['xcp'] = MagicMock()
+sys.modules['xen'] = MagicMock()
+sys.modules['xen.lowlevel'] = MagicMock()
+sys.modules['xen.lowlevel.xs'] = MagicMock()
+
+sys.path.append('./scripts')
+
+from igmp_query_injector import Cleanup, IGMPQueryGenerator, VifsInjector, \
+    BridgeInjector, XSUtil, XSVifStateWatch, Vif
+
+
+class TestCleanup(unittest.TestCase):
+    def test_cleanup(self):
+        with Cleanup():
+            pass
+
+        XSUtil.xs_handler.close.assert_called()
+
+
+class TestXSVifStateWatch(unittest.TestCase):
+    def test_watch(self):
+        watch = XSVifStateWatch('1')
+        path = '/a/b/c'
+        watch.watch(path, '000')
+        XSUtil.xs_handler.watch.assert_called()
+        self.assertIn(path, watch.watches)
+
+    def test_unwatch(self):
+        watch = XSVifStateWatch('1')
+        path = '/a/b/c'
+        token = '000'
+        watch.watch(path, token)
+        XSUtil.xs_handler.watch.assert_called()
+        self.assertIn(path, watch.watches)
+
+        watch.unwatch(path, token)
+        XSUtil.xs_handler.unwatch.assert_called()
+        self.assertNotIn(path, watch.watches)
+
+
+class TestIGMPQueryGenerator(unittest.TestCase):
+    def test_create_igmp_layer(self):
+        gen = IGMPQueryGenerator('00:00:00:00:00:00', -1, 10000)
+        layer = gen.create_igmp_layer()
+        expect_hex_str = "1164ee9b00000000"
+        self.assertEqual(layer, binascii.unhexlify(expect_hex_str))
+
+    def test_generate_without_vlan(self):
+        gen = IGMPQueryGenerator('01:00:5e:00:00:01', -1, 10000)
+        packet = gen.generate()
+        expect_hex_str = '01005e00000100000000000008004600002000010000010244d600000000e0000001940400001164ee9b00000000'
+        self.assertEqual(packet, binascii.unhexlify(expect_hex_str))
+
+    def test_generate_with_vlan(self):
+        gen = IGMPQueryGenerator('01:00:5e:00:00:01', 1209, 10000)
+        packet = gen.generate()
+        expect_hex_str = '01005e000001000000000000810024b908004600002000010000010244d600000000e0000001940400001164ee9b00000000'
+        self.assertEqual(packet, binascii.unhexlify(expect_hex_str))
+
+    def test_generate_max_resp_time_100ms(self):
+        gen = IGMPQueryGenerator('01:00:5e:00:00:01', -1, 100)
+        packet = gen.generate()
+        expect_hex_str = '01005e00000100000000000008004600002000010000010244d600000000e0000001940400001101eefe00000000'
+        self.assertEqual(packet, binascii.unhexlify(expect_hex_str))
+
+
+class TestVifsInjector(unittest.TestCase):
+    @contextmanager
+    def assert_time_elapse_in(self, min, max):
+        start = time.time()
+        yield
+        elapse = time.time() - start
+        self.assertTrue(min <= elapse <= max, 'elapse time %f should in [%f, %f]' % (elapse, min, max))
+
+    @patch('igmp_query_injector.Vif')
+    @patch('igmp_query_injector.IGMPQueryInjector.inject_to_vif')
+    @patch('igmp_query_injector.VifsInjector._inject_with_connection_state_check')
+    def test_inject_without_connection_state_check(self, mock_inject_with_connection_state_check,
+                                                   mock_inject_to_vif, MockVif):
+        injector = VifsInjector(100, ['vif1.1', 'vif2.1'], 0)
+        injector.inject()
+        mock_inject_with_connection_state_check.assert_not_called()
+        self.assertEqual(mock_inject_to_vif.call_count, 2)
+
+    @patch('igmp_query_injector.IGMPQueryInjector.inject_to_vif')
+    @patch('threading.Thread')
+    def test_inject_with_connection_state_check_timeout(self, mockThread, mock_inject_to_vif):
+        injector = VifsInjector(100, ['vif1.1', 'vif2.1'], 3)
+        # should timeout in 3 seconds
+        with self.assert_time_elapse_in(2, 4):
+            injector.inject()
+        # won't inject query to any vif
+        mock_inject_to_vif.assert_not_called()
+
+    @patch('igmp_query_injector.IGMPQueryInjector.inject_to_vif')
+    @patch('igmp_query_injector.XSUtil.read_watch')
+    @patch('igmp_query_injector.XSVifStateWatch.val_change_to_expected')
+    def test_inject_with_connection_state_check_succ(self, mock_val_change_to_expected, mock_read_watch, mock_inject_to_vif):
+        mock_val_change_to_expected.return_value = True
+        vifs = []
+        side_effect = []
+        for domid, vifid in [(1, 2), (2, 3)]:
+            vif = 'vif%d.%d' % (domid, vifid)
+            side_effect.append((XSUtil.vif_state_path(domid, vifid), Vif(vif)))
+            vifs.append(vif)
+        mock_read_watch.side_effect = side_effect
+        injector = VifsInjector(100, vifs, 3)
+        with self.assert_time_elapse_in(0, 1):
+            injector.inject()
+        self.assertEqual(mock_inject_to_vif.call_count, 2)
+
+
+class TestBridgeInjector(unittest.TestCase):
+    @patch('subprocess.check_output')
+    def test_get_vifs_on_bridge(self, mock_subprocess_check_output):
+        mock_subprocess_check_output.return_value = 'vif1.1\ntap1.0\nvif1.2'
+        injector = BridgeInjector(100, ['xenbr0'])
+        vifs = injector.get_vifs_on_bridge('xenbr0')
+        self.assertEqual(len(vifs), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implement a script for IGMP query injection.
It can 
- inject IGMP query to vifs with/without vif connection state checking & waiting
- inject IGMP query to vifs of specific bridges
- specify MAX_RESP_TIME field of IGMP query packet

Signed-off-by: Yang Qian <yang.qian@citrix.com>