### PR TITLE
CA-267466: create a single QMP_Event thread

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1995,6 +1995,7 @@ module Backend = struct
               )
 
           let qmp_event_thread () =
+            debug "Starting QMP_Event thread";
             (* Add the existing qmp sockets first *)
             Sys.readdir var_run_xen_path
             |> Array.to_list
@@ -2107,7 +2108,7 @@ module Backend = struct
   let of_domid x = of_profile (Profile.of_domid x)
 
   let init() =
-    Profile.all |> List.iter (fun p -> let module Q = (val of_profile p) in Q.Dm.Event.init() )
+    Qemu_upstream.Dm.Event.init()
 end
 
 (*


### PR DESCRIPTION
There are two qemu-upstream profiles, and each was creating its own
upstream-qemu QMP_Event thread. Instead, we should have only a single
QMP_Event thread.

This patch replaces the `Q.Dm.Event.init()` call for each profile in favour of a
single static `Qemu_upstrea.Dm.Event.init()` call. In the future, we may return
to the `init()` call for each profile as long as the function that creates the
QMP_Event thread returns a singleton instance of the thread.

before the patch:
Oct  2 13:36:26 st45 xenopsd-xc: [debug|st45|7 ||xenops] Starting QMP_Event thread
Oct  2 13:36:26 st45 xenopsd-xc: [debug|st45|8 ||xenops] Starting QMP_Event thread
Oct  2 13:36:26 st45 xenopsd-xc: [debug|st45|8 ||xenops] Added QMP Event fd for domain 34
Oct  2 13:36:26 st45 xenopsd-xc: [debug|st45|8 ||xenops] Added QMP Event fd for domain 32

after the patch:
Oct  2 13:43:50 st45 xenopsd-xc: [debug|st45|7 ||xenops] Starting QMP_Event thread
Oct  2 13:43:50 st45 xenopsd-xc: [debug|st45|7 ||xenops] Added QMP Event fd for domain 34
Oct  2 13:43:50 st45 xenopsd-xc: [debug|st45|7 ||xenops] Added QMP Event fd for domain 32

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>