### PR TITLE
CP-25156: change the suspend sequence in xenopsd for qemu-upstream

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1884,6 +1884,9 @@ module Backend = struct
 
       (** [cmdline_of_info xenstore info restore domid] creates the command line arguments to pass to the qemu wrapper script *)
       val cmdline_of_info: xs:Xenstore.Xs.xsh -> dm:Profile.t -> Dm_Common.info -> bool -> int -> string list
+
+      (** [after_suspend_image xs qemu_domid domid] hook to execute actions after the suspend image has been created *)
+      val after_suspend_image: xs:Xenstore.Xs.xsh -> qemu_domid:int -> int -> unit
     end
   end
 
@@ -1934,6 +1937,8 @@ module Backend = struct
               ) nics
           else [["-net"; "none"]] in
         common @ (List.concat nics')
+
+      let after_suspend_image ~xs ~qemu_domid domid = ()
 
     end (* Backend.Qemu_trad.Dm *)
   end (* Backend.Qemu_trad *)
@@ -2203,6 +2208,10 @@ module Backend = struct
         in
         common @ (List.concat nics')
 
+      let after_suspend_image ~xs ~qemu_domid domid =
+        (* device model not needed anymore after suspend image has been created *)
+        stop ~xs ~qemu_domid domid
+
     end (* Backend.Qemu_upstream_compat.Dm *)
   end (* Backend.Qemu_upstream *)
 
@@ -2266,6 +2275,9 @@ module Dm = struct
     let module Q = (val Backend.of_profile dm) in
     Q.Dm.cmdline_of_info ~xs ~dm info restore domid
 
+  let after_suspend_image ~xs ~dm ~qemu_domid domid =
+    let module Q = (val Backend.of_profile dm) in
+    Q.Dm.after_suspend_image ~xs ~qemu_domid domid
 
   (* the following functions depend on the functions above that use the qemu backend Q *)
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -267,6 +267,7 @@ sig
   val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> unit
 
   val with_dirty_log: Profile.t -> int -> f:(unit -> 'a) -> 'a
+  val after_suspend_image: xs:Xenstore.Xs.xsh -> dm:Profile.t -> qemu_domid:int -> int -> unit
 end
 
 module Backend: sig

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1372,8 +1372,7 @@ module Suspend_restore_emu_manager : SUSPEND_RESTORE = struct
     | `Ok () ->
       debug "VM = %s; domid = %d; suspend complete" (Uuid.to_string uuid) domid
     );
-    (* device model not needed anymore after suspend image has been created *)
-    (if hvm then Device.Dm.stop ~xs ~qemu_domid ~dm domid)
+    (if hvm then Device.Dm.after_suspend_image ~xs ~dm ~qemu_domid domid)
 
 end
 
@@ -1791,8 +1790,7 @@ module Suspend_restore_xenguest: SUSPEND_RESTORE = struct
     | `Ok () ->
       debug "VM = %s; domid = %d; suspend complete" (Uuid.to_string uuid) domid
     );
-    (* device model not needed anymore after suspend image has been created *)
-    (if hvm then Device.Dm.stop ~xs ~qemu_domid ~dm domid)
+    (if hvm then Device.Dm.after_suspend_image ~xs ~dm ~qemu_domid domid)
 
 end
 


### PR DESCRIPTION
qemu-upstream only terminates at the end of the suspend process, when the VM_destroy_device_model is called, producing the following xenopsd activity trace during suspend: VM_save -> Qmp.Xen_save_devices_state -> tap-ctl_close -> tap-ctl_detach -> VM_shutdown -> VM_destroy_device_model -> qemu_terminate -> tap-ctl_detach (again).

The problem in the trace above is that the tap operations occur before VM_destroy_device_model is called to terminate qemu-upstream, so tapdisk can't close the fds of the VBDs. This requires a workaround in the qemu-upstream patchqueue to close the fds of the VBDs when Qmp.Xen_save_devices_state is called. 

To remove the necessity of this workaround, the changes in this PR terminate qemu-upstream just after its state has been saved during the suspend operation and therefore qemu-upstream is not needed anymore.

The changes were dev-tested with migration and suspend/resume.

Before changes:
- qemu-upstream stops only after VM_destroy_device_model is issued.

After changes:
- qemu-upstream stops immediately after suspend image is written:
```
Oct 27 14:49:18 st45 xenopsd-xc: [debug|st45|30 |Async.VM.suspend R:38b817985062|mig64] Qemu record written
Oct 27 14:49:18 st45 xenopsd-xc: [debug|st45|30 |Async.VM.suspend R:38b817985062|mig64] Writing End_of_image footer
Oct 27 14:49:18 st45 xenopsd-xc: [debug|st45|30 |Async.VM.suspend R:38b817985062|mig64] VM = 72f0c245-13b1-00ba-0733-09196277d29c; domid = 60; suspend complete
Oct 27 14:49:18 st45 xenopsd-xc: [debug|st45|30 |Async.VM.suspend R:38b817985062|xenops] qemu-dm: stopping qemu-dm with SIGTERM (domid = 60)
...
Oct 27 14:49:26 st45 xenopsd-xc: [debug|st45|32 |events|xenops_server] Performing: ["VM_destroy_device_model", "72f0c245-13b1-00ba-0733-09196277d29c"]
Oct 27 14:49:26 st45 xenopsd-xc: [debug|st45|32 |events|xenops_server] VM.destroy_device_model 72f0c245-13b1-00ba-0733-09196277d29c
Oct 27 14:49:26 st45 xenopsd-xc: [debug|st45|32 |events|xenops] Domain for VM 72f0c245-13b1-00ba-0733-09196277d29c does not exist: ignoring
```
- qemu-trad and PV are not affected, and still stop only after VM_destroy_model is issued. For qemu-trad:
```
Oct 27 14:58:17 st45 xenopsd-xc: [debug|st45|28 |Async.VM.suspend R:a425b8b82844|mig64] Writing End_of_image footer
Oct 27 14:58:17 st45 xenopsd-xc: [debug|st45|28 |Async.VM.suspend R:a425b8b82844|mig64] VM = fa28e918-3430-bff2-5bf7-beff7e0eb2c5; domid = 62; suspend complete
...
Oct 27 14:58:22 st45 xenopsd-xc: [debug|st45|28 |Async.VM.suspend R:a425b8b82844|xenops_server] Performing: ["VM_destroy_device_model", "fa28e918-3430-bff2-5bf7-beff7e0eb2c5"]
Oct 27 14:58:22 st45 xenopsd-xc: [debug|st45|28 |Async.VM.suspend R:a425b8b82844|xenops_server] VM.destroy_device_model fa28e918-3430-bff2-5bf7-beff7e0eb2c5
Oct 27 14:58:22 st45 xenopsd-xc: [debug|st45|28 |Async.VM.suspend R:a425b8b82844|xenops] qemu-dm: stopping qemu-dm with SIGTERM (domid = 62)
Oct 27 14:58:24 st45 xenopsd-xc: [debug|st45|34 |events|xenops_server] Performing: ["VM_destroy_device_model", "fa28e918-3430-bff2-5bf7-beff7e0eb2c5"]
Oct 27 14:58:24 st45 xenopsd-xc: [debug|st45|34 |events|xenops_server] VM.destroy_device_model fa28e918-3430-bff2-5bf7-beff7e0eb2c5
Oct 27 14:58:24 st45 xenopsd-xc: [debug|st45|34 |events|xenops] Domain for VM fa28e918-3430-bff2-5bf7-beff7e0eb2c5 does not exist: ignoring
```