### PR TITLE
CA-262911: Use poweroff rather than halt

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -842,7 +842,7 @@ let rec atomics_of_operation = function
 			VM_set_domain_action_request(id, None)
 		]
 	| VM_shutdown (id, timeout) ->
-		(Opt.default [] (Opt.map (fun x -> [ VM_shutdown_domain(id, Halt, x) ]) timeout)
+		(Opt.default [] (Opt.map (fun x -> [ VM_shutdown_domain(id, PowerOff, x) ]) timeout)
 		) @ simplify ([
 			(* At this point we have a shutdown domain (ie Needs_poweroff) *)
 			VM_destroy_device_model id;

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1364,16 +1364,6 @@ module VM = struct
 			(fun xc xs task vm di ->
 
 				let domid = di.Xenctrl.domid in
-
-				(* As per comment on CA-217805 *)
-				let use_poweroff =
-					try
-						xs.Xs.read (xs.Xs.getdomainpath domid ^ "/control/feature-poweroff") = "1"
-					with _ -> false
-				in
-
-				let reason = match reason, use_poweroff with Domain.Halt, true -> Domain.PowerOff | x, _ -> x in
-
 				try
 					Domain.shutdown ~xc ~xs domid reason;
 					Domain.shutdown_wait_for_ack task ~timeout:ack_delay ~xc ~xs domid reason;


### PR DESCRIPTION
xenopsd was changed to send poweroff instead of halt for newer guests
with commit 7a71ef8ac5e8 ("CA-217805: Prefer asking newer guests to
poweroff rather than halt").  Unfortunately there are some existing
guests (NetScaler/FreeBSD 8.4) that actually do halt when asked to. This
is not correct because the toolstack has been told to shutdown the VM,
not halt it. This is only seen with upstream QEMU because qemu-trad had
a bug in the emulated serial controller that caused FreeBSD to go
straight from halt to shutdown so this halting behavior was never
noticed.

Since all known guests support being asked to poweroff, send this
instead of halt.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>