### PR TITLE
CP-24090: Respond to RTC_CHANGE QMP message

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1505,6 +1505,9 @@ module Dm = struct
                 with End_of_file ->
                   debug "domain-%d: end of file, close qmp socket" domid;
                   remove domid
+                | e ->
+                  debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
+                  remove domid
               else begin
                 debug "EPOLL error on domain-%d, close qmp socket" domid;
                 remove domid


### PR DESCRIPTION
For QEMU-upstream, when receives RTC_CHANGE event, write the value to
xenstore path /vm/<uuid>/rtc/timeoffset, which will wakeup xenstore
watcher in xenops_server_xen to uptdate timeoffset.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>