### PR TITLE
CP-24774: use QMP event XEN_PLATFORM_PV_DRIVER_INFO to set HVM Linux feature flags

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1984,8 +1984,8 @@ module Backend = struct
           let qmp_event_handle domid qmp_event =
             (* This function will be extended to handle qmp events *)
             debug "Got QMP event, domain-%d: %s" domid qmp_event.event;
-            qmp_event.data >>= function
-            | RTC_CHANGE timeoffset ->
+
+            let rtc_change timeoffset =
               with_xs (fun xs ->
                 let timeoffset_key = sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid)) in
                 try
@@ -1993,6 +1993,9 @@ module Backend = struct
                   xs.Xs.write timeoffset_key Int64.(add timeoffset (of_string rtc) |> to_string)
                 with e -> error "Failed to process RTC_CHANGE for domain %d: %s" domid (Printexc.to_string e)
               )
+            in
+            qmp_event.data >>= function
+            | RTC_CHANGE timeoffset -> rtc_change timeoffset
 
           let qmp_event_thread () =
             debug "Starting QMP_Event thread";

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1823,9 +1823,6 @@ module Backend = struct
       (** [get_vnc_port xenstore domid] returns the dom0 tcp port in which the vnc server for [domid] can be found *)
       val get_vnc_port : xs:Xenstore.Xs.xsh -> int -> int option
 
-      (** [maybe_write_pv_feature_flags xenstore domid] writes the necessary pv feature flags to indicate that the domid supports clean shutdown, reboot, suspend *)
-      val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> int -> unit
-
       (** [suspend task xenstore qemu_domid xc] suspends a domain *)
       val suspend: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 
@@ -1859,8 +1856,6 @@ module Backend = struct
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
           (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
         )
-
-      let maybe_write_pv_feature_flags ~xs domid = ()
 
       let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =
         Dm_Common.suspend task ~xs ~qemu_domid domid;
@@ -1994,8 +1989,25 @@ module Backend = struct
                 with e -> error "Failed to process RTC_CHANGE for domain %d: %s" domid (Printexc.to_string e)
               )
             in
+
+            let xen_platform_pv_driver_info pv_info =
+              with_xs (fun xs ->
+                let is_hvm_linux { product_num; build_num } =
+                  let _XEN_IOPORT_LINUX_PRODNUM = 3 in (* from Linux include/xen/platform_pci.h *)
+                  (product_num = _XEN_IOPORT_LINUX_PRODNUM) && (build_num <= 0xff)
+                in
+                if is_hvm_linux pv_info then
+                begin
+                  let write_local_domain prefix x = xs.Xs.write (Printf.sprintf "/local/domain/%d/%s%s" domid prefix x) "1" in
+                  List.iter (write_local_domain "control/feature-") ["suspend"; "shutdown"; "vcpu-hotplug"];
+                  List.iter (write_local_domain "data/") ["updated"]
+                end
+              )
+            in
+
             qmp_event.data >>= function
-            | RTC_CHANGE timeoffset -> rtc_change timeoffset
+            | RTC_CHANGE timeoffset         -> rtc_change timeoffset
+            | XEN_PLATFORM_PV_DRIVER_INFO x -> xen_platform_pv_driver_info x
 
           let qmp_event_thread () =
             debug "Starting QMP_Event thread";
@@ -2048,28 +2060,6 @@ module Backend = struct
           | Some qmp_message -> parse_qmp_message qmp_message
           | None -> debug "Fail to get result after sending Qmp message: %s" (string_of_message qmp_cmd); None
         )
-
-      let is_hvm_linux domid =
-        let _XEN_IOPORT_LINUX_PRODNUM = 3 in (* from Linux include/xen/platform_pci.h *)
-        let error x = error "%s" x; Result.Error x in
-        try
-          let open Qmp in
-          match qmp_write_and_read domid (Command (None, Query_xen_platform_pv_driver_info)) with
-          | Some (Success (None, Xen_platform_pv_driver_info { product_num; build_num })) ->
-            Result.Ok ((product_num = _XEN_IOPORT_LINUX_PRODNUM) && (build_num <= 0xff))
-          | Some x ->
-            error (Printf.sprintf "Unexpected QMP response: %s" (Qmp.string_of_message x))
-          | None -> error "No QMP response for Query_xen_platform_pv_driver_info"
-        with e ->
-          error (Printf.sprintf "Exception attempting to obtain Linux product_id and build_number: %s" (Printexc.to_string e))
-
-      let maybe_write_pv_feature_flags ~xs domid =
-        match is_hvm_linux domid with
-        | Result.Ok true ->
-          let write_local_domain prefix x = xs.Xs.write (Printf.sprintf "/local/domain/%d/%s%s" domid prefix x) "1" in
-          List.iter (write_local_domain "control/feature-") ["suspend"; "shutdown"; "vcpu-hotplug"];
-          List.iter (write_local_domain "data/") ["updated"]
-        | _ -> ()
 
       let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =
         Dm_Common.suspend task ~xs ~qemu_domid domid;
@@ -2155,10 +2145,6 @@ module Dm = struct
   let stop ~xs ~qemu_domid domid  =
     let module Q = (val Backend.of_domid domid) in
     Q.Dm.stop ~xs ~qemu_domid domid
-
-  let maybe_write_pv_feature_flags ~xs domid =
-    let module Q = (val Backend.of_domid domid) in
-    Q.Dm.maybe_write_pv_feature_flags ~xs domid
 
   let with_dirty_log domid ~f =
     let module Q = (val Backend.of_domid domid) in

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2005,9 +2005,10 @@ module Backend = struct
               )
             in
 
-            qmp_event.data >>= function
-            | RTC_CHANGE timeoffset         -> rtc_change timeoffset
-            | XEN_PLATFORM_PV_DRIVER_INFO x -> xen_platform_pv_driver_info x
+            qmp_event.data |> function
+            | Some (RTC_CHANGE timeoffset)         -> rtc_change timeoffset
+            | Some (XEN_PLATFORM_PV_DRIVER_INFO x) -> xen_platform_pv_driver_info x
+            | _ -> () (* unhandled QMP events *)
 
           let qmp_event_thread () =
             debug "Starting QMP_Event thread";

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1999,7 +1999,7 @@ module Backend = struct
                 if is_hvm_linux pv_info then
                 begin
                   let write_local_domain prefix x = xs.Xs.write (Printf.sprintf "/local/domain/%d/%s%s" domid prefix x) "1" in
-                  List.iter (write_local_domain "control/feature-") ["suspend"; "shutdown"; "vcpu-hotplug"];
+                  List.iter (write_local_domain "control/feature-") ["suspend"; "poweroff"; "reboot"; "vcpu-hotplug"];
                   List.iter (write_local_domain "data/") ["updated"]
                 end
               )

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -262,7 +262,6 @@ sig
 	val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 
-	val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
 	val with_dirty_log: int -> f:(unit -> unit) -> unit
 end
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2757,7 +2757,6 @@ module Actions = struct
 							let non_persistent = { non_persistent with VmExtra.pv_drivers_detected = true } in
 							debug "VM = %s; found PV driver evidence on %s (value = %s)" vm path value;
 							DB.write vm { VmExtra.persistent; non_persistent };
-							Device.Dm.maybe_write_pv_feature_flags ~xs domid;
 							Updates.add (Dynamic.Vm vm) internal_updates
 						end
 					with Xs_protocol.Enoent _ ->


### PR DESCRIPTION
This new event replaces the reliance on the xenops_server_xen.ml function `maybe_update_pv_drivers_detected` to detect the PV drivers connected state 4 event to decide when to set the HVM Linux feature flags in xenstore. Relying on the QMP event XEN_PLATFORM_PV_DRIVER_INFO to set the HVM Linux feature flags makes it completely backwards-compatible with qemu-trad.                                                                                           
                                                                                           
The improvement above is also an opportunity to remove the public function `maybe_write_pv_feature_flags`, which was only added to permit it to be called from the function `maybe_update_pv_drivers_detected` in xenops_server_xen.ml. 

The last commit replaces the control/feature flags according to the xen upstream design                                                                                                     
at http://xenbits.xen.org/gitweb/?p=xen.git;a=blob;f=docs/misc/xenstore-paths.markdown;h=7be2592c74799fb0a1303ce7ab48613a84ffce21;hb=HEAD                                                                                                                                                                         
- `shutdown` becomes `poweroff`                                                                                                                                                   
- `reboot` is added           

This PR depends on https://github.com/xapi-project/ocaml-qmp/pull/25