### PR TITLE
Merge support for qemu-upstream into master

### DIFF
--- a/_oasis.in
+++ b/_oasis.in
@@ -159,7 +159,8 @@ Executable xenopsd_xc_main
     sexplib,
     xcp-inventory,
     ezxenstore,
-    profiling
+    profiling,
+    qmp
   CSources:           fsync_stubs.c, xenctrlext_stubs.c
 
 Executable xenopsd_simulator

--- a/_oasis.in
+++ b/_oasis.in
@@ -86,7 +86,8 @@ Library xenopsd
     xenstore.unix,
     xenstore_transport,
     xenstore_transport.unix,
-    oclock
+    oclock,
+    core
   CSources:	      sockopt_stubs.c
 
 Executable dbgring

--- a/lib/resources.ml
+++ b/lib/resources.ml
@@ -15,6 +15,7 @@
 let network_conf = ref "/etc/xcp/network.conf"
 let qemu_dm_wrapper = ref "qemu-dm-wrapper"
 let qemu_system_i386 = ref "qemu-system-i386"
+let upstream_compat_qemu_dm_wrapper = ref "qemu-wrapper"
 let chgrp = ref "chgrp"
 let modprobe = ref "/usr/sbin/modprobe"
 let rmmod = ref "/usr/sbin/rmmod"
@@ -31,6 +32,7 @@ let hvm_guests = [
 	R_OK, "hvmloader", hvmloader, "path to the hvmloader binary for HVM guests";
 	X_OK, "qemu-dm-wrapper", qemu_dm_wrapper, "path to the qemu-dm-wrapper script";
 	X_OK, "qemu-system-i386", qemu_system_i386, "path to the qemu-system-i386 binary";
+	X_OK, "upstream-compat-qemu-dm-wrapper", upstream_compat_qemu_dm_wrapper, "path to the upstream compat qemu-dm-wrapper script";
 ]
 
 let pv_guests = [

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -844,7 +844,7 @@ let rec atomics_of_operation = function
 			VM_set_domain_action_request(id, None)
 		]
 	| VM_shutdown (id, timeout) ->
-		(Opt.default [] (Opt.map (fun x -> [ VM_shutdown_domain(id, Halt, x) ]) timeout)
+		(Opt.default [] (Opt.map (fun x -> [ VM_shutdown_domain(id, PowerOff, x) ]) timeout)
 		) @ simplify ([
 			(* At this point we have a shutdown domain (ie Needs_poweroff) *)
 			VM_destroy_device_model id;

--- a/opam
+++ b/opam
@@ -37,4 +37,5 @@ depends: [
   "xapi-inventory"
   "ezxenstore"
   "bisect_ppx"
+  "core"
 ]

--- a/scripts/qemu-dm-wrapper
+++ b/scripts/qemu-dm-wrapper
@@ -61,43 +61,21 @@ def enable_core_dumps():
         setrlimit(RLIMIT_CORE, (limit, hardlimit))
         return limit
 
-def qemu_dm_upstream():
-    return '/usr/lib64/xen/bin/qemu-wrapper'
-
-def qemu_dm_trad():
+def main(argv):
+    qemu_env = os.environ
     qemu_dm_list = ['/usr/lib/xen/bin/qemu-dm',
                     '/usr/lib64/xen/bin/qemu-dm',
                     '/usr/lib/xen-4.1/bin/qemu-dm',
                     '/usr/lib/xen-4.2/bin/qemu-dm',
                     '/usr/lib/xen-4.4/bin/qemu-dm']
+    qemu_dm = None
     for loc in qemu_dm_list:
         if os.path.exists(loc):
-            return loc
-    raise Exception("Cannot find qemu-dm in %s" % qemu_dm_list)
+            qemu_dm = loc
+    if qemu_dm is None:
+        raise Exception("Cannot find qemu-dm in %s" % qemu_dm_list)
 
-def qemu_dm_path(domid, argv):
-    up_qemu = 0
-
-    try:
-        qemu_v = xenstore_read("/local/domain/%d/vm-data/up-qemu" % domid)
-    except RuntimeError:
-        qemu_v = "0"
-    if qemu_v == "1":
-        up_qemu = 1
-    elif qemu_v == "2":
-        for arg in argv:
-            if arg == "-loadvm":
-                up_qemu = 1
-
-    if up_qemu:
-        return qemu_dm_upstream()
-    else:
-        return qemu_dm_trad()
-
-def main(argv):
-    qemu_env = os.environ
     domid = int(argv[1])
-    qemu_dm = qemu_dm_path(domid, argv)
     qemu_args = ['qemu-dm-%d'%domid] + argv[2:]
 
     # Workaround http://unix.stackexchange.com/questions/39495/domain-ubuntu-hvm-does-not-exists-xen-ubuntu-hvm-guest-os-installation-pro

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2034,8 +2034,10 @@ module Dm = struct
     let stop_qemu () = (match (Qemu.pid ~xs domid) with
         | None -> () (* nothing to do *)
         | Some qemu_pid ->
-          if is_upstream_qemu domid then
+          if is_upstream_qemu domid then begin
             QMP_Event.remove domid;
+            xs.Xs.rm (sprintf "/libxl/%d" domid)
+          end;
           debug "qemu-dm: stopping qemu-dm with SIGTERM (domid = %d)" domid;
           let open Generic in
           best_effort "signalling that qemu is ending as expected, mask further signals"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1505,6 +1505,9 @@ module Dm = struct
                 with End_of_file ->
                   debug "domain-%d: end of file, close qmp socket" domid;
                   remove domid
+                | e ->
+                  debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
+                  remove domid
               else begin
                 debug "EPOLL error on domain-%d, close qmp socket" domid;
                 remove domid

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2140,7 +2140,8 @@ module Backend = struct
 
       let stop ~xs ~qemu_domid domid  =
         Dm_Common.stop ~xs ~qemu_domid domid;
-        QMP_Event.remove domid
+        QMP_Event.remove domid;
+        xs.Xs.rm (sprintf "/libxl/%d" domid)
 
       let with_dirty_log domid ~f =
         finally

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1904,11 +1904,23 @@ module Backend = struct
 
     (** Dm functions that use the dispatcher to choose between different profile backends *)
     module Dm: sig
+
+      (** [get_vnc_port xenstore domid] returns the dom0 tcp port in which the vnc server for [domid] can be found *)
       val get_vnc_port : xs:Xenstore.Xs.xsh -> int -> int option
+
+      (** [maybe_write_pv_feature_flags xenstore domid] writes the necessary pv feature flags to indicate that the domid supports clean shutdown, reboot, suspend *)
       val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> int -> unit
+
+      (** [suspend task xenstore qemu_domid xc] suspends a domain *)
       val suspend: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
+
+      (** [init_daemon task path args name domid xenstore ready_path ready_val timeout cancel] returns a forkhelper pid after starting the qemu daemon in dom0 *)
       val init_daemon: task:Xenops_task.task_handle -> path:string -> args:string list -> name:string -> domid:int -> xs:Xenstore.Xs.xsh -> ready_path:Watch.path -> ?ready_val:string -> timeout:float -> cancel:Cancel_utils.key -> 'a -> Forkhelpers.pidty
+
+      (** [stop xenstore qemu_domid domid] stops a domain *)
       val stop: xs:Xenstore.Xs.xsh -> qemu_domid:int -> int -> unit
+
+      (** [with_dirty_log domid f] executes f in a context where the dirty log is enabled *)
       val with_dirty_log: int -> f:(unit -> unit) -> unit
     end
   end

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -607,12 +607,36 @@ let qemu_media_change ~xs device _type params =
 
 	if is_upstream_qemu device.frontend.domid
 	then begin
+		let open Qmp in
 		let cd = "ide1-cd1" in
-		let qmp_cmd =
-			if params = ""
-			then (Qmp.Command(None, Qmp.Eject (cd, Some true)))
-			else (Qmp.Command(None, Qmp.Change (cd, params, None))) in
-		qmp_write device.frontend.domid qmp_cmd
+		match params with
+		| "" ->
+			let qmp_cmd = Command(None, Eject (cd, Some true)) in
+			qmp_write device.frontend.domid qmp_cmd
+		| _ ->
+			try
+				let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" device.frontend.domid) in
+				let fd_of_c = Qmp_protocol.to_fd c in
+				let fd_of_cd = Unix.openfile params [ Unix.O_RDONLY ] 0o640 in
+				finally
+					(fun () -> ignore(Fd_send_recv.send_fd fd_of_c " " 0 1 [] fd_of_cd))
+					(fun () -> Unix.close fd_of_cd);
+				
+				let qmp_cmd = Command (None, Add_fd (Fd_send_recv.int_of_fd fd_of_cd)) in
+				Qmp_protocol.negotiate c;
+				Qmp_protocol.write c qmp_cmd;
+				let new_fd = match Qmp_protocol.read c with
+				| Success (None, Fd_info fd_info) -> fd_info.fd
+				| _ -> raise (Internal_error (Printf.sprintf "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd)))
+				in
+				let cmd = Command (None, Blockdev_change_medium (cd, "/dev/fd/" ^ (string_of_int new_fd))) in
+				Qmp_protocol.write c cmd;
+				Qmp_protocol.close c
+			with
+			| Unix.Unix_error(Unix.ECONNREFUSED, "connect", p) -> raise(Internal_error (Printf.sprintf "Failed to connnect qmp socket: %s" p))
+			| Unix.Unix_error(Unix.ENOENT, "open", p) -> raise(Internal_error (Printf.sprintf "Failed to open CD Image: %s" p))
+			| Internal_error(_) as e -> raise e
+			| e -> raise(Internal_error (Printf.sprintf "Get unexpected error trying to change CD: %s" (Printexc.to_string e)))
 	end
 
 let media_eject ~xs device =

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1986,6 +1986,11 @@ module Backend = struct
               )
 
           let qmp_event_thread () =
+            (* Add the existing qmp sockets first *)
+            Sys.readdir "/var/run/xen"
+            |> Array.to_list
+            |> List.iter (fun x -> try Scanf.sscanf x "qmp-event-%d" add with _ -> ());
+
             while true do
               try
                 Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1896,8 +1896,6 @@ module Backend = struct
       val qemu_media_change : xs:Xenstore.Xs.xsh -> device -> string -> string -> unit
     end
     module Dm: sig
-      module Event: sig
-      end
       val get_vnc_port : xs:Xenstore.Xs.xsh -> int -> int option
       val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> int -> unit
       val suspend: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
@@ -1912,8 +1910,6 @@ module Backend = struct
       let qemu_media_change = Vbd_Common.qemu_media_change
     end
     module Dm = struct
-      module Event =  struct
-      end
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
           (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
@@ -1975,7 +1971,6 @@ module Backend = struct
     end (* Backend.Qemu_upstream_compat.Vbd *)
 
     module Dm = struct
-      module Event =  struct
 
         module QMP_Event = struct
           open Qmp
@@ -2073,8 +2068,7 @@ module Backend = struct
 
           let _init_qmp_event =
             Thread.create qmp_event_thread ()
-        end (* QMP_Event *)
-      end (* Qemu_upstream_compat.Dm.Event *)
+        end (* Qemu_upstream_compat.Dm.QMP_Event *)
 
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
@@ -2119,12 +2113,12 @@ module Backend = struct
 
       let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel _ =
         let pid = Dm_Common.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel () in
-        Event.QMP_Event.add domid;
+        QMP_Event.add domid;
         pid
 
       let stop ~xs ~qemu_domid domid  =
         Dm_Common.stop ~xs ~qemu_domid domid;
-        Event.QMP_Event.remove domid
+        QMP_Event.remove domid
 
       let with_dirty_log domid ~f =
         finally

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1879,7 +1879,7 @@ module Backend = struct
           qmp_write device.frontend.domid qmp_cmd
         else
           try
-            let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" device.frontend.domid) in
+            let c = Qmp_protocol.connect (qmp_libxl_path device.frontend.domid) in
             finally
               (fun () ->
                  let fd_of_c = Qmp_protocol.to_fd c in
@@ -1946,7 +1946,7 @@ module Backend = struct
           end
           let m = Monitor.create ()
 
-          let monitor_path domid = Printf.sprintf "/var/run/xen/qmp-event-%d" domid
+          let monitor_path domid = qmp_event_path domid
           let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
 
           let remove domid =
@@ -1987,7 +1987,7 @@ module Backend = struct
 
           let qmp_event_thread () =
             (* Add the existing qmp sockets first *)
-            Sys.readdir "/var/run/xen"
+            Sys.readdir var_run_xen_path
             |> Array.to_list
             |> List.iter (fun x -> try Scanf.sscanf x "qmp-event-%d" add with _ -> ());
 

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2133,7 +2133,7 @@ module Backend = struct
     end (* Backend.Qemu_upstream_compat.Dm *)
   end (* Backend.Qemu_upstream *)
 
-  (* Until stage 4, qemu_upstream behaves as qemu_upstream_compat *)
+  (* Until the stage 4 defined in the qemu upstream design is implemented, qemu_upstream behaves as qemu_upstream_compat *)
   module Qemu_upstream  = Qemu_upstream_compat
 
   let of_profile p = match p with

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2167,7 +2167,7 @@ module Dm = struct
         )
     | _ -> failwith "Unsupported vGPU configuration"
 
-  let __start (task: Xenops_task.task_handle) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready_timeout) l info domid =
+  let __start (task: Xenops_task.task_handle) ~xs ~dm ?(timeout = !Xenopsd.qemu_dm_ready_timeout) l info domid =
     debug "Device.Dm.start domid=%d args: [%s]" domid (String.concat " " l);
 
     (* start vgpu emulation if appropriate *)
@@ -2185,7 +2185,7 @@ module Dm = struct
     let ready_path =
       Printf.sprintf "/local/domain/%d/device-model/%d/state" qemu_domid domid in
     let cancel = Cancel_utils.Qemu (qemu_domid, domid) in
-    let qemu_pid = init_daemon ~task ~path:dmpath ~args ~name:"qemu-dm" ~domid
+    let qemu_pid = init_daemon ~task ~path:(Profile.wrapper_of dm) ~args ~name:"qemu-dm" ~domid
         ~xs ~ready_path ~ready_val:"running" ~timeout ~cancel () in
     match !Xenopsd.action_after_qemu_crash with
     | None ->
@@ -2221,17 +2221,17 @@ module Dm = struct
               xs.Xs.write (Qemu.pid_path_signal domid) crash_reason
         ))
 
-  let start (task: Xenops_task.task_handle) ~xs ~dmpath ?timeout info domid =
+  let start (task: Xenops_task.task_handle) ~xs ~dm ?timeout info domid =
     let l = cmdline_of_info info false domid in
-    __start task ~xs ~dmpath ?timeout l info domid
+    __start task ~xs ~dm ?timeout l info domid
 
-  let restore (task: Xenops_task.task_handle) ~xs ~dmpath ?timeout info domid =
+  let restore (task: Xenops_task.task_handle) ~xs ~dm ?timeout info domid =
     let l = cmdline_of_info info true domid in
-    __start task ~xs ~dmpath ?timeout l info domid
+    __start task ~xs ~dm ?timeout l info domid
 
-  let start_vnconly (task: Xenops_task.task_handle) ~xs ~dmpath ?timeout info domid =
+  let start_vnconly (task: Xenops_task.task_handle) ~xs ~dm ?timeout info domid =
     let l = vnconly_cmdline ~info domid in
-    __start task ~xs ~dmpath ?timeout l info domid
+    __start task ~xs ~dm ?timeout l info domid
 
 end (* Dm *)
 

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1454,106 +1454,6 @@ let can_surprise_remove ~xs (x: device) = Generic.can_surprise_remove ~xs x
 
 module Dm = struct
 
-  module QMP_Event = struct
-    open Qmp
-
-    let (>>=) m f = match m with | Some x -> f x | None -> ()
-    let (>>|) m f = match m with | Some _ -> () | None -> f ()
-
-    module Lookup = struct
-      let ftod, dtoc = Hashtbl.create 16, Hashtbl.create 16
-      let add c domid =
-        Hashtbl.replace ftod (Qmp_protocol.to_fd c) domid;
-        Hashtbl.replace dtoc domid c
-      let remove c domid =
-        Hashtbl.remove ftod (Qmp_protocol.to_fd c);
-        Hashtbl.remove dtoc domid
-      let domid_of fd = try Some (Hashtbl.find ftod fd) with Not_found -> None
-      let channel_of domid = try Some (Hashtbl.find dtoc domid) with Not_found -> None
-    end
-
-    module Monitor = struct
-      module Epoll = Core.Linux_ext.Epoll
-      module Flags = Core.Linux_ext.Epoll.Flags
-      let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
-      let add m fd = Epoll.set m fd Flags.in_
-      let remove m fd = Epoll.remove m fd
-      let wait m = Epoll.wait m ~timeout:`Never
-      let with_event m fn = function
-        | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
-        | `Timeout -> debug "Shouldn't receive epoll timeout event in qmp_event_thread"
-    end
-    let m = Monitor.create ()
-
-    let monitor_path domid = Printf.sprintf "/var/run/xen/qmp-event-%d" domid
-    let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
-
-    let remove domid =
-      Lookup.channel_of domid >>= fun c ->
-      try 
-        finally
-          (fun () ->
-             Lookup.remove c domid;
-             Monitor.remove m (Qmp_protocol.to_fd c);
-             debug "Removed QMP Event fd for domain %d" domid)
-          (fun () -> Qmp_protocol.close c)
-      with e -> debug_exn (Printf.sprintf "Got exception trying to remove qmp on domain-%d" domid) e
-
-    let add domid =
-      try
-        Lookup.channel_of domid >>| fun () ->
-        let c = Qmp_protocol.connect (monitor_path domid) in
-        Qmp_protocol.negotiate c;
-        Lookup.add c domid;
-        Monitor.add m (Qmp_protocol.to_fd c);
-        debug "Added QMP Event fd for domain %d" domid
-      with e ->
-        debug_exn (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket" domid) e;
-        remove domid
-
-    let qmp_event_handle domid qmp_event =
-      (* This function will be extended to handle qmp events *)
-      debug "Got QMP event, domain-%d: %s" domid qmp_event.event;
-      qmp_event.data >>= function
-      | RTC_CHANGE timeoffset ->
-        with_xs (fun xs ->
-          let timeoffset_key = sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid)) in
-          try
-            let rtc = xs.Xs.read timeoffset_key in
-            xs.Xs.write timeoffset_key Int64.(add timeoffset (of_string rtc) |> to_string)
-          with e -> error "Failed to process RTC_CHANGE for domain %d: %s" domid (Printexc.to_string e)
-        )
-
-    let qmp_event_thread () =
-      while true do
-        try
-          Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
-              Lookup.domid_of fd >>= fun domid ->
-              if is_flag_in then
-                Lookup.channel_of domid >>= fun c ->
-                try
-                  match Qmp_protocol.read c with
-                  | Event e -> qmp_event_handle domid e
-                  | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
-                with End_of_file ->
-                  debug "domain-%d: end of file, close qmp socket" domid;
-                  remove domid
-                | e ->
-                  debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
-                  remove domid
-              else begin
-                debug "EPOLL error on domain-%d, close qmp socket" domid;
-                remove domid
-              end
-            )
-        with e ->
-          debug_exn "Exception in qmp_event_thread: %s" e;
-      done
-
-    let _init_qmp_event =
-      Thread.create qmp_event_thread ()
-  end
-
   (* An example one:
      /usr/lib/xen/bin/qemu-dm -d 39 -m 256 -boot cd -serial pty -usb -usbdevice tablet -domain-name bee94ac1-8f97-42e0-bf77-5cb7a6b664ee -net nic,vlan=1,macaddr=00:16:3E:76:CE:44,model=rtl8139 -net tap,vlan=1,bridge=xenbr0 -vnc 39 -k en-us -vnclisten 127.0.0.1
   *)
@@ -2154,7 +2054,106 @@ module Backend = struct
 
     module Dm = struct
       module Event =  struct
-      end
+
+        module QMP_Event = struct
+          open Qmp
+          let (pipe_r, pipe_w) = Unix.pipe ()
+
+          let (>>=) m f = match m with | Some x -> f x | None -> ()
+          let (>>|) m f = match m with | Some _ -> () | None -> f ()
+
+          module Lookup = struct
+            let ftod, dtoc = Hashtbl.create 16, Hashtbl.create 16
+            let add c domid =
+              Hashtbl.replace ftod (Qmp_protocol.to_fd c) domid;
+              Hashtbl.replace dtoc domid c
+            let remove c domid =
+              Hashtbl.remove ftod (Qmp_protocol.to_fd c);
+              Hashtbl.remove dtoc domid
+            let domid_of fd = try Some (Hashtbl.find ftod fd) with Not_found -> None
+            let channel_of domid = try Some (Hashtbl.find dtoc domid) with Not_found -> None
+          end
+
+          module Monitor = struct
+            module Epoll = Core.Linux_ext.Epoll
+            module Flags = Core.Linux_ext.Epoll.Flags
+            let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
+            let wakeup () =  (* write single byte to wake up Monitor.wait *)
+              if Unix.write pipe_w " " 0 1 <> 1 then
+                debug "Pipe write error, failed to wake up qmp event thread"
+            let add m fd = Epoll.set m fd Flags.in_; wakeup ()
+            let remove m fd = Epoll.remove m fd; wakeup ()
+            let wait m = Epoll.wait m ~timeout:`Never
+            let with_event m fn = function
+              | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
+              | `Timeout -> debug "Shouldn't receive epoll timeout event in qmp_event_thread"
+          end
+          let m = Monitor.create ()
+
+          let monitor_path domid = Printf.sprintf "/var/run/xen/qmp-event-%d" domid
+          let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
+
+          let remove domid =
+            Lookup.channel_of domid >>= fun c ->
+            try 
+              finally
+                (fun () ->
+                   Lookup.remove c domid;
+                   Monitor.remove m (Qmp_protocol.to_fd c);
+                   debug "Removed QMP Event fd for domain %d" domid)
+                (fun () -> Qmp_protocol.close c)
+            with e -> debug_exn (Printf.sprintf "Got exception trying to remove qmp on domain-%d" domid) e
+
+          let add domid =
+            try
+              Lookup.channel_of domid >>| fun () ->
+              let c = Qmp_protocol.connect (monitor_path domid) in
+              Qmp_protocol.negotiate c;
+              Lookup.add c domid;
+              Monitor.add m (Qmp_protocol.to_fd c);
+              debug "Added QMP Event fd for domain %d" domid
+            with e ->
+              debug_exn (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket" domid) e;
+              remove domid
+
+          let qmp_event_handle domid qmp_event =
+            (* This function will be extended to handle qmp events *)
+            debug "Got QMP event, domain-%d: %s" domid qmp_event.event
+
+          let qmp_event_thread () =
+            Monitor.add m pipe_r;
+            while true do
+              try
+                Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
+                    match fd with
+                    | pipe when pipe = pipe_r ->
+                      if is_flag_in then ()
+                      else debug "Received unexpected epoll event on pipe_r in qmp_event_thread"
+                    | sock ->
+                      Lookup.domid_of sock >>= fun domid ->
+                      if is_flag_in then
+                        Lookup.channel_of domid >>= fun c ->
+                        try
+                          match Qmp_protocol.read c with
+                          | Event e -> qmp_event_handle domid e
+                          | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
+                        with End_of_file ->
+                          debug "domain-%d: end of file, close qmp socket" domid;
+                          remove domid
+                      else begin
+                        debug "EPOLL error on domain-%d, close qmp socket" domid;
+                        remove domid
+                      end
+                  )
+              with e ->
+                debug_exn "Exception in qmp_event_thread: %s" e;
+            done
+
+          let _init_qmp_event =
+            Thread.create qmp_event_thread ()
+        end (* QMP_Event *)
+      end (* Qemu_upstream_compat.Dm.Event *)
+
       let get_vnc_port ~xs domid =
         Dm.Common.get_vnc_port ~xs domid ~f:(fun () ->
           let open Qmp in
@@ -2198,12 +2197,12 @@ module Backend = struct
 
       let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel _ =
         let pid = Dm.Common.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel () in
-        Dm.QMP_Event.add domid;
+        Event.QMP_Event.add domid;
         pid
 
       let stop ~xs ~qemu_domid domid  =
         Dm.Common.stop ~xs ~qemu_domid domid;
-        Dm.QMP_Event.remove domid
+        Event.QMP_Event.remove domid
 
     end (* Backend.Qemu_upstream_compat.Dm *)
   end (* Backend.Qemu_upstream *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -609,29 +609,33 @@ let qemu_media_change ~xs device _type params =
 	then begin
 		let open Qmp in
 		let cd = "ide1-cd1" in
-		match params with
-		| "" ->
+		if params = "" then
 			let qmp_cmd = Command(None, Eject (cd, Some true)) in
 			qmp_write device.frontend.domid qmp_cmd
-		| _ ->
+		else
 			try
 				let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" device.frontend.domid) in
-				let fd_of_c = Qmp_protocol.to_fd c in
-				let fd_of_cd = Unix.openfile params [ Unix.O_RDONLY ] 0o640 in
 				finally
-					(fun () -> ignore(Fd_send_recv.send_fd fd_of_c " " 0 1 [] fd_of_cd))
-					(fun () -> Unix.close fd_of_cd);
-				
-				let qmp_cmd = Command (None, Add_fd (Fd_send_recv.int_of_fd fd_of_cd)) in
-				Qmp_protocol.negotiate c;
-				Qmp_protocol.write c qmp_cmd;
-				let new_fd = match Qmp_protocol.read c with
-				| Success (None, Fd_info fd_info) -> fd_info.fd
-				| _ -> raise (Internal_error (Printf.sprintf "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd)))
-				in
-				let cmd = Command (None, Blockdev_change_medium (cd, "/dev/fd/" ^ (string_of_int new_fd))) in
-				Qmp_protocol.write c cmd;
-				Qmp_protocol.close c
+					(fun () ->
+						let fd_of_c = Qmp_protocol.to_fd c in
+						let fd_of_cd = Unix.openfile params [ Unix.O_RDONLY ] 0o640 in
+						finally
+							(fun () -> ignore(Fd_send_recv.send_fd fd_of_c " " 0 1 [] fd_of_cd))
+							(fun () -> Unix.close fd_of_cd);
+
+						let qmp_cmd = Command (None, Add_fd None) in
+						Qmp_protocol.negotiate c;
+						Qmp_protocol.write c qmp_cmd;
+						let fd_info = match Qmp_protocol.read c with
+							| Success (None, Fd_info x) -> x
+							| _ -> raise (Internal_error (Printf.sprintf "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd)))
+						in
+						finally
+							(fun () ->
+								Qmp_protocol.write c (Command (None, Blockdev_change_medium (cd, "/dev/fdset/" ^ (string_of_int fd_info.fdset_id)))))
+							(fun () ->
+								Qmp_protocol.write c (Command (None, Remove_fd fd_info.fdset_id))))
+					(fun () -> Qmp_protocol.close c)
 			with
 			| Unix.Unix_error(Unix.ECONNREFUSED, "connect", p) -> raise(Internal_error (Printf.sprintf "Failed to connnect qmp socket: %s" p))
 			| Unix.Unix_error(Unix.ENOENT, "open", p) -> raise(Internal_error (Printf.sprintf "Failed to open CD Image: %s" p))

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2004,7 +2004,6 @@ module Backend = struct
         (** Handler for the QMP events in upstream qemu *)
         module QMP_Event = struct
           open Qmp
-          let (pipe_r, pipe_w) = Unix.pipe ()
 
           let (>>=) m f = match m with | Some x -> f x | None -> ()
           let (>>|) m f = match m with | Some _ -> () | None -> f ()
@@ -2027,11 +2026,8 @@ module Backend = struct
             module Epoll = Core.Linux_ext.Epoll
             module Flags = Core.Linux_ext.Epoll.Flags
             let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
-            let wakeup () =  (* write single byte to wake up Monitor.wait *)
-              if Unix.write pipe_w " " 0 1 <> 1 then
-                debug "Pipe write error, failed to wake up qmp event thread"
-            let add m fd = Epoll.set m fd Flags.in_; wakeup ()
-            let remove m fd = Epoll.remove m fd; wakeup ()
+            let add m fd = Epoll.set m fd Flags.in_
+            let remove m fd = Epoll.remove m fd
             let wait m = Epoll.wait m ~timeout:`Never
             let with_event m fn = function
               | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
@@ -2070,29 +2066,23 @@ module Backend = struct
             debug "Got QMP event, domain-%d: %s" domid qmp_event.event
 
           let qmp_event_thread () =
-            Monitor.add m pipe_r;
             while true do
               try
                 Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
-                    match fd with
-                    | pipe when pipe = pipe_r ->
-                      if is_flag_in then ()
-                      else debug "Received unexpected epoll event on pipe_r in qmp_event_thread"
-                    | sock ->
-                      Lookup.domid_of sock >>= fun domid ->
-                      if is_flag_in then
-                        Lookup.channel_of domid >>= fun c ->
-                        try
-                          match Qmp_protocol.read c with
-                          | Event e -> qmp_event_handle domid e
-                          | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
-                        with End_of_file ->
-                          debug "domain-%d: end of file, close qmp socket" domid;
-                          remove domid
-                      else begin
-                        debug "EPOLL error on domain-%d, close qmp socket" domid;
-                        remove domid
-                      end
+                  Lookup.domid_of fd >>= fun domid ->
+                  if is_flag_in then
+                    Lookup.channel_of domid >>= fun c ->
+                    try
+                      match Qmp_protocol.read c with
+                      | Event e -> qmp_event_handle domid e
+                      | msg -> debug "Got non-event message, domain-%d: %s" domid (string_of_message msg)
+                    with End_of_file ->
+                      debug "domain-%d: end of file, close qmp socket" domid;
+                      remove domid
+                  else begin
+                    debug "EPOLL error on domain-%d, close qmp socket" domid;
+                    remove domid
+                  end
                   )
               with e ->
                 debug_exn "Exception in qmp_event_thread: %s" e;

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2079,6 +2079,9 @@ module Backend = struct
                     with End_of_file ->
                       debug "domain-%d: end of file, close qmp socket" domid;
                       remove domid
+                    | e ->
+                      debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
+                      remove domid
                   else begin
                     debug "EPOLL error on domain-%d, close qmp socket" domid;
                     remove domid

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1816,6 +1816,10 @@ module Backend = struct
     (** Dm functions that use the dispatcher to choose between different profile backends *)
     module Dm: sig
 
+      module Event: sig
+        val init : unit -> unit
+      end
+
       (** [get_vnc_port xenstore domid] returns the dom0 tcp port in which the vnc server for [domid] can be found *)
       val get_vnc_port : xs:Xenstore.Xs.xsh -> int -> int option
 
@@ -1846,6 +1850,11 @@ module Backend = struct
 
     (** Implementation of the Dm functions that use the dispatcher for the qemu-trad backend *)
     module Dm = struct
+
+      module Event = struct
+        let init () = ()
+      end
+
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
           (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
@@ -2016,9 +2025,11 @@ module Backend = struct
                 debug_exn "Exception in qmp_event_thread: %s" e;
             done
 
-          let _init_qmp_event =
-            Thread.create qmp_event_thread ()
         end (* Qemu_upstream_compat.Dm.QMP_Event *)
+
+        module Event = struct
+          let init () = ignore(Thread.create QMP_Event.qmp_event_thread ())
+        end
 
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
@@ -2094,6 +2105,9 @@ module Backend = struct
     | Profile.Qemu_upstream        -> (module Qemu_upstream        : Intf)
 
   let of_domid x = of_profile (Profile.of_domid x)
+
+  let init() =
+    Profile.all |> List.iter (fun p -> let module Q = (val of_profile p) in Q.Dm.Event.init() )
 end
 
 (*

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1483,6 +1483,30 @@ module Dm = struct
     extras: (string * string option) list;
   }
 
+  module Profile = struct
+    type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+    let fallback = Qemu_trad
+    module Name = struct
+      let qemu_trad            = "qemu-trad"
+      let qemu_upstream_compat = "qemu-upstream-compat"
+      let qemu_upstream        = "qemu-upstream"
+      let all = [ qemu_trad; qemu_upstream_compat; qemu_upstream ]
+    end
+    let wrapper_of = function
+      | Qemu_trad            -> !Resources.qemu_dm_wrapper
+      | Qemu_upstream_compat -> !Resources.upstream_compat_qemu_dm_wrapper
+      | Qemu_upstream        -> !Resources.upstream_compat_qemu_dm_wrapper
+    let string_of  = function
+      | Qemu_trad              -> Name.qemu_trad
+      | Qemu_upstream_compat   -> Name.qemu_upstream_compat
+      | Qemu_upstream          -> Name.qemu_upstream
+    let of_string  = function
+      | x when x = Name.qemu_trad            -> Qemu_trad
+      | x when x = Name.qemu_upstream_compat -> Qemu_upstream_compat
+      | x when x = Name.qemu_upstream        -> Qemu_upstream
+      | x -> debug "unknown device-model profile %s: defaulting to fallback: %s" x (string_of fallback);
+         fallback
+  end
 
   let get_vnc_port ~xs domid =
     let is_running = Qemu.is_running ~xs domid in

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2063,7 +2063,16 @@ module Backend = struct
 
           let qmp_event_handle domid qmp_event =
             (* This function will be extended to handle qmp events *)
-            debug "Got QMP event, domain-%d: %s" domid qmp_event.event
+            debug "Got QMP event, domain-%d: %s" domid qmp_event.event;
+            qmp_event.data >>= function
+            | RTC_CHANGE timeoffset ->
+              with_xs (fun xs ->
+                let timeoffset_key = sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid)) in
+                try
+                  let rtc = xs.Xs.read timeoffset_key in
+                  xs.Xs.write timeoffset_key Int64.(add timeoffset (of_string rtc) |> to_string)
+                with e -> error "Failed to process RTC_CHANGE for domain %d: %s" domid (Printexc.to_string e)
+              )
 
           let qmp_event_thread () =
             while true do

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -35,11 +35,11 @@ open D
 module Profile = struct
   type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
   let fallback = Qemu_trad
+  let all = [ Qemu_trad; Qemu_upstream_compat; Qemu_upstream ]
   module Name = struct
     let qemu_trad            = "qemu-trad"
     let qemu_upstream_compat = "qemu-upstream-compat"
     let qemu_upstream        = "qemu-upstream"
-    let all = [ qemu_trad; qemu_upstream_compat; qemu_upstream ]
   end
   let wrapper_of = function
     | Qemu_trad            -> !Resources.qemu_dm_wrapper

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1457,21 +1457,22 @@ type info = {
 
 
 let get_vnc_port ~xs domid =
-	if not (Qemu.is_running ~xs domid)
-	then None
-	else begin
-		if is_upstream_qemu domid then begin
-			let open Qmp in
-			let qmp_cmd = Command (None, Query_vnc) in
-			let qmp_cmd_result = qmp_write_and_read domid  qmp_cmd in
-			match qmp_cmd_result with
-			| Some qmp_message -> (match qmp_message with
-				| Success (None, Vnc vnc) -> (try Some vnc.service with _ -> None)
-				| _ -> raise (Internal_error (Printf.sprintf "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd))))
-			| None -> raise (Internal_error (Printf.sprintf "Fail to get result after sending Qmp message: %s" (string_of_message qmp_cmd)))
-		end
-		else (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
-	end
+	let is_running = Qemu.is_running ~xs domid in
+	let is_upstream = is_upstream_qemu domid in
+	match is_running, is_upstream with
+	| true, false -> (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
+	| true, true  -> (
+		let open Qmp in
+		let qmp_cmd = Command (None, Query_vnc) in
+		let parse_qmp_message = function
+			| Success (None, Vnc vnc) -> (try Some vnc.service with _ -> None)
+			| _ -> debug "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd); None
+		in
+		let qmp_cmd_result = qmp_write_and_read domid qmp_cmd in
+		match qmp_cmd_result with
+		| Some qmp_message -> parse_qmp_message qmp_message
+		| None -> debug "Fail to get result after sending Qmp message: %s" (string_of_message qmp_cmd); None)
+	| _, _  -> None
 
 let get_tc_port ~xs domid =
 	if not (Qemu.is_running ~xs domid)

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -266,5 +266,9 @@ sig
 	val with_dirty_log: int -> f:(unit -> unit) -> unit
 end
 
+module Backend: sig
+	val init : unit -> unit
+end
+
 val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -21,17 +21,31 @@ exception Device_not_found
 
 exception Cdrom
 
+(** Definition of available qemu profiles, used by the qemu backend implementations *)
 module Profile: sig
 	type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+	(** available qemu profiles *)
+
+	(** the fallback profile in case an invalid profile string is provided to [of_string] *)
 	val fallback : t
+
+	(** all available profiles *)
 	val all: t list
+
+	(** Valid names for a profile, used to define valid values for VM.platform.device-model *)
 	module Name: sig
 		val qemu_trad: string
 		val qemu_upstream_compat: string
 		val qemu_upstream: string
 	end
+
+	(** [wrapper_of profile] returns the qemu wrapper script path of a profile *)
 	val wrapper_of: t -> string
+
+	(** [string_of  profile] returns the profile name of a profile *)
 	val string_of : t -> string
+
+	(** [of_string  profile_name] returns the profile of a profile name, and [fallback] if an invalid name is provided. *)
 	val of_string : string -> t
 end
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -115,6 +115,15 @@ end
 
 module Qemu :
 sig
+	module SignalMask: sig
+		type t
+		val create: unit -> t
+		val set: t -> int -> unit
+		val unset: t -> int -> unit
+		val has: t -> int -> bool
+	end
+	val signal_mask : SignalMask.t
+	val pid_path_signal : Xenctrl.domid -> string
 	val pid : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 	val is_running : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> bool
 end

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -24,11 +24,11 @@ exception Cdrom
 module Profile: sig
 	type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
 	val fallback : t
+	val all: t list
 	module Name: sig
 		val qemu_trad: string
 		val qemu_upstream_compat: string
 		val qemu_upstream: string
-		val all: string list
 	end
 	val wrapper_of: t -> string
 	val string_of : t -> string

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -255,9 +255,9 @@ sig
 
 	val cmdline_of_info: info -> bool -> int -> string list
 
-	val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
-	val start_vnconly : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
-	val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
+	val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+	val start_vnconly : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+	val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
 	val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -233,6 +233,8 @@ sig
 	val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
+
+	val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
 end
 
 val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -21,6 +21,20 @@ exception Device_not_found
 
 exception Cdrom
 
+module Profile: sig
+	type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+	val fallback : t
+	module Name: sig
+		val qemu_trad: string
+		val qemu_upstream_compat: string
+		val qemu_upstream: string
+		val all: string list
+	end
+	val wrapper_of: t -> string
+	val string_of : t -> string
+	val of_string : string -> t
+end
+
 module Generic :
 sig
 	val rm_device_state : xs:Xenstore.Xs.xsh -> device -> unit
@@ -218,20 +232,6 @@ sig
 
 		extras: (string * string option) list;
 	}
-
-	module Profile: sig
-		type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
-		val fallback : t
-		module Name: sig
-			val qemu_trad: string
-			val qemu_upstream_compat: string
-			val qemu_upstream: string
-			val all: string list
-		end
-		val wrapper_of: t -> string
-		val string_of : t -> string
-		val of_string : string -> t
-	end
 
 	val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 	val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -219,6 +219,20 @@ sig
 		extras: (string * string option) list;
 	}
 
+	module Profile: sig
+		type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+		val fallback : t
+		module Name: sig
+			val qemu_trad: string
+			val qemu_upstream_compat: string
+			val qemu_upstream: string
+			val all: string list
+		end
+		val wrapper_of: t -> string
+		val string_of : t -> string
+		val of_string : string -> t
+	end
+
 	val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 	val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -249,6 +249,7 @@ sig
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 
 	val maybe_write_pv_feature_flags : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+	val with_dirty_log: int -> f:(unit -> unit) -> unit
 end
 
 val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -335,19 +335,20 @@ let is_upstream_qemu domid =
 	with _ -> false
 
 let qmp_write_and_read domid ?(read_result=true) cmd  =
-  let open Qmp in
-  let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" domid) in
-  finally
-    (fun () ->
-      try
+  try
+    let open Qmp in
+    let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" domid) in
+    finally
+      (fun () ->
         Qmp_protocol.negotiate c;
         Qmp_protocol.write c cmd;
         if read_result then
           Some (Qmp_protocol.read c)
         else None
-      with e ->
-        error "Caught exception attempting to write qmp message: %s" (Printexc.to_string e);
-        None)
-    (fun () -> Qmp_protocol.close c)
+      )
+      (fun () -> Qmp_protocol.close c)
+  with e ->
+    error "Caught exception attempting to write qmp message: %s" (Printexc.to_string e);
+    None
 
 let qmp_write domid cmd = qmp_write_and_read ~read_result:false domid cmd |> ignore

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -321,6 +321,10 @@ let qemu_restore_path : (_, _, _) format = "/var/lib/xen/qemu-resume.%d"
 let demu_save_path : (_, _, _) format = "/var/lib/xen/demu-save.%d"
 let demu_restore_path : (_, _, _) format = "/var/lib/xen/demu-resume.%d"
 
+let var_run_xen_path = "/var/run/xen"
+let qmp_libxl_path = (sprintf "%s/qmp-libxl-%d") var_run_xen_path
+let qmp_event_path = (sprintf "%s/qmp-event-%d") var_run_xen_path
+
 (* Where qemu writes its state and is signalled *)
 let device_model_path ~qemu_domid domid = sprintf "/local/domain/%d/device-model/%d" qemu_domid domid
 
@@ -331,13 +335,13 @@ let xenops_vgpu_path domid devid =
 
 let is_upstream_qemu domid =
 	try
-		with_xs (fun xs -> xs.Xs.read (Printf.sprintf "/libxl/%d/dm-version" domid)) = "qemu_xen"
+		with_xs (fun xs -> xs.Xs.read (sprintf "/libxl/%d/dm-version" domid)) = "qemu_xen"
 	with _ -> false
 
 let qmp_write_and_read domid ?(read_result=true) cmd  =
   try
     let open Qmp in
-    let c = Qmp_protocol.connect (Printf.sprintf "/var/run/xen/qmp-libxl-%d" domid) in
+    let c = Qmp_protocol.connect (qmp_libxl_path domid) in
     finally
       (fun () ->
         Qmp_protocol.negotiate c;

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -92,6 +92,10 @@ val qemu_restore_path: (int -> 'a, 'b, 'a) format
 val demu_save_path: (int -> 'a, 'b, 'a) format
 val demu_restore_path: (int -> 'a, 'b, 'a) format
 
+val var_run_xen_path: string
+val qmp_libxl_path: int -> string
+val qmp_event_path: int -> string
+
 (** Directory in xenstore where qemu writes its state *)
 val device_model_path: qemu_domid:int -> int -> string
 

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -98,3 +98,5 @@ val device_model_path: qemu_domid:int -> int -> string
 val xenops_domain_path: string
 val xenops_path_of_domain: Xenctrl.domid -> string
 val xenops_vgpu_path: Xenctrl.domid -> devid -> string
+val is_upstream_qemu: Xenctrl.domid -> bool
+val qmp_write: Xenctrl.domid -> Qmp.message -> unit

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -99,4 +99,5 @@ val xenops_domain_path: string
 val xenops_path_of_domain: Xenctrl.domid -> string
 val xenops_vgpu_path: Xenctrl.domid -> devid -> string
 val is_upstream_qemu: Xenctrl.domid -> bool
+val qmp_write_and_read: Xenctrl.domid -> ?read_result:bool -> Qmp.message -> Qmp.message option
 val qmp_write: Xenctrl.domid -> Qmp.message -> unit

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1128,15 +1128,9 @@ let write_libxc_record' (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_pa
 	)
 
 let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
-	finally
-		(fun() ->
-			if is_upstream_qemu domid
-			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log true));
-			write_libxc_record' task ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback)
-		(fun() ->
-			if is_upstream_qemu domid
-			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log false));
-		)
+	Device.Dm.with_dirty_log domid (fun () ->
+		write_libxc_record' task ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback
+	)
 
 let write_qemu_record domid uuid legacy_libxc fd =
 	let file = sprintf qemu_save_path domid in

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1051,7 +1051,7 @@ let restore (task: Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid 
 
 type suspend_flag = Live | Debug
 
-let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
+let write_libxc_record' (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
 	let fd_uuid = Uuid.(to_string (create `V4)) in
 
 	let cmdline_to_flag flag =
@@ -1113,7 +1113,7 @@ let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_pat
 			debug "VM = %s; domid = %d; suspending qemu-dm" (Uuid.to_string uuid) domid;
 			Device.Dm.suspend task ~xs ~qemu_domid domid;
 		);
- 		XenguestHelper.send cnx "done\n";
+		XenguestHelper.send cnx "done\n";
 
 		let msg = XenguestHelper.non_debug_receive cnx in
 		progress_callback 1.;
@@ -1126,6 +1126,17 @@ let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_pat
 		| _                       ->
 			error "VM = %s; domid = %d; xenguesthelper protocol failure" (Uuid.to_string uuid) domid;
 	)
+
+let write_libxc_record (task: Xenops_task.task_handle) ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback =
+	finally
+		(fun() ->
+			if is_upstream_qemu domid
+			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log true));
+			write_libxc_record' task ~xc ~xs ~hvm xenguest_path domid uuid fd flags progress_callback qemu_domid do_suspend_callback)
+		(fun() ->
+			if is_upstream_qemu domid
+			then qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log false));
+		)
 
 let write_qemu_record domid uuid legacy_libxc fd =
 	let file = sprintf qemu_save_path domid in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -57,10 +57,10 @@ let choose_alternative kind default platformdata =
 	end else default
 
 (* We allow qemu-dm to be overriden via a platform flag *)
-let choose_qemu_dm x = Device.(Dm.Profile.wrapper_of (
+let choose_qemu_dm x = Device.(Profile.wrapper_of (
 	if List.mem_assoc _device_model x
-	then Dm.Profile.of_string (List.assoc _device_model x)
-	else Dm.Profile.fallback
+	then Profile.of_string (List.assoc _device_model x)
+	else Profile.fallback
 ))
 
 (* We allow xenguest to be overriden via a platform flag *)

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -57,7 +57,11 @@ let choose_alternative kind default platformdata =
 	end else default
 
 (* We allow qemu-dm to be overriden via a platform flag *)
-let choose_qemu_dm x = choose_alternative _device_model !Resources.qemu_dm_wrapper x
+let choose_qemu_dm x = Device.(Dm.Profile.wrapper_of (
+	if List.mem_assoc _device_model x
+	then Dm.Profile.of_string (List.assoc _device_model x)
+	else Dm.Profile.fallback
+))
 
 (* We allow xenguest to be overriden via a platform flag *)
 let choose_xenguest x = choose_alternative _xenguest !Xc_resources.xenguest x

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1364,16 +1364,6 @@ module VM = struct
 			(fun xc xs task vm di ->
 
 				let domid = di.Xenctrl.domid in
-
-				(* As per comment on CA-217805 *)
-				let use_poweroff =
-					try
-						xs.Xs.read (xs.Xs.getdomainpath domid ^ "/control/feature-poweroff") = "1"
-					with _ -> false
-				in
-
-				let reason = match reason, use_poweroff with Domain.Halt, true -> Domain.PowerOff | x, _ -> x in
-
 				try
 					Domain.shutdown ~xc ~xs domid reason;
 					Domain.shutdown_wait_for_ack task ~timeout:ack_delay ~xc ~xs domid reason;

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2763,6 +2763,7 @@ module Actions = struct
 							let non_persistent = { non_persistent with VmExtra.pv_drivers_detected = true } in
 							debug "VM = %s; found PV driver evidence on %s (value = %s)" vm path value;
 							DB.write vm { VmExtra.persistent; non_persistent };
+							Device.Dm.maybe_write_pv_feature_flags ~xs domid;
 							Updates.add (Dynamic.Vm vm) internal_updates
 						end
 					with Xs_protocol.Enoent _ ->

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -3089,6 +3089,7 @@ let init () =
 			xs.Xs.setperms xe_key { Xs_protocol.ACL.owner = 0; other = Xs_protocol.ACL.READ; acl = [] }
 	);
 
+	Device.Backend.init();
 	debug "xenstore is responding to requests";
 	let () = Watcher.create_watcher_thread () in
 	()

--- a/xc/xenops_xc_main.ml
+++ b/xc/xenops_xc_main.ml
@@ -42,7 +42,7 @@ let check_domain0_uuid () =
 	forget_client ()
 
 let make_var_run_xen () =
-	Stdext.Unixext.mkdir_rec "/var/run/xen" 0o0755
+	Stdext.Unixext.mkdir_rec Device_common.var_run_xen_path 0o0755
 
 (* Start the program with the xen backend *)
 let _ =


### PR DESCRIPTION
This PR merges branch qemu-stable into master. 

```
52dac0cc CA-267466: call QMP_Event initialisation in xenops_server_xen.init()
850935f7 CA-267466: define constant for '/var/run/xen' and qmp socket path
4ecc622f CA-267466: xenopsd does not reconnect to QMP events after xenopsd restart
d4ff5e12 CP-24361: use the profile to select the backend before running the qemu daemon
470f36b1 CP-24361: improve abstraction for dmpath parameter from string to Profile.t
6f39be21 CP-24361: use the qemu backends for init_daemon
77e3c136 CP-24361: abstract qemu interface: rebase patch CP-24090 d1cfa14 into qemu backends
fc98abb2 CP-24361: abstract qemu interface: rebase patch CP-24090 65b9975 into qemu backends
7b6a3fa0 CP-24361: abstract qemu interface: rebase patch CP-24468 9b81674 into qemu backends
b94364e4 CP-24361: abstract qemu interface: rebase patch CA-266874 05b0481 into qemu backends
b9e3655b CP-24361: abstract qemu interface: add more doc strings to the new module interfaces
542c60cb CP-24361: abstract qemu interface: add doc strings to the new module interfaces
506b09fc CP-24361: abstract qemu interface: elaborate about stage 4 of upstream qemu
bc1bdaf4 CP-24361: abstract qemu interface: remove unnecessary Backend.Event module
fe176d63 CP-24361: abstract qemu interface: remove backend refs
f0a4ce56 CP-24361: abstract qemu interface: all:string list -> all:Profile.t list
4b51f9e9 CP-24361: abstract qemu interface: write_libxc_record in domain.ml
d1c3549b CP-24361: abstract qemu interface: move QMP_Event into qemu upstream backend
08ffe338 CP-24361: abstract qemu interface: move stop into qemu backends
043a3c8f CP-24361: abstract qemu interface: move init_daemon into qemu backends
b9bd8478 CP-24361: abstract qemu interface: move suspend into qemu backends
2b2994b0 CP-24361: abstract qemu interface: move maybe_write_pv_feature_flags into qemu backends
5d726b61 CP-24361: abstract qemu interface: move get_vnc_port into qemu backends
b8ca69b1 CP-24361: abstract qemu interface: move Vbd.qemu_media_change into qemu backends
f83e0e5a CP-24361: abstract qemu interface: create module dispatcher
b6d835b8 CP-24090: Respond to RTC_CHANGE QMP message
d8dc6eef CP-24090: Capture generic exception in qmp_event_thread
110efa0d CA-266874: Fix infinite epoll wakeup loop
3461c49d CP-24468: Clean up libxl xenstore keys after qemu-wrapper
8c77c5c8 CP-23986: Implement QMP event thread in xenopsd
889df236 CP-23595: Revert "CP-19645: qemu-dm-wrapper: run QEMU if requested"
dc08335e CP-23595: Introduce device model profiles to xenopsd - Stage 1
df5452cd CA-262911: Use poweroff rather than halt
9e4d5d13 Format xc/device.ml with ocp-indent
1713c397 CP-23007: Use /dev/fdset/<fdset-id> rather than /dev/fd/<fd> to change CD
fea34ebd CA-260353: return None if Qmp_protocol.connect raises error
3abd6614 CP-23007: Implement CD change using fd over QMP
beab0b01 CP-22500: support clean suspend,shutdown etc for HVM Linux using upstream qemu
5a2b8dbe CA-260220: Return None when fail to query vnc port
d35dc819 CP-21131: Get VNC port using QMP
c54721fc CP23043: Send xen-set-global-dirty-log from xenopsd
d69531e8 CP-17693: take action when qemu crashes or exits unexpectedly
30107cd5 CP-17622: Use QMP to get the QEMU save image
f8b7588a CP-18194: Use QMP to change CD media (insert/remove)
```
