### PR TITLE
CP-24468: Clean up libxl xenstore keys after qemu-wrapper

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2034,8 +2034,10 @@ module Dm = struct
     let stop_qemu () = (match (Qemu.pid ~xs domid) with
         | None -> () (* nothing to do *)
         | Some qemu_pid ->
-          if is_upstream_qemu domid then
+          if is_upstream_qemu domid then begin
             QMP_Event.remove domid;
+            xs.Xs.rm (sprintf "/libxl/%d" domid)
+          end;
           debug "qemu-dm: stopping qemu-dm with SIGTERM (domid = %d)" domid;
           let open Generic in
           best_effort "signalling that qemu is ending as expected, mask further signals"


### PR DESCRIPTION
The xenstore key '/libxl/<dom-id>/dm-version' is created by qemu-wrap
when starting QEMU-upstream, we need to clean up this after the domain
is destroyed.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>