### PR TITLE
CA-265618: Fix vCPU hotplug for PV domains

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1075,7 +1075,7 @@ module VM = struct
 
 	let set_vcpus task vm target = on_domain (fun xc xs _ _ di ->
 		let domid = di.Xenctrl.domid in
-		Xenctrlext.domain_set_vcpu_hotplug xc domid target;
+		if di.Xenctrl.hvm_guest then Xenctrlext.domain_set_vcpu_hotplug xc domid target;
 		(* Returns the instantaneous CPU number from xenstore *)
 		let current =
 			let n = ref (-1) in


### PR DESCRIPTION
Commit 42bd3e76a1f5 ("CA-264906: Call new domctl for qemu-trad vCPU
hotplug") broke vCPU hotplug for PV domains because it always called the
new domctl but this domctl does not work with PV domains. Fix this by
only calling the new domctl for HVM domains.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>