### PR TITLE
CP-24361: use abstract qemu interface to split code between trad/upstream qemu in xenopsd

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1904,11 +1904,23 @@ module Backend = struct
 
     (** Dm functions that use the dispatcher to choose between different profile backends *)
     module Dm: sig
+
+      (** [get_vnc_port xenstore domid] returns the dom0 tcp port in which the vnc server for [domid] can be found *)
       val get_vnc_port : xs:Xenstore.Xs.xsh -> int -> int option
+
+      (** [maybe_write_pv_feature_flags xenstore domid] writes the necessary pv feature flags to indicate that the domid supports clean shutdown, reboot, suspend *)
       val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> int -> unit
+
+      (** [suspend task xenstore qemu_domid xc] suspends a domain *)
       val suspend: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
+
+      (** [init_daemon task path args name domid xenstore ready_path ready_val timeout cancel] returns a forkhelper pid after starting the qemu daemon in dom0 *)
       val init_daemon: task:Xenops_task.task_handle -> path:string -> args:string list -> name:string -> domid:int -> xs:Xenstore.Xs.xsh -> ready_path:Watch.path -> ?ready_val:string -> timeout:float -> cancel:Cancel_utils.key -> 'a -> Forkhelpers.pidty
+
+      (** [stop xenstore qemu_domid domid] stops a domain *)
       val stop: xs:Xenstore.Xs.xsh -> qemu_domid:int -> int -> unit
+
+      (** [with_dirty_log domid f] executes f in a context where the dirty log is enabled *)
       val with_dirty_log: int -> f:(unit -> unit) -> unit
     end
   end

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1896,8 +1896,6 @@ module Backend = struct
       val qemu_media_change : xs:Xenstore.Xs.xsh -> device -> string -> string -> unit
     end
     module Dm: sig
-      module Event: sig
-      end
       val get_vnc_port : xs:Xenstore.Xs.xsh -> int -> int option
       val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> int -> unit
       val suspend: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
@@ -1912,8 +1910,6 @@ module Backend = struct
       let qemu_media_change = Vbd_Common.qemu_media_change
     end
     module Dm = struct
-      module Event =  struct
-      end
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
           (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
@@ -1975,7 +1971,6 @@ module Backend = struct
     end (* Backend.Qemu_upstream_compat.Vbd *)
 
     module Dm = struct
-      module Event =  struct
 
         module QMP_Event = struct
           open Qmp
@@ -2073,8 +2068,7 @@ module Backend = struct
 
           let _init_qmp_event =
             Thread.create qmp_event_thread ()
-        end (* QMP_Event *)
-      end (* Qemu_upstream_compat.Dm.Event *)
+        end (* Qemu_upstream_compat.Dm.QMP_Event *)
 
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
@@ -2119,12 +2113,12 @@ module Backend = struct
 
       let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel _ =
         let pid = Dm_Common.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel () in
-        Event.QMP_Event.add domid;
+        QMP_Event.add domid;
         pid
 
       let stop ~xs ~qemu_domid domid  =
         Dm_Common.stop ~xs ~qemu_domid domid;
-        Event.QMP_Event.remove domid
+        QMP_Event.remove domid
 
       let with_dirty_log domid ~f =
         finally

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2133,7 +2133,7 @@ module Backend = struct
     end (* Backend.Qemu_upstream_compat.Dm *)
   end (* Backend.Qemu_upstream *)
 
-  (* Until stage 4, qemu_upstream behaves as qemu_upstream_compat *)
+  (* Until the stage 4 defined in the qemu upstream design is implemented, qemu_upstream behaves as qemu_upstream_compat *)
   module Qemu_upstream  = Qemu_upstream_compat
 
   let of_profile p = match p with

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1454,106 +1454,6 @@ let can_surprise_remove ~xs (x: device) = Generic.can_surprise_remove ~xs x
 
 module Dm = struct
 
-  module QMP_Event = struct
-    open Qmp
-
-    let (>>=) m f = match m with | Some x -> f x | None -> ()
-    let (>>|) m f = match m with | Some _ -> () | None -> f ()
-
-    module Lookup = struct
-      let ftod, dtoc = Hashtbl.create 16, Hashtbl.create 16
-      let add c domid =
-        Hashtbl.replace ftod (Qmp_protocol.to_fd c) domid;
-        Hashtbl.replace dtoc domid c
-      let remove c domid =
-        Hashtbl.remove ftod (Qmp_protocol.to_fd c);
-        Hashtbl.remove dtoc domid
-      let domid_of fd = try Some (Hashtbl.find ftod fd) with Not_found -> None
-      let channel_of domid = try Some (Hashtbl.find dtoc domid) with Not_found -> None
-    end
-
-    module Monitor = struct
-      module Epoll = Core.Linux_ext.Epoll
-      module Flags = Core.Linux_ext.Epoll.Flags
-      let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
-      let add m fd = Epoll.set m fd Flags.in_
-      let remove m fd = Epoll.remove m fd
-      let wait m = Epoll.wait m ~timeout:`Never
-      let with_event m fn = function
-        | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
-        | `Timeout -> debug "Shouldn't receive epoll timeout event in qmp_event_thread"
-    end
-    let m = Monitor.create ()
-
-    let monitor_path domid = Printf.sprintf "/var/run/xen/qmp-event-%d" domid
-    let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
-
-    let remove domid =
-      Lookup.channel_of domid >>= fun c ->
-      try 
-        finally
-          (fun () ->
-             Lookup.remove c domid;
-             Monitor.remove m (Qmp_protocol.to_fd c);
-             debug "Removed QMP Event fd for domain %d" domid)
-          (fun () -> Qmp_protocol.close c)
-      with e -> debug_exn (Printf.sprintf "Got exception trying to remove qmp on domain-%d" domid) e
-
-    let add domid =
-      try
-        Lookup.channel_of domid >>| fun () ->
-        let c = Qmp_protocol.connect (monitor_path domid) in
-        Qmp_protocol.negotiate c;
-        Lookup.add c domid;
-        Monitor.add m (Qmp_protocol.to_fd c);
-        debug "Added QMP Event fd for domain %d" domid
-      with e ->
-        debug_exn (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket" domid) e;
-        remove domid
-
-    let qmp_event_handle domid qmp_event =
-      (* This function will be extended to handle qmp events *)
-      debug "Got QMP event, domain-%d: %s" domid qmp_event.event;
-      qmp_event.data >>= function
-      | RTC_CHANGE timeoffset ->
-        with_xs (fun xs ->
-          let timeoffset_key = sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid)) in
-          try
-            let rtc = xs.Xs.read timeoffset_key in
-            xs.Xs.write timeoffset_key Int64.(add timeoffset (of_string rtc) |> to_string)
-          with e -> error "Failed to process RTC_CHANGE for domain %d: %s" domid (Printexc.to_string e)
-        )
-
-    let qmp_event_thread () =
-      while true do
-        try
-          Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
-              Lookup.domid_of fd >>= fun domid ->
-              if is_flag_in then
-                Lookup.channel_of domid >>= fun c ->
-                try
-                  match Qmp_protocol.read c with
-                  | Event e -> qmp_event_handle domid e
-                  | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
-                with End_of_file ->
-                  debug "domain-%d: end of file, close qmp socket" domid;
-                  remove domid
-                | e ->
-                  debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
-                  remove domid
-              else begin
-                debug "EPOLL error on domain-%d, close qmp socket" domid;
-                remove domid
-              end
-            )
-        with e ->
-          debug_exn "Exception in qmp_event_thread: %s" e;
-      done
-
-    let _init_qmp_event =
-      Thread.create qmp_event_thread ()
-  end
-
   (* An example one:
      /usr/lib/xen/bin/qemu-dm -d 39 -m 256 -boot cd -serial pty -usb -usbdevice tablet -domain-name bee94ac1-8f97-42e0-bf77-5cb7a6b664ee -net nic,vlan=1,macaddr=00:16:3E:76:CE:44,model=rtl8139 -net tap,vlan=1,bridge=xenbr0 -vnc 39 -k en-us -vnclisten 127.0.0.1
   *)
@@ -2154,7 +2054,106 @@ module Backend = struct
 
     module Dm = struct
       module Event =  struct
-      end
+
+        module QMP_Event = struct
+          open Qmp
+          let (pipe_r, pipe_w) = Unix.pipe ()
+
+          let (>>=) m f = match m with | Some x -> f x | None -> ()
+          let (>>|) m f = match m with | Some _ -> () | None -> f ()
+
+          module Lookup = struct
+            let ftod, dtoc = Hashtbl.create 16, Hashtbl.create 16
+            let add c domid =
+              Hashtbl.replace ftod (Qmp_protocol.to_fd c) domid;
+              Hashtbl.replace dtoc domid c
+            let remove c domid =
+              Hashtbl.remove ftod (Qmp_protocol.to_fd c);
+              Hashtbl.remove dtoc domid
+            let domid_of fd = try Some (Hashtbl.find ftod fd) with Not_found -> None
+            let channel_of domid = try Some (Hashtbl.find dtoc domid) with Not_found -> None
+          end
+
+          module Monitor = struct
+            module Epoll = Core.Linux_ext.Epoll
+            module Flags = Core.Linux_ext.Epoll.Flags
+            let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
+            let wakeup () =  (* write single byte to wake up Monitor.wait *)
+              if Unix.write pipe_w " " 0 1 <> 1 then
+                debug "Pipe write error, failed to wake up qmp event thread"
+            let add m fd = Epoll.set m fd Flags.in_; wakeup ()
+            let remove m fd = Epoll.remove m fd; wakeup ()
+            let wait m = Epoll.wait m ~timeout:`Never
+            let with_event m fn = function
+              | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
+              | `Timeout -> debug "Shouldn't receive epoll timeout event in qmp_event_thread"
+          end
+          let m = Monitor.create ()
+
+          let monitor_path domid = Printf.sprintf "/var/run/xen/qmp-event-%d" domid
+          let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
+
+          let remove domid =
+            Lookup.channel_of domid >>= fun c ->
+            try 
+              finally
+                (fun () ->
+                   Lookup.remove c domid;
+                   Monitor.remove m (Qmp_protocol.to_fd c);
+                   debug "Removed QMP Event fd for domain %d" domid)
+                (fun () -> Qmp_protocol.close c)
+            with e -> debug_exn (Printf.sprintf "Got exception trying to remove qmp on domain-%d" domid) e
+
+          let add domid =
+            try
+              Lookup.channel_of domid >>| fun () ->
+              let c = Qmp_protocol.connect (monitor_path domid) in
+              Qmp_protocol.negotiate c;
+              Lookup.add c domid;
+              Monitor.add m (Qmp_protocol.to_fd c);
+              debug "Added QMP Event fd for domain %d" domid
+            with e ->
+              debug_exn (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket" domid) e;
+              remove domid
+
+          let qmp_event_handle domid qmp_event =
+            (* This function will be extended to handle qmp events *)
+            debug "Got QMP event, domain-%d: %s" domid qmp_event.event
+
+          let qmp_event_thread () =
+            Monitor.add m pipe_r;
+            while true do
+              try
+                Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
+                    match fd with
+                    | pipe when pipe = pipe_r ->
+                      if is_flag_in then ()
+                      else debug "Received unexpected epoll event on pipe_r in qmp_event_thread"
+                    | sock ->
+                      Lookup.domid_of sock >>= fun domid ->
+                      if is_flag_in then
+                        Lookup.channel_of domid >>= fun c ->
+                        try
+                          match Qmp_protocol.read c with
+                          | Event e -> qmp_event_handle domid e
+                          | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
+                        with End_of_file ->
+                          debug "domain-%d: end of file, close qmp socket" domid;
+                          remove domid
+                      else begin
+                        debug "EPOLL error on domain-%d, close qmp socket" domid;
+                        remove domid
+                      end
+                  )
+              with e ->
+                debug_exn "Exception in qmp_event_thread: %s" e;
+            done
+
+          let _init_qmp_event =
+            Thread.create qmp_event_thread ()
+        end (* QMP_Event *)
+      end (* Qemu_upstream_compat.Dm.Event *)
+
       let get_vnc_port ~xs domid =
         Dm.Common.get_vnc_port ~xs domid ~f:(fun () ->
           let open Qmp in
@@ -2198,12 +2197,12 @@ module Backend = struct
 
       let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel _ =
         let pid = Dm.Common.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel () in
-        Dm.QMP_Event.add domid;
+        Event.QMP_Event.add domid;
         pid
 
       let stop ~xs ~qemu_domid domid  =
         Dm.Common.stop ~xs ~qemu_domid domid;
-        Dm.QMP_Event.remove domid
+        Event.QMP_Event.remove domid
 
     end (* Backend.Qemu_upstream_compat.Dm *)
   end (* Backend.Qemu_upstream *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -35,11 +35,11 @@ open D
 module Profile = struct
   type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
   let fallback = Qemu_trad
+  let all = [ Qemu_trad; Qemu_upstream_compat; Qemu_upstream ]
   module Name = struct
     let qemu_trad            = "qemu-trad"
     let qemu_upstream_compat = "qemu-upstream-compat"
     let qemu_upstream        = "qemu-upstream"
-    let all = [ qemu_trad; qemu_upstream_compat; qemu_upstream ]
   end
   let wrapper_of = function
     | Qemu_trad            -> !Resources.qemu_dm_wrapper

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -21,17 +21,31 @@ exception Device_not_found
 
 exception Cdrom
 
+(** Definition of available qemu profiles, used by the qemu backend implementations *)
 module Profile: sig
 	type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+	(** available qemu profiles *)
+
+	(** the fallback profile in case an invalid profile string is provided to [of_string] *)
 	val fallback : t
+
+	(** all available profiles *)
 	val all: t list
+
+	(** Valid names for a profile, used to define valid values for VM.platform.device-model *)
 	module Name: sig
 		val qemu_trad: string
 		val qemu_upstream_compat: string
 		val qemu_upstream: string
 	end
+
+	(** [wrapper_of profile] returns the qemu wrapper script path of a profile *)
 	val wrapper_of: t -> string
+
+	(** [string_of  profile] returns the profile name of a profile *)
 	val string_of : t -> string
+
+	(** [of_string  profile_name] returns the profile of a profile name, and [fallback] if an invalid name is provided. *)
 	val of_string : string -> t
 end
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -24,11 +24,11 @@ exception Cdrom
 module Profile: sig
 	type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
 	val fallback : t
+	val all: t list
 	module Name: sig
 		val qemu_trad: string
 		val qemu_upstream_compat: string
 		val qemu_upstream: string
-		val all: string list
 	end
 	val wrapper_of: t -> string
 	val string_of : t -> string

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -21,6 +21,20 @@ exception Device_not_found
 
 exception Cdrom
 
+module Profile: sig
+	type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+	val fallback : t
+	module Name: sig
+		val qemu_trad: string
+		val qemu_upstream_compat: string
+		val qemu_upstream: string
+		val all: string list
+	end
+	val wrapper_of: t -> string
+	val string_of : t -> string
+	val of_string : string -> t
+end
+
 module Generic :
 sig
 	val rm_device_state : xs:Xenstore.Xs.xsh -> device -> unit
@@ -218,20 +232,6 @@ sig
 
 		extras: (string * string option) list;
 	}
-
-	module Profile: sig
-		type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
-		val fallback : t
-		module Name: sig
-			val qemu_trad: string
-			val qemu_upstream_compat: string
-			val qemu_upstream: string
-			val all: string list
-		end
-		val wrapper_of: t -> string
-		val string_of : t -> string
-		val of_string : string -> t
-	end
 
 	val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 	val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -249,6 +249,7 @@ sig
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 
 	val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+	val with_dirty_log: int -> f:(unit -> unit) -> unit
 end
 
 val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1128,15 +1128,9 @@ let write_libxc_record' (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_pa
 	)
 
 let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
-	finally
-		(fun() ->
-			if is_upstream_qemu domid
-			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log true));
-			write_libxc_record' task ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback)
-		(fun() ->
-			if is_upstream_qemu domid
-			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log false));
-		)
+	Device.Dm.with_dirty_log domid (fun () ->
+		write_libxc_record' task ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback
+	)
 
 let write_qemu_record domid uuid legacy_libxc fd =
 	let file = sprintf qemu_save_path domid in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -57,10 +57,10 @@ let choose_alternative kind default platformdata =
 	end else default
 
 (* We allow qemu-dm to be overriden via a platform flag *)
-let choose_qemu_dm x = Device.(Dm.Profile.wrapper_of (
+let choose_qemu_dm x = Device.(Profile.wrapper_of (
 	if List.mem_assoc _device_model x
-	then Dm.Profile.of_string (List.assoc _device_model x)
-	else Dm.Profile.fallback
+	then Profile.of_string (List.assoc _device_model x)
+	else Profile.fallback
 ))
 
 (* We allow xenguest to be overriden via a platform flag *)


### PR DESCRIPTION
With the introduction of upstream qemu, the xenopsd code was getting full of if-then conditions for upstream qemu, which was removing the modularity of the code, making it difficult in the future to remove the qemu-trad code.

This patch series adds an interface to handle code that has different behaviour between different device model profiles (eg. qemu-trad and qemu-upstream), so that we regain the modularity back and it's easier in the future to add more profiles.

Only the following functions that are currently using is_upstream_qemu() are affected by the series:
> xc/device.ml:608:    if is_upstream_qemu device.frontend.domid           -> Device.Vbd.qemu_media_change
> xc/device.ml:1611:    let is_upstream = is_upstream_qemu domid in        -> Device.Dm.get_vnc_port
> xc/device.ml:1905:    if is_upstream_qemu domid then                     -> Device.Dm.init_daemon
> xc/device.ml:2021:    if not (is_upstream_qemu domid)                    -> Device.Dm.suspend
> xc/device.ml:2037:          if is_upstream_qemu domid then               -> Device.Dm.stop
> xc/device.ml:2085:    if is_upstream_qemu domid then                     -> Device.Dm.maybe_write_pv_feature_flags
> 
> In write_libxc_record(), called by suspend():
> xc/domain.ml:1133:                      if is_upstream_qemu domid        
> xc/domain.ml:1137:                      if is_upstream_qemu domid

The interface was created so that it's easy to split more functions between the qemu profiles in the future as it may become necessary.