### PR TITLE
CA-264980 /usr/libexec/xenopsd/igmp_query_injector.py was broken due …

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1559,7 +1559,8 @@ module VM = struct
 		let vif_names = List.map (fun vif -> Printf.sprintf "vif%d.%d" domid vif.Vif.position) vifs in
 		debug "Inject IGMP query to %s" (String.concat " " vif_names);
 		(* Call script to inject IGMP query asynchronously *)
-		Forkhelpers.execute_command_get_output !Xc_resources.igmp_query_injector_script ("--detach" :: "vif" :: "--wait-vif-connected":: (string_of_int !Xenopsd.vif_ready_for_igmp_query_timeout) :: vif_names)
+		let pid = Forkhelpers.safe_close_and_exec None None None [] !Xc_resources.igmp_query_injector_script ("--wait-vif-connected":: (string_of_int !Xenopsd.vif_ready_for_igmp_query_timeout) :: vif_names) in
+		Forkhelpers.dontwaitpid pid
 
 	let restore task progress_callback vm vbds vifs data extras =
 		on_domain


### PR DESCRIPTION
…to closing of fd when at daemonizing

There is an issue in the script detected when at feature testing, in that when at detach the current process, the fds are closed (impacted one such as to xenstore) in child process where it is unnecessary (origianlly needed as child is popen-ed in earlier implementation). Script (child daemon one) will hang by doing so. In fact, to detach the current one by fork, the child process carries exactly the same context as parent if not to detach and running henceover, so just remove the closing fd logic.