### PR TITLE
CA-267466: xenopsd does not reconnect to QMP events after xenopsd res…

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1986,6 +1986,11 @@ module Backend = struct
               )
 
           let qmp_event_thread () =
+            (* Add the existing qmp sockets first *)
+            Sys.readdir "/var/run/xen"
+            |> Array.to_list
+            |> List.iter (fun x -> try Scanf.sscanf x "qmp-event-%d" add with _ -> ());
+
             while true do
               try
                 Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1879,7 +1879,7 @@ module Backend = struct
           qmp_write device.frontend.domid qmp_cmd
         else
           try
-            let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" device.frontend.domid) in
+            let c = Qmp_protocol.connect (qmp_libxl_path device.frontend.domid) in
             finally
               (fun () ->
                  let fd_of_c = Qmp_protocol.to_fd c in
@@ -1946,7 +1946,7 @@ module Backend = struct
           end
           let m = Monitor.create ()
 
-          let monitor_path domid = Printf.sprintf "/var/run/xen/qmp-event-%d" domid
+          let monitor_path domid = qmp_event_path domid
           let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
 
           let remove domid =
@@ -1987,7 +1987,7 @@ module Backend = struct
 
           let qmp_event_thread () =
             (* Add the existing qmp sockets first *)
-            Sys.readdir "/var/run/xen"
+            Sys.readdir var_run_xen_path
             |> Array.to_list
             |> List.iter (fun x -> try Scanf.sscanf x "qmp-event-%d" add with _ -> ());
 

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1816,6 +1816,10 @@ module Backend = struct
     (** Dm functions that use the dispatcher to choose between different profile backends *)
     module Dm: sig
 
+      module Event: sig
+        val init : unit -> unit
+      end
+
       (** [get_vnc_port xenstore domid] returns the dom0 tcp port in which the vnc server for [domid] can be found *)
       val get_vnc_port : xs:Xenstore.Xs.xsh -> int -> int option
 
@@ -1846,6 +1850,11 @@ module Backend = struct
 
     (** Implementation of the Dm functions that use the dispatcher for the qemu-trad backend *)
     module Dm = struct
+
+      module Event = struct
+        let init () = ()
+      end
+
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
           (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
@@ -2016,9 +2025,11 @@ module Backend = struct
                 debug_exn "Exception in qmp_event_thread: %s" e;
             done
 
-          let _init_qmp_event =
-            Thread.create qmp_event_thread ()
         end (* Qemu_upstream_compat.Dm.QMP_Event *)
+
+        module Event = struct
+          let init () = ignore(Thread.create QMP_Event.qmp_event_thread ())
+        end
 
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
@@ -2094,6 +2105,9 @@ module Backend = struct
     | Profile.Qemu_upstream        -> (module Qemu_upstream        : Intf)
 
   let of_domid x = of_profile (Profile.of_domid x)
+
+  let init() =
+    Profile.all |> List.iter (fun p -> let module Q = (val of_profile p) in Q.Dm.Event.init() )
 end
 
 (*

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -266,5 +266,9 @@ sig
 	val with_dirty_log: int -> f:(unit -> unit) -> unit
 end
 
+module Backend: sig
+	val init : unit -> unit
+end
+
 val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -321,6 +321,10 @@ let qemu_restore_path : (_, _, _) format = "/var/lib/xen/qemu-resume.%d"
 let demu_save_path : (_, _, _) format = "/var/lib/xen/demu-save.%d"
 let demu_restore_path : (_, _, _) format = "/var/lib/xen/demu-resume.%d"
 
+let var_run_xen_path = "/var/run/xen"
+let qmp_libxl_path = (sprintf "%s/qmp-libxl-%d") var_run_xen_path
+let qmp_event_path = (sprintf "%s/qmp-event-%d") var_run_xen_path
+
 (* Where qemu writes its state and is signalled *)
 let device_model_path ~qemu_domid domid = sprintf "/local/domain/%d/device-model/%d" qemu_domid domid
 
@@ -331,13 +335,13 @@ let xenops_vgpu_path domid devid =
 
 let is_upstream_qemu domid =
 	try
-		with_xs (fun xs -> xs.Xs.read (Printf.sprintf "/libxl/%d/dm-version" domid)) = "qemu_xen"
+		with_xs (fun xs -> xs.Xs.read (sprintf "/libxl/%d/dm-version" domid)) = "qemu_xen"
 	with _ -> false
 
 let qmp_write_and_read domid ?(read_result=true) cmd  =
   try
     let open Qmp in
-    let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" domid) in
+    let c = Qmp_protocol.connect (qmp_libxl_path domid) in
     finally
       (fun () ->
         Qmp_protocol.negotiate c;

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -92,6 +92,10 @@ val qemu_restore_path: (int -> 'a, 'b, 'a) format
 val demu_save_path: (int -> 'a, 'b, 'a) format
 val demu_restore_path: (int -> 'a, 'b, 'a) format
 
+val var_run_xen_path: string
+val qmp_libxl_path: int -> string
+val qmp_event_path: int -> string
+
 (** Directory in xenstore where qemu writes its state *)
 val device_model_path: qemu_domid:int -> int -> string
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -3089,6 +3089,7 @@ let init () =
 			xs.Xs.setperms xe_key { Xs_protocol.ACL.owner = 0; other = Xs_protocol.ACL.READ; acl = [] }
 	);
 
+	Device.Backend.init();
 	debug "xenstore is responding to requests";
 	let () = Watcher.create_watcher_thread () in
 	()

--- a/xc/xenops_xc_main.ml
+++ b/xc/xenops_xc_main.ml
@@ -42,7 +42,7 @@ let check_domain0_uuid () =
 	forget_client ()
 
 let make_var_run_xen () =
-	Stdext.Unixext.mkdir_rec "/var/run/xen" 0o0755
+	Stdext.Unixext.mkdir_rec Device_common.var_run_xen_path 0o0755
 
 (* Start the program with the xen backend *)
 let _ =


### PR DESCRIPTION
…tart

After restarting xenopsd, QMP events for any VM already running are not
received anymore.

This patch scans the '/var/run/xen' directory to find the existing qmp
socket and add them before the qmp thread enters loop.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>