### PR TITLE
CP-24361:  abstract qemu interface: rebase 4 conflicting patches

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2140,7 +2140,8 @@ module Backend = struct
 
       let stop ~xs ~qemu_domid domid  =
         Dm_Common.stop ~xs ~qemu_domid domid;
-        QMP_Event.remove domid
+        QMP_Event.remove domid;
+        xs.Xs.rm (sprintf "/libxl/%d" domid)
 
       let with_dirty_log domid ~f =
         finally

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2004,7 +2004,6 @@ module Backend = struct
         (** Handler for the QMP events in upstream qemu *)
         module QMP_Event = struct
           open Qmp
-          let (pipe_r, pipe_w) = Unix.pipe ()
 
           let (>>=) m f = match m with | Some x -> f x | None -> ()
           let (>>|) m f = match m with | Some _ -> () | None -> f ()
@@ -2027,11 +2026,8 @@ module Backend = struct
             module Epoll = Core.Linux_ext.Epoll
             module Flags = Core.Linux_ext.Epoll.Flags
             let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
-            let wakeup () =  (* write single byte to wake up Monitor.wait *)
-              if Unix.write pipe_w " " 0 1 <> 1 then
-                debug "Pipe write error, failed to wake up qmp event thread"
-            let add m fd = Epoll.set m fd Flags.in_; wakeup ()
-            let remove m fd = Epoll.remove m fd; wakeup ()
+            let add m fd = Epoll.set m fd Flags.in_
+            let remove m fd = Epoll.remove m fd
             let wait m = Epoll.wait m ~timeout:`Never
             let with_event m fn = function
               | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
@@ -2070,29 +2066,23 @@ module Backend = struct
             debug "Got QMP event, domain-%d: %s" domid qmp_event.event
 
           let qmp_event_thread () =
-            Monitor.add m pipe_r;
             while true do
               try
                 Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
-                    match fd with
-                    | pipe when pipe = pipe_r ->
-                      if is_flag_in then ()
-                      else debug "Received unexpected epoll event on pipe_r in qmp_event_thread"
-                    | sock ->
-                      Lookup.domid_of sock >>= fun domid ->
-                      if is_flag_in then
-                        Lookup.channel_of domid >>= fun c ->
-                        try
-                          match Qmp_protocol.read c with
-                          | Event e -> qmp_event_handle domid e
-                          | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
-                        with End_of_file ->
-                          debug "domain-%d: end of file, close qmp socket" domid;
-                          remove domid
-                      else begin
-                        debug "EPOLL error on domain-%d, close qmp socket" domid;
-                        remove domid
-                      end
+                  Lookup.domid_of fd >>= fun domid ->
+                  if is_flag_in then
+                    Lookup.channel_of domid >>= fun c ->
+                    try
+                      match Qmp_protocol.read c with
+                      | Event e -> qmp_event_handle domid e
+                      | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
+                    with End_of_file ->
+                      debug "domain-%d: end of file, close qmp socket" domid;
+                      remove domid
+                  else begin
+                    debug "EPOLL error on domain-%d, close qmp socket" domid;
+                    remove domid
+                  end
                   )
               with e ->
                 debug_exn "Exception in qmp_event_thread: %s" e;

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2079,6 +2079,9 @@ module Backend = struct
                     with End_of_file ->
                       debug "domain-%d: end of file, close qmp socket" domid;
                       remove domid
+                    | e ->
+                      debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
+                      remove domid
                   else begin
                     debug "EPOLL error on domain-%d, close qmp socket" domid;
                     remove domid

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2063,7 +2063,16 @@ module Backend = struct
 
           let qmp_event_handle domid qmp_event =
             (* This function will be extended to handle qmp events *)
-            debug "Got QMP event, domain-%d: %s" domid qmp_event.event
+            debug "Got QMP event, domain-%d: %s" domid qmp_event.event;
+            qmp_event.data >>= function
+            | RTC_CHANGE timeoffset ->
+              with_xs (fun xs ->
+                let timeoffset_key = sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid)) in
+                try
+                  let rtc = xs.Xs.read timeoffset_key in
+                  xs.Xs.write timeoffset_key Int64.(add timeoffset (of_string rtc) |> to_string)
+                with e -> error "Failed to process RTC_CHANGE for domain %d: %s" domid (Printexc.to_string e)
+              )
 
           let qmp_event_thread () =
             while true do


### PR DESCRIPTION
The refactoring of the abstract qemu interface in xenopsd occurred at the same time as 4 patches were added to xenopsd, causing a merge conflict and requiring manual rebasing. 

This patch series rebases each of the conflicting patches.