### PR TITLE
CP-24744: Add VUSB plug/unplug

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -68,8 +68,8 @@ module type S = sig
 		val add: Vm.t -> unit
 		val remove: Vm.t -> unit
 		val create: Xenops_task.task_handle -> int64 option -> Vm.t -> unit
-		val build: ?restore_fd:Unix.file_descr -> Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> string list -> bool ->  unit (* XXX cancel *)
-		val create_device_model: Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> bool -> unit
+		val build: ?restore_fd:Unix.file_descr -> Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list-> string list -> bool ->  unit (* XXX cancel *)
+		val create_device_model: Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list -> bool -> unit
 		val destroy_device_model: Xenops_task.task_handle -> Vm.t -> unit
 		val destroy: Xenops_task.task_handle -> Vm.t -> unit
 		val pause: Xenops_task.task_handle -> Vm.t -> unit
@@ -139,6 +139,12 @@ module type S = sig
 	end
 	module VGPU : sig
 		val get_state: Vm.id -> Vgpu.t -> Vgpu.state
+	end
+	module VUSB :sig
+		val plug: Xenops_task.task_handle -> Vm.id -> Vusb.t -> unit
+		val unplug: Xenops_task.task_handle -> Vm.id -> Vusb.t -> unit
+		val get_state: Vm.id -> Vusb.t -> Vusb.state
+		val get_device_action_request: Vm.id -> Vusb.t -> device_action_request option
 	end
 	module UPDATES : sig
 		val get: Updates.id option -> int option -> Dynamic.barrier list * Dynamic.id list * Updates.id

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -114,6 +114,12 @@ end
 module VGPU = struct
 	let get_state _ _ = unplugged_vgpu
 end
+module VUSB = struct
+	let plug _ _ _  = unimplemented "VUSB.plug"
+	let unplug _ _ _ = unimplemented "VUSB.unplug"
+	let get_state _ _ = unplugged_vusb
+	let get_device_action_request _ _ = None
+end
 module UPDATES  = struct
 	let get _ _ = while true do Thread.delay 5. done; assert false
 end

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -584,6 +584,10 @@ let unplugged_vgpu = {
 	Vgpu.emulator_pid = None;
 }
 
+let unplugged_vusb = {
+	Vusb.plugged = false;
+}
+
 let remap_vdi vdi_map = function 
 	| Xenops_interface.VDI vdi -> 
 		if List.mem_assoc vdi vdi_map 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -270,5 +270,12 @@ module Backend: sig
 	val init : unit -> unit
 end
 
+module Vusb :
+sig
+	val vusb_plug : xs:Xenstore.Xs.xsh -> domid:Xenctrl.domid -> id:string -> hostbus:string -> hostport: string -> version: string-> unit
+	val vusb_unplug : xs:Xenstore.Xs.xsh -> domid:Xenctrl.domid -> id:string -> unit
+	val qom_list : xs:Xenstore.Xs.xsh -> domid:Xenctrl.domid -> string list
+end
+
 val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xl/xenops_server_xenlight.cppo.ml
+++ b/xl/xenops_server_xenlight.cppo.ml
@@ -684,6 +684,13 @@ module VGPU = struct
 	let get_state vm vgpu = failwith "Not implemented"
 end
 
+module VUSB = struct
+	let plug _ vm vusb = ()
+	let unplug _ vm vusb = ()
+	let get_state vm vusb = failwith "Not implemented"
+	let get_device_action_request vm vusb = failwith "Not implemented"
+end
+
 let set_active_device path active =
 	with_xs
 		(fun xs ->
@@ -2098,7 +2105,7 @@ module VM = struct
 	) Newest task vm
 
 	(*let create task memory_upper_bound vm vbds =*)
-	let build ?restore_fd task vm vbds vifs vgpus extras force =
+	let build ?restore_fd task vm vbds vifs vgpus vusbs extras force =
 		let memory_upper_bound = None in
 		let k = vm.Vm.id in
 
@@ -2619,7 +2626,7 @@ module VM = struct
 					error "VM = %s; read invalid save file signature: \"%s\"" vm.Vm.id read_signature;
 					raise Restore_signature_mismatch
 				end;
-				build ~restore_fd:fd task vm vbds vifs [] extras false
+				build ~restore_fd:fd task vm vbds vifs [] [] extras false
 			)
 		)
 


### PR DESCRIPTION
    To support usb passthrough feature, will use qemu to
    add/del usb devices to vm.

    1. Add vusbs to vm metadata.
    2. Add VUSB VUSB_DB module.
    3. Add VUSB_plug VUSB_unplug to atom operation.
