### PR TITLE
CP-24744: Ensure vusb plug must use upstream qemu

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1404,7 +1404,10 @@ module Vusb = struct
     | _ ->()
 
   let vusb_plug ~xs ~domid ~id ~hostbus ~hostport ~version =
-    debug "Vusb plugged: vusb device plugged ";
+    let device_model = Profile.of_domid domid in
+    if device_model = Profile.Qemu_trad then
+      raise (Internal_error (Printf.sprintf "Failed to plug VUSB %s because domain %d uses device-model profile %s." id domid (Profile.string_of device_model)));
+    debug "Vusb plugged: vusb device %s plugged" id;
     let get_bus v =
       if String.startswith "1" v then
          "usb-bus.0"


### PR DESCRIPTION
We need to check the if qemu-upstream is used when plug vusb to vm.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>