### PR TITLE
CA-260353: return None if Qmp_protocol.connect raises error

### DIFF
--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -335,19 +335,20 @@ let is_upstream_qemu domid =
 	with _ -> false
 
 let qmp_write_and_read domid ?(read_result=true) cmd  =
-  let open Qmp in
-  let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" domid) in
-  finally
-    (fun () ->
-      try
+  try
+    let open Qmp in
+    let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" domid) in
+    finally
+      (fun () ->
         Qmp_protocol.negotiate c;
         Qmp_protocol.write c cmd;
         if read_result then
           Some (Qmp_protocol.read c)
         else None
-      with e ->
-        error "Caught exception attempting to write qmp message: %s" (Printexc.to_string e);
-        None)
-    (fun () -> Qmp_protocol.close c)
+      )
+      (fun () -> Qmp_protocol.close c)
+  with e ->
+    error "Caught exception attempting to write qmp message: %s" (Printexc.to_string e);
+    None
 
 let qmp_write domid cmd = qmp_write_and_read ~read_result:false domid cmd |> ignore


### PR DESCRIPTION
Originally, an error in Qmp_protocol.connect would cause xenopsd
tasks to fail. This would create a race condition, where tasks
would fail after qemu was killed and prevent specific signals
such as VM_check_state from being handled until the end, resulting
in VMs with inconsistent state.

This patch makes sure that in the event of a QMP connection error,
None is returned as expected.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>