### PR TITLE
 CP-25063: Reset USB device before passthrough

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -889,6 +889,9 @@ let rec atomics_of_operation = function
 		]
 	| VM_shutdown (id, timeout) ->
 		(Opt.default [] (Opt.map (fun x -> [ VM_shutdown_domain(id, PowerOff, x) ]) timeout)
+		(* When shutdown vm, need to unplug vusb from vm. *)
+		) @ (List.map (fun vusb -> VUSB_unplug vusb.Vusb.id)
+			(VUSB_DB.vusbs id)
 		) @ simplify ([
 			(* At this point we have a shutdown domain (ie Needs_poweroff) *)
 			VM_destroy_device_model id;

--- a/xc/xc_resources.ml
+++ b/xc/xc_resources.ml
@@ -30,6 +30,7 @@ let gimtool = ref "/opt/xensource/bin/gimtool"
 
 let alternatives = ref "/usr/lib/xapi/alternatives"
 
+
 open Unix
 
 let essentials = [

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1959,7 +1959,6 @@ module VUSB = struct
 				let emulator_pid = Device.Qemu.pid ~xs frontend_domid in
 				debug "Qom list to get vusb state";
 				let peripherals = Device.Vusb.qom_list ~xs ~domid:frontend_domid in
-				debug "qom list result head %s" (List.hd peripherals);
 				let found = List.mem (snd vusb.Vusb.id)  peripherals in
 				match emulator_pid, found with
 				| Some pid, true -> {plugged = true}


### PR DESCRIPTION
According to CP-24616. we need to reset usb device before pasthrough to vm.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>