### PR TITLE
CA-264906: Call new domctl for qemu-trad vCPU hotplug

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1073,8 +1073,9 @@ module VM = struct
 		Domain.set_xsdata ~xs di.Xenctrl.domid xsdata
 	) Newest task vm
 
-	let set_vcpus' task vm target = on_domain (fun xc xs _ _ di ->
+	let set_vcpus task vm target = on_domain (fun xc xs _ _ di ->
 		let domid = di.Xenctrl.domid in
+		Xenctrlext.domain_set_vcpu_hotplug xc domid target;
 		(* Returns the instantaneous CPU number from xenstore *)
 		let current =
 			let n = ref (-1) in
@@ -1096,14 +1097,6 @@ module VM = struct
 				Device.Vcpu.set ~xs ~devid:i domid true
 			done
 		)
-	) Newest task vm
-
-	let set_vcpus task vm ncpus = on_domain (fun xc xs _ _ di ->
-		if Device_common.is_upstream_qemu di.Xenctrl.domid then begin
-			Xenctrlext.domain_set_vcpu_hotplug xc di.Xenctrl.domid ncpus;
-			set_vcpus' task vm ncpus
-		end else
-			set_vcpus' task vm ncpus
 	) Newest task vm
 
 	let set_shadow_multiplier task vm target = on_domain (fun xc xs _ _ di ->


### PR DESCRIPTION
Call the new domctl for vCPU hotplug for both qemu-trad and upstream
QEMU. This is needed to fix vCPU hotplug with qemu-trad since now that
the emulation is done in Xen, the hotplug implementation in qemu-trad
does not take effect.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>