### PR TITLE
CP-24831: improve selection of the runtime qemu backend in xenopsd

### DIFF
--- a/xc/device.mli
+++ b/xc/device.mli
@@ -47,6 +47,10 @@ module Profile: sig
 
 	(** [of_string  profile_name] returns the profile of a profile name, and [fallback] if an invalid name is provided. *)
 	val of_string : string -> t
+
+	module Cache: sig
+		val remove: int -> unit
+	end
 end
 
 module Generic :

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -483,6 +483,9 @@ let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid domid =
 	(* Also zap any remaining cancellation paths in xenstore *)
 	Cancel_utils.cleanup_for_domain ~xs domid;
 
+	(* After domid is deleted from xenstore, no need for the profile backend caching *)
+	Device.Profile.Cache.remove domid;
+
 	(* Block waiting for the dying domain to disappear: aim is to catch shutdown errors early*)
 	let still_exists () =
 	  try


### PR DESCRIPTION
The function is_upstream_qemu is a somewhat fragile mechanism to select the
qemu profile from a domid because it uses a xenstore key that can be
manipulated by other processes outside xenopsd or race with threads inside
xenopsd. Manipulation of this key will lead to xenopsd selecting different
qemu profiles for the same domid, which can cause errors. An example of an
error caused by is_upstream_qemu is when Vm.shutdown is explicitly called on
a domid with a qemu-upstream profile. Vm.shutdown will eventually call Dm.stop,
which deletes this key. This races with the xenopsd xenstore watcher thread,
which can detect that the domid changed state to shutdown and then call
Dm.stop again via VM_check_state, causing the second Dm.stop that is executed
to run with the wrong qemu-trad profile because the first one deleted the key
that is_upstream_qemu uses to select the qemu-upstream profile.

This patch improves the robustness of this mechanism by making xenopsd remember
the profile that was used to start qemu. This removes all external dependencies
when selecting the profile while xenopsd is running, causing xenopsd to reuse
the same profile throughout the lifetime of the domid. This information is then
removed to prevent leaks in xenopsd whenever the domid is destroyed and its
tree removed from xenstored.

When xenopsd restarts, we use is_upstream_qemu to reinitialise the cache as this
is the only location where the profile information persists between xenopsd
restarts. Ideally, in the future xenopsd should provide a state persistence
service to permit this and other state to persist between xenopsd restarts.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>