### PR TITLE
CP-23595: Introduce device model profiles to xenopsd - Stage 1

### DIFF
--- a/lib/resources.ml
+++ b/lib/resources.ml
@@ -15,6 +15,7 @@
 let network_conf = ref "/etc/xcp/network.conf"
 let qemu_dm_wrapper = ref "qemu-dm-wrapper"
 let qemu_system_i386 = ref "qemu-system-i386"
+let upstream_compat_qemu_dm_wrapper = ref "qemu-wrapper"
 let chgrp = ref "chgrp"
 let modprobe = ref "/usr/sbin/modprobe"
 let rmmod = ref "/usr/sbin/rmmod"
@@ -31,6 +32,7 @@ let hvm_guests = [
 	R_OK, "hvmloader", hvmloader, "path to the hvmloader binary for HVM guests";
 	X_OK, "qemu-dm-wrapper", qemu_dm_wrapper, "path to the qemu-dm-wrapper script";
 	X_OK, "qemu-system-i386", qemu_system_i386, "path to the qemu-system-i386 binary";
+	X_OK, "upstream-compat-qemu-dm-wrapper", upstream_compat_qemu_dm_wrapper, "path to the upstream compat qemu-dm-wrapper script";
 ]
 
 let pv_guests = [

--- a/scripts/qemu-dm-wrapper
+++ b/scripts/qemu-dm-wrapper
@@ -61,43 +61,21 @@ def enable_core_dumps():
         setrlimit(RLIMIT_CORE, (limit, hardlimit))
         return limit
 
-def qemu_dm_upstream():
-    return '/usr/lib64/xen/bin/qemu-wrapper'
-
-def qemu_dm_trad():
+def main(argv):
+    qemu_env = os.environ
     qemu_dm_list = ['/usr/lib/xen/bin/qemu-dm',
                     '/usr/lib64/xen/bin/qemu-dm',
                     '/usr/lib/xen-4.1/bin/qemu-dm',
                     '/usr/lib/xen-4.2/bin/qemu-dm',
                     '/usr/lib/xen-4.4/bin/qemu-dm']
+    qemu_dm = None
     for loc in qemu_dm_list:
         if os.path.exists(loc):
-            return loc
-    raise Exception("Cannot find qemu-dm in %s" % qemu_dm_list)
+            qemu_dm = loc
+    if qemu_dm is None:
+        raise Exception("Cannot find qemu-dm in %s" % qemu_dm_list)
 
-def qemu_dm_path(domid, argv):
-    up_qemu = 0
-
-    try:
-        qemu_v = xenstore_read("/local/domain/%d/vm-data/up-qemu" % domid)
-    except RuntimeError:
-        qemu_v = "0"
-    if qemu_v == "1":
-        up_qemu = 1
-    elif qemu_v == "2":
-        for arg in argv:
-            if arg == "-loadvm":
-                up_qemu = 1
-
-    if up_qemu:
-        return qemu_dm_upstream()
-    else:
-        return qemu_dm_trad()
-
-def main(argv):
-    qemu_env = os.environ
     domid = int(argv[1])
-    qemu_dm = qemu_dm_path(domid, argv)
     qemu_args = ['qemu-dm-%d'%domid] + argv[2:]
 
     # Workaround http://unix.stackexchange.com/questions/39495/domain-ubuntu-hvm-does-not-exists-xen-ubuntu-hvm-guest-os-installation-pro

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1483,6 +1483,30 @@ module Dm = struct
     extras: (string * string option) list;
   }
 
+  module Profile = struct
+    type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+    let fallback = Qemu_trad
+    module Name = struct
+      let qemu_trad            = "qemu-trad"
+      let qemu_upstream_compat = "qemu-upstream-compat"
+      let qemu_upstream        = "qemu-upstream"
+      let all = [ qemu_trad; qemu_upstream_compat; qemu_upstream ]
+    end
+    let wrapper_of = function
+      | Qemu_trad            -> !Resources.qemu_dm_wrapper
+      | Qemu_upstream_compat -> !Resources.upstream_compat_qemu_dm_wrapper
+      | Qemu_upstream        -> !Resources.upstream_compat_qemu_dm_wrapper
+    let string_of  = function
+      | Qemu_trad              -> Name.qemu_trad
+      | Qemu_upstream_compat   -> Name.qemu_upstream_compat
+      | Qemu_upstream          -> Name.qemu_upstream
+    let of_string  = function
+      | x when x = Name.qemu_trad            -> Qemu_trad
+      | x when x = Name.qemu_upstream_compat -> Qemu_upstream_compat
+      | x when x = Name.qemu_upstream        -> Qemu_upstream
+      | x -> debug "unknown device-model profile %s: defaulting to fallback: %s" x (string_of fallback);
+         fallback
+  end
 
   let get_vnc_port ~xs domid =
     let is_running = Qemu.is_running ~xs domid in

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -219,6 +219,20 @@ sig
 		extras: (string * string option) list;
 	}
 
+	module Profile: sig
+		type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+		val fallback : t
+		module Name: sig
+			val qemu_trad: string
+			val qemu_upstream_compat: string
+			val qemu_upstream: string
+			val all: string list
+		end
+		val wrapper_of: t -> string
+		val string_of : t -> string
+		val of_string : string -> t
+	end
+
 	val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 	val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -57,7 +57,11 @@ let choose_alternative kind default platformdata =
 	end else default
 
 (* We allow qemu-dm to be overriden via a platform flag *)
-let choose_qemu_dm x = choose_alternative _device_model !Resources.qemu_dm_wrapper x
+let choose_qemu_dm x = Device.(Dm.Profile.wrapper_of (
+	if List.mem_assoc _device_model x
+	then Dm.Profile.of_string (List.assoc _device_model x)
+	else Dm.Profile.fallback
+))
 
 (* We allow xenguest to be overriden via a platform flag *)
 let choose_xenguest x = choose_alternative _xenguest !Xc_resources.xenguest x


### PR DESCRIPTION
For Stage 1:
* Always use qemu-trad unless a VM is specifically set to
use one of the known profiles:
  - qemu-trad
  - qemu-upstream
  - qemu-upstream-compat
* The device model profile used if VM.platform["device-model"] is
not set shall be 'qemu-trad' (the fallback)
* Each profile has its own device model wrapper.
* Remove unused global variables related to old qemu-trad wrapper.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>

(cc: @jonludlam, @robhoes, @lindig )