### PR TITLE
CP-24771: Moved CLI network options from qemu-wrapper to xenopsd.

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -218,38 +218,6 @@ def main(argv):
             n += 2
             continue
 
-        if p == "-net":
-            n += 1
-            if qemu_args[n].startswith("nic,"):
-                vm_uuid = re.search(r'\/vm\/(.*)', xenstore_read("/local/domain/%d/vm" % domid)).group(1)
-                nic_mac = re.search(r'macaddr=(.*),', qemu_args[n]).group(1)
-                # we suppose that the output of next command is always in same order
-                nic_addrs = os.popen('xe vif-list vm-uuid=' + vm_uuid + ' MAC=' + nic_mac + ' params="device" --minimal').read().rstrip()
-                nic_addrs = nic_addrs.split(',')  
-                if dic_mac.has_key(nic_mac):
-                   dic_mac[nic_mac] += 1
-                   count = dic_mac[nic_mac]
-                   nic_addr = int(nic_addrs[count])
-                else:
-                   dic_mac[nic_mac] = 0
-                   nic_addr = int(nic_addrs[0])                
-                nic_addr += 4
-                qemu_args[n - 1] = '-device'
-                qemu_args[n] = re.sub(r'^nic,', '', qemu_args[n])
-                qemu_args[n] = qemu_args[n].replace('vlan=', 'netdev=tapnet')
-                model = re.search(r',model=([^,]+)', qemu_args[n]).group(1)
-                qemu_args[n] = re.sub(r',model=([^,]+)', '', qemu_args[n])
-                qemu_args[n] = re.sub(r',macaddr=', ',mac=', qemu_args[n])
-                qemu_args[n] = model + ',' +  qemu_args[n] + ",addr=" + str(nic_addr)
-                n += 1
-                continue
-
-            if qemu_args[n].startswith("tap,"):
-                qemu_args[n - 1] = '-netdev'
-                qemu_args[n] = re.sub(r',vlan=', ',id=tapnet', qemu_args[n])
-                qemu_args[n] = re.sub(r'bridge=[^,]+,', '', qemu_args[n])
-                qemu_args[n] += ",script=no,downscript=no"
-
         if p == "-usbdevice":
             if qemu_args[n+1] == "tablet":
                 qemu_args[n] = "-device"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -55,7 +55,7 @@ module Profile = struct
     | x when x = Name.qemu_upstream_compat -> Qemu_upstream_compat
     | x when x = Name.qemu_upstream        -> Qemu_upstream
     | x -> debug "unknown device-model profile %s: defaulting to fallback: %s" x (string_of fallback);
-       fallback
+      fallback
   let of_domid x = if is_upstream_qemu x then Qemu_upstream else Qemu_trad
 end
 
@@ -133,10 +133,10 @@ module Generic = struct
       raise e
 
   let safe_rm ~xs path =
-    try 
+    try
       debug "xenstore-rm %s" path;
       xs.Xs.rm path
-    with _ -> debug "Failed to xenstore-rm %s; continuing" path 
+    with _ -> debug "Failed to xenstore-rm %s; continuing" path
 
   (* Helper function to delete the frontend, backend and error trees for a device.
      This must only be done after synchronising with the hotplug scripts.
@@ -163,7 +163,7 @@ module Generic = struct
     with _ -> false
 
   (** Checks whether the supplied device still exists (ie hasn't been deleted) *)
-  let exists ~xs (x: device) = 
+  let exists ~xs (x: device) =
     let backend_stub = backend_path_of_device ~xs x in
     try
       ignore_string(xs.Xs.read backend_stub);
@@ -257,7 +257,7 @@ module Generic = struct
    When the watch fires, call a predicate function and look for an error node.
    If an error node appears, throw Device_error. If the predicate returns true then
    return unit. If the timeout expires throw Device_disconnect_timeout. *)
-let wait_for_error_or ~xs ?(timeout=Hotplug.hotplug_timeout) doc predicate otherpath domid kind devid = 
+let wait_for_error_or ~xs ?(timeout=Hotplug.hotplug_timeout) doc predicate otherpath domid kind devid =
 	let doc' = Printf.sprintf "%s (timeout = %f; %s)" doc timeout (print_device domid kind devid) in
   	let errorpath = error_node domid kind devid in
 	debug "Device.wait_for_error_or %s (watching [ %s; %s ])" doc' otherpath errorpath;
@@ -472,7 +472,7 @@ module Vbd_Common = struct
     if !Xenopsd.run_hotplug_scripts
     then Hotplug.run_hotplug_script x [ "remove" ];
 
-    (* As for add above, if the frontend is in dom0, we can wait for the frontend 
+    (* As for add above, if the frontend is in dom0, we can wait for the frontend
        	 * to unplug as well as the backend. CA-13506 *)
     if x.frontend.domid = 0 then Hotplug.wait_for_frontend_unplug task ~xs x
 
@@ -511,7 +511,7 @@ module Vbd_Common = struct
       | None ->
         make (free_device ~xs hvm domid) in
     let devid = to_xenstore_key device_number in
-    let device = 
+    let device =
       let backend = { domid = x.backend_domid; kind = x.kind; devid = devid }
       in  device_of_backend backend domid
     in
@@ -741,7 +741,7 @@ module Vif = struct
 
   let hard_shutdown = Generic.hard_shutdown
 
-  let set_carrier ~xs (x: device) carrier = 
+  let set_carrier ~xs (x: device) carrier =
     debug "Device.Vif.set_carrier %s <- %b" (string_of_device x) carrier;
     let disconnect_path = disconnect_path_of_device ~xs x in
     xs.Xs.write disconnect_path (if carrier then "0" else "1")
@@ -847,7 +847,7 @@ module PV_Vnc = struct
   let get_statefile ~xs domid =
     match pid ~xs domid with
     | None -> None
-    | Some pid -> 
+    | Some pid ->
       let filename = vncterm_statefile pid in
       if Sys.file_exists filename then
         Some filename
@@ -856,7 +856,7 @@ module PV_Vnc = struct
 
   let save ~xs domid =
     match pid ~xs domid with
-    | Some pid -> 
+    | Some pid ->
       Unix.kill pid Sys.sigusr1;
       let filename = vncterm_statefile pid in
       let delay = 10. in
@@ -1232,10 +1232,10 @@ module PCI = struct
   let device_model_state_path xs be_domid fe_domid =
     Printf.sprintf "%s/device-model/%d/state" (xs.Xs.getdomainpath be_domid) fe_domid
 
-  let signal_device_model ~xs domid cmd parameter = 
+  let signal_device_model ~xs domid cmd parameter =
     debug "Device.Pci.signal_device_model domid=%d cmd=%s param=%s" domid cmd parameter;
     let be_domid = 0 in (* XXX: assume device model is in domain 0 *)
-    let be_path = xs.Xs.getdomainpath be_domid in 
+    let be_path = xs.Xs.getdomainpath be_domid in
     (* Currently responses go in this global place. Blank it to prevent request/response/request confusion *)
     xs.Xs.rm (device_model_state_path xs be_domid domid);
 
@@ -1261,7 +1261,7 @@ module PCI = struct
     end
 
   (* Return a list of PCI devices *)
-  let list ~xs domid = 
+  let list ~xs domid =
     (* replace the sort index with the default '0' -- XXX must figure out whether this matters to anyone *)
     List.map (fun (_, y) -> (0, y)) (read_pcidir ~xs domid)
 
@@ -1468,20 +1468,20 @@ module Dm_Common = struct
   let inject_sci_path ~qemu_domid domid = sprintf "/local/domain/%d/device-model/%d/inject-sci" qemu_domid domid
 
   let xenclient_specific ~xs info ~qemu_domid domid =
-    (match info.power_mgmt with 
+    (match info.power_mgmt with
      | Some i -> begin
-         try 
+         try
            if (Unix.stat "/proc/acpi/battery").Unix.st_kind == Unix.S_DIR then
              xs.Xs.write (power_mgmt_path ~qemu_domid domid) (string_of_int i);
          with _ -> ()
        end
      | None -> ());
 
-    (match info.oem_features with 
+    (match info.oem_features with
      | Some i -> xs.Xs.write (oem_features_path ~qemu_domid domid) (string_of_int i);
      | None -> ());
 
-    (match info.inject_sci with 
+    (match info.inject_sci with
      | Some i -> xs.Xs.write (inject_sci_path ~qemu_domid domid) (string_of_int i)
      | None -> ());
 
@@ -1492,7 +1492,7 @@ module Dm_Common = struct
     in
 
     ["-videoram"; string_of_int info.video_mib;
-     "-M"; (if info.hvm then "xenfv" else "xenpv")] 
+     "-M"; (if info.hvm then "xenfv" else "xenpv")]
     @ sound_options
 
   let signal (task: Xenops_task.task_handle) ~xs ~qemu_domid ~domid ?wait_for ?param cmd =
@@ -1556,7 +1556,7 @@ module Dm_Common = struct
     in
     let disp_options, wait_for_port =
       match info.disp with
-      | NONE -> 
+      | NONE ->
         ([], false)
       | SDL (opts, x11name) ->
         ([], false)
@@ -1854,8 +1854,8 @@ module Backend = struct
 
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
-          (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
-        )
+            (try Some(int_of_string (xs.Xs.read (Generic.vnc_port_path domid))) with _ -> None)
+          )
 
       let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =
         Dm_Common.suspend task ~xs ~qemu_domid domid;
@@ -1916,110 +1916,110 @@ module Backend = struct
     (** Implementation of the Dm functions that use the dispatcher for the qemu-upstream-compat backend *)
     module Dm = struct
 
-        (** Handler for the QMP events in upstream qemu *)
-        module QMP_Event = struct
-          open Qmp
+      (** Handler for the QMP events in upstream qemu *)
+      module QMP_Event = struct
+        open Qmp
 
-          let (>>=) m f = match m with | Some x -> f x | None -> ()
-          let (>>|) m f = match m with | Some _ -> () | None -> f ()
+        let (>>=) m f = match m with | Some x -> f x | None -> ()
+        let (>>|) m f = match m with | Some _ -> () | None -> f ()
 
-          (** Efficient lookup table between file descriptors, channels and domain ids *)
-          module Lookup = struct
-            let ftod, dtoc = Hashtbl.create 16, Hashtbl.create 16
-            let add c domid =
-              Hashtbl.replace ftod (Qmp_protocol.to_fd c) domid;
-              Hashtbl.replace dtoc domid c
-            let remove c domid =
-              Hashtbl.remove ftod (Qmp_protocol.to_fd c);
-              Hashtbl.remove dtoc domid
-            let domid_of fd = try Some (Hashtbl.find ftod fd) with Not_found -> None
-            let channel_of domid = try Some (Hashtbl.find dtoc domid) with Not_found -> None
-          end
+        (** Efficient lookup table between file descriptors, channels and domain ids *)
+        module Lookup = struct
+          let ftod, dtoc = Hashtbl.create 16, Hashtbl.create 16
+          let add c domid =
+            Hashtbl.replace ftod (Qmp_protocol.to_fd c) domid;
+            Hashtbl.replace dtoc domid c
+          let remove c domid =
+            Hashtbl.remove ftod (Qmp_protocol.to_fd c);
+            Hashtbl.remove dtoc domid
+          let domid_of fd = try Some (Hashtbl.find ftod fd) with Not_found -> None
+          let channel_of domid = try Some (Hashtbl.find dtoc domid) with Not_found -> None
+        end
 
-          (** File-descriptor event monitor implementation for the epoll library *)
-          module Monitor = struct
-            module Epoll = Core.Linux_ext.Epoll
-            module Flags = Core.Linux_ext.Epoll.Flags
-            let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
-            let add m fd = Epoll.set m fd Flags.in_
-            let remove m fd = Epoll.remove m fd
-            let wait m = Epoll.wait m ~timeout:`Never
-            let with_event m fn = function
-              | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
-              | `Timeout -> debug "Shouldn't receive epoll timeout event in qmp_event_thread"
-          end
-          let m = Monitor.create ()
+        (** File-descriptor event monitor implementation for the epoll library *)
+        module Monitor = struct
+          module Epoll = Core.Linux_ext.Epoll
+          module Flags = Core.Linux_ext.Epoll.Flags
+          let create () = (Core.Std.Or_error.ok_exn Epoll.create) ~num_file_descrs:1001 ~max_ready_events:1
+          let add m fd = Epoll.set m fd Flags.in_
+          let remove m fd = Epoll.remove m fd
+          let wait m = Epoll.wait m ~timeout:`Never
+          let with_event m fn = function
+            | `Ok -> Epoll.iter_ready m ~f:(fun fd flags -> fn fd (flags = Flags.in_))
+            | `Timeout -> debug "Shouldn't receive epoll timeout event in qmp_event_thread"
+        end
+        let m = Monitor.create ()
 
-          let monitor_path domid = qmp_event_path domid
-          let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
+        let monitor_path domid = qmp_event_path domid
+        let debug_exn msg e = debug "%s: %s" msg (Printexc.to_string e)
 
-          let remove domid =
-            Lookup.channel_of domid >>= fun c ->
-            try 
-              finally
-                (fun () ->
-                   Lookup.remove c domid;
-                   Monitor.remove m (Qmp_protocol.to_fd c);
-                   debug "Removed QMP Event fd for domain %d" domid)
-                (fun () -> Qmp_protocol.close c)
-            with e -> debug_exn (Printf.sprintf "Got exception trying to remove qmp on domain-%d" domid) e
+        let remove domid =
+          Lookup.channel_of domid >>= fun c ->
+          try
+            finally
+              (fun () ->
+                 Lookup.remove c domid;
+                 Monitor.remove m (Qmp_protocol.to_fd c);
+                 debug "Removed QMP Event fd for domain %d" domid)
+              (fun () -> Qmp_protocol.close c)
+          with e -> debug_exn (Printf.sprintf "Got exception trying to remove qmp on domain-%d" domid) e
 
-          let add domid =
-            try
-              Lookup.channel_of domid >>| fun () ->
-              let c = Qmp_protocol.connect (monitor_path domid) in
-              Qmp_protocol.negotiate c;
-              Lookup.add c domid;
-              Monitor.add m (Qmp_protocol.to_fd c);
-              debug "Added QMP Event fd for domain %d" domid
-            with e ->
-              debug_exn (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket" domid) e;
-              remove domid
+        let add domid =
+          try
+            Lookup.channel_of domid >>| fun () ->
+            let c = Qmp_protocol.connect (monitor_path domid) in
+            Qmp_protocol.negotiate c;
+            Lookup.add c domid;
+            Monitor.add m (Qmp_protocol.to_fd c);
+            debug "Added QMP Event fd for domain %d" domid
+          with e ->
+            debug_exn (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket" domid) e;
+            remove domid
 
-          let qmp_event_handle domid qmp_event =
-            (* This function will be extended to handle qmp events *)
-            debug "Got QMP event, domain-%d: %s" domid qmp_event.event;
+        let qmp_event_handle domid qmp_event =
+          (* This function will be extended to handle qmp events *)
+          debug "Got QMP event, domain-%d: %s" domid qmp_event.event;
 
-            let rtc_change timeoffset =
-              with_xs (fun xs ->
+          let rtc_change timeoffset =
+            with_xs (fun xs ->
                 let timeoffset_key = sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid)) in
                 try
                   let rtc = xs.Xs.read timeoffset_key in
                   xs.Xs.write timeoffset_key Int64.(add timeoffset (of_string rtc) |> to_string)
                 with e -> error "Failed to process RTC_CHANGE for domain %d: %s" domid (Printexc.to_string e)
               )
-            in
+          in
 
-            let xen_platform_pv_driver_info pv_info =
-              with_xs (fun xs ->
+          let xen_platform_pv_driver_info pv_info =
+            with_xs (fun xs ->
                 let is_hvm_linux { product_num; build_num } =
                   let _XEN_IOPORT_LINUX_PRODNUM = 3 in (* from Linux include/xen/platform_pci.h *)
                   (product_num = _XEN_IOPORT_LINUX_PRODNUM) && (build_num <= 0xff)
                 in
                 if is_hvm_linux pv_info then
-                begin
-                  let write_local_domain prefix x = xs.Xs.write (Printf.sprintf "/local/domain/%d/%s%s" domid prefix x) "1" in
-                  List.iter (write_local_domain "control/feature-") ["suspend"; "poweroff"; "reboot"; "vcpu-hotplug"];
-                  List.iter (write_local_domain "data/") ["updated"]
-                end
+                  begin
+                    let write_local_domain prefix x = xs.Xs.write (Printf.sprintf "/local/domain/%d/%s%s" domid prefix x) "1" in
+                    List.iter (write_local_domain "control/feature-") ["suspend"; "poweroff"; "reboot"; "vcpu-hotplug"];
+                    List.iter (write_local_domain "data/") ["updated"]
+                  end
               )
-            in
+          in
 
-            qmp_event.data |> function
-            | Some (RTC_CHANGE timeoffset)         -> rtc_change timeoffset
-            | Some (XEN_PLATFORM_PV_DRIVER_INFO x) -> xen_platform_pv_driver_info x
-            | _ -> () (* unhandled QMP events *)
+          qmp_event.data |> function
+          | Some (RTC_CHANGE timeoffset)         -> rtc_change timeoffset
+          | Some (XEN_PLATFORM_PV_DRIVER_INFO x) -> xen_platform_pv_driver_info x
+          | _ -> () (* unhandled QMP events *)
 
-          let qmp_event_thread () =
-            debug "Starting QMP_Event thread";
-            (* Add the existing qmp sockets first *)
-            Sys.readdir var_run_xen_path
-            |> Array.to_list
-            |> List.iter (fun x -> try Scanf.sscanf x "qmp-event-%d" add with _ -> ());
+        let qmp_event_thread () =
+          debug "Starting QMP_Event thread";
+          (* Add the existing qmp sockets first *)
+          Sys.readdir var_run_xen_path
+          |> Array.to_list
+          |> List.iter (fun x -> try Scanf.sscanf x "qmp-event-%d" add with _ -> ());
 
-            while true do
-              try
-                Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
+          while true do
+            try
+              Monitor.wait m |> Monitor.with_event m (fun fd is_flag_in ->
                   Lookup.domid_of fd >>= fun domid ->
                   if is_flag_in then
                     Lookup.channel_of domid >>= fun c ->
@@ -2030,37 +2030,37 @@ module Backend = struct
                     with End_of_file ->
                       debug "domain-%d: end of file, close qmp socket" domid;
                       remove domid
-                    | e ->
-                      debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
-                      remove domid
+                       | e ->
+                         debug_exn (Printf.sprintf "domain-%d: close qmp socket" domid) e;
+                         remove domid
                   else begin
                     debug "EPOLL error on domain-%d, close qmp socket" domid;
                     remove domid
                   end
-                  )
-              with e ->
-                debug_exn "Exception in qmp_event_thread: %s" e;
-            done
+                )
+            with e ->
+              debug_exn "Exception in qmp_event_thread: %s" e;
+          done
 
-        end (* Qemu_upstream_compat.Dm.QMP_Event *)
+      end (* Qemu_upstream_compat.Dm.QMP_Event *)
 
-        module Event = struct
-          let init () = ignore(Thread.create QMP_Event.qmp_event_thread ())
-        end
+      module Event = struct
+        let init () = ignore(Thread.create QMP_Event.qmp_event_thread ())
+      end
 
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
-          let open Qmp in
-          let qmp_cmd = Command (None, Query_vnc) in
-          let parse_qmp_message = function
-            | Success (None, Vnc vnc) -> (try Some vnc.service with _ -> None)
-            | _ -> debug "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd); None
-          in
-          let qmp_cmd_result = qmp_write_and_read domid qmp_cmd in
-          match qmp_cmd_result with
-          | Some qmp_message -> parse_qmp_message qmp_message
-          | None -> debug "Fail to get result after sending Qmp message: %s" (string_of_message qmp_cmd); None
-        )
+            let open Qmp in
+            let qmp_cmd = Command (None, Query_vnc) in
+            let parse_qmp_message = function
+              | Success (None, Vnc vnc) -> (try Some vnc.service with _ -> None)
+              | _ -> debug "Get unexpected result after sending Qmp message: %s" (string_of_message qmp_cmd); None
+            in
+            let qmp_cmd_result = qmp_write_and_read domid qmp_cmd in
+            match qmp_cmd_result with
+            | Some qmp_message -> parse_qmp_message qmp_message
+            | None -> debug "Fail to get result after sending Qmp message: %s" (string_of_message qmp_cmd); None
+          )
 
       let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =
         Dm_Common.suspend task ~xs ~qemu_domid domid;
@@ -2131,7 +2131,7 @@ module Dm = struct
   let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel profile =
     (* init_daemon must decide the backend based on a profile because the qemu daemon is not running
        at the moment and Backend.of_domid uses is_upstream_qemu which depends on a running qemu.
-     *)
+    *)
     let module Q = (val Backend.of_profile profile) in
     Q.Dm.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel ()
 
@@ -2266,14 +2266,14 @@ let clean_shutdown (task: Xenops_task.task_handle) ~xs (x: device) = match x.bac
   | Vfb -> Vfb.clean_shutdown task ~xs x
   | Vkbd -> Vkbd.clean_shutdown task ~xs x
 
-let get_vnc_port ~xs domid = 
+let get_vnc_port ~xs domid =
   (* Check whether a qemu exists for this domain *)
   let qemu_exists = Qemu.is_running ~xs domid in
   if qemu_exists
   then Dm.get_vnc_port ~xs domid
   else PV_Vnc.get_vnc_port ~xs domid
 
-let get_tc_port ~xs domid = 
+let get_tc_port ~xs domid =
   (* Check whether a qemu exists for this domain *)
   let qemu_exists = Qemu.is_running ~xs domid in
   if qemu_exists

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -253,7 +253,7 @@ sig
 	val signal : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> domid:Xenctrl.domid -> ?wait_for:string -> ?param:string
 	          -> string -> unit
 
-	val cmdline_of_info: info -> bool -> int -> string list
+	val cmdline_of_info: xs:Xenstore.Xs.xsh -> dm:Profile.t -> info -> bool -> int -> string list
 
 	val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
 	val start_vnconly : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit

--- a/xc/stubdom.ml
+++ b/xc/stubdom.ml
@@ -46,7 +46,7 @@ let create ~xc ~xs domid =
     Domain.set_machine_address_size ~xc stubdom_domid (Some 32);
 	stubdom_domid
 
-let build (task: Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid info xenguest domid stubdom_domid =
+let build (task: Xenops_task.task_handle) ~xc ~xs ~dm ~store_domid ~console_domid info xenguest domid stubdom_domid =
     (* Now build it as a PV domain *)
     let (_: Domain.domarch) = Domain.build task ~xc ~xs ~store_domid ~console_domid ~timeoffset:"" ~extras:[] {
         Domain.memory_max=memory_kib;
@@ -77,7 +77,7 @@ let build (task: Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid in
     let path = Printf.sprintf "/vm/%s/image/dmargs" guest_uuid_str in
 	(* Remove any 'pty' references from the arguments: XXX why? *)
 	let info' = { info with Device.Dm.serial = None; monitor = None } in
-	let args = Device.Dm.cmdline_of_info info' false domid in
+	let args = Device.Dm.cmdline_of_info ~xs ~dm info' false domid in
     xs.Xs.write path (String.concat " " args);
     debug "jjd27: written qemu-dm args into xenstore at %s: [%s]" path (String.concat " " args);
 
@@ -98,7 +98,7 @@ let build (task: Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid in
 	(* VKBD is needed for keyboard input via the stubdom *)
 	Device.Vkbd.add ~xc ~xs stubdom_domid;
 
-	(* XXX: 
+	(* XXX:
     (* Add a place for qemu to record the dm state in XenStore, with appropriate permissions *)
     List.iter (fun domid -> Device.Dm.init ~xs ~domid) [stubdom_domid; domid];
 	*)

--- a/xc/stubdom.mli
+++ b/xc/stubdom.mli
@@ -19,6 +19,7 @@ val create: xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Xenctrl.
 val build: Xenops_task.Xenops_task.task_handle
   -> xc:Xenctrl.handle
   -> xs:Xenstore.Xs.xsh
+  -> dm:Device.Profile.t
   -> store_domid:int
   -> console_domid:int
   -> Device.Dm.info

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1343,7 +1343,7 @@ module VM = struct
 						if saved_state then failwith "Cannot resume with stubdom yet";
 						Opt.iter
 							(fun stubdom_domid ->
-								Stubdom.build task ~xc ~xs ~store_domid ~console_domid info xenguest di.Xenctrl.domid stubdom_domid;
+								Stubdom.build task ~xc ~xs ~dm:qemu_dm ~store_domid ~console_domid info xenguest di.Xenctrl.domid stubdom_domid;
 								Device.Dm.start_vnconly task ~xs ~dm:qemu_dm info stubdom_domid
 							) (get_stubdom ~xs di.Xenctrl.domid);
 					| Vm.HVM { Vm.qemu_stubdom = false } ->
@@ -1476,7 +1476,7 @@ module VM = struct
 				(* Not currently ballooning *)
 				| None | Some "0" -> ()
 				(* Ballooning in progress, we need to wait *)
-				| Some _ -> 
+				| Some _ ->
 					let watches = [ Watch.value_to_become balloon_active_path "0"
 					              ; Watch.key_to_disappear balloon_active_path ]
 					in


### PR DESCRIPTION
I'm attaching results from dev testing. The lines are from /var/log/daemon.log with inserted line breaks for legibility.

Before the current changes these are the CLI options coming out of xenopsd:
```
Oct 30 14:00:15 localhost forkexecd: [ info|dt16|0 ||forkexecd] qemu-dm-4[30956]: Arguments: 4 --syslog -d 4 -m 2048 -boot cdn
 -serial pty -vcpus 2 -std-vga -videoram 8 -vncunused -vnc 127.0.0.1:1 -usb -usbdevice tablet
 -net nic,vlan=0,macaddr=ce:f2:af:5f:a6:e2,model=rtl8139 -net tap,vlan=0,bridge=xenbr0,ifname=tap4.0
 -net nic,vlan=1,macaddr=fa:61:82:f5:d3:8a,model=rtl8139 -net tap,vlan=1,bridge=xenbr0,ifname=tap4.1
 -net nic,vlan=2,macaddr=9e:2b:92:31:76:a5,model=rtl8139 -net tap,vlan=2,bridge=xenbr0,ifname=tap4.2
 -net nic,vlan=3,macaddr=d6:23:c8:d1:08:2a,model=rtl8139 -net tap,vlan=3,bridge=xenbr0,ifname=tap4.3
 -acpi -monitor null
```
and qemu-wrapper converts them to the following:
```
Oct 30 14:00:15 localhost forkexecd: [ info|dt16|0 ||forkexecd] qemu-dm-4[30956]: Exec: /usr/lib64/xen/bin/qemu-system-i386 qemu-dm-4
 -machine pc-0.10,accel=xen,max-ram-below-4g=4026531840,allow-unassigned=true,trad_compat=true -display none -nodefaults
 -device xen-platform,addr=3,device-id=0x0001,revision=0x2,class-id=0x0100,subvendor_id=0x5853,subsystem_id=0x0001
 -qmp unix:/var/run/xen/qmp-libxl-4,server,nowait -qmp unix:/var/run/xen/qmp-event-4,server,nowait -parallel null -xen-domid 4
 -m size=2048 -boot order=cdn -serial pty -smp maxcpus=2
 -vnc 127.0.0.1:1,to=1000,lock-key-sync=off -usb -device usb-tablet,port=2

 -device rtl8139,netdev=tapnet0,mac=ce:f2:af:5f:a6:e2,addr=4 -netdev tap,id=tapnet0,ifname=tap4.0,script=no,downscript=no
 -device rtl8139,netdev=tapnet1,mac=fa:61:82:f5:d3:8a,addr=5 -netdev tap,id=tapnet1,ifname=tap4.1,script=no,downscript=no
 -device rtl8139,netdev=tapnet2,mac=9e:2b:92:31:76:a5,addr=6 -netdev tap,id=tapnet2,ifname=tap4.2,script=no,downscript=no
 -device rtl8139,netdev=tapnet3,mac=d6:23:c8:d1:08:2a,addr=7 -netdev tap,id=tapnet3,ifname=tap4.3,script=no,downscript=no -monitor null

 -drive file=/dev/sm/backend/943c9dfe-9fc4-b08f-6778-39907eaadac2/c3c85550-b31a-4640-9dd3-02716e4ecc52,if=ide,index=0,media=disk,format=raw,force-lba=on
 -drive file=,if=ide,index=3,media=cdrom,force-lba=off -device VGA,vgamem_mb=8,rombar=1,romfile=,subvendor_id=0x5853,subsystem_id=0x0001,qemu-extended-regs=false
 -global PIIX4_PM.revision_id=0x1 -global ide-hd.ver=0.10.2 -global piix3-ide-xen.subvendor_id=0x5853
 -global piix3-ide-xen.subsystem_id=0x0001 -global piix3-usb-uhci.subvendor_id=0x5853 -global piix3-usb-uhci.subsystem_id=0x0001
 -global rtl8139.subvendor_id=0x5853 -global rtl8139.subsystem_id=0x0001 -trace enable=xen_platform_log -vnc-clipboard-socket-fd 4
```
After the changes these are the CLI options coming out of xenopsd:
```
Oct 30 13:41:52 localhost forkexecd: [ info|dt18|0 ||forkexecd] qemu-dm-6[2438]: Arguments: 6 --syslog -d 6 -m 2048 -boot cdn
 -serial pty -vcpus 2 -std-vga -videoram 8 -vncunused -vnc 127.0.0.1:1 -usb -usbdevice tablet -acpi -monitor null
 -device rtl8139,netdev=tapnet0,mac=82:f2:03:48:21:d3,addr=4 -netdev tap,id=tapnet0,ifname=tap6.0,script=no,downscript=no
 -device rtl8139,netdev=tapnet1,mac=3e:47:af:98:8d:dd,addr=5 -netdev tap,id=tapnet1,ifname=tap6.1,script=no,downscript=no
 -device rtl8139,netdev=tapnet2,mac=32:46:a2:3b:d8:fb,addr=6 -netdev tap,id=tapnet2,ifname=tap6.2,script=no,downscript=no
 -device rtl8139,netdev=tapnet3,mac=ee:10:3f:fc:51:74,addr=7 -netdev tap,id=tapnet3,ifname=tap6.3,script=no,downscript=no
```
and here is what the qemu-wrapper executes:
```
Oct 30 13:41:52 localhost forkexecd: [ info|dt18|0 ||forkexecd] qemu-dm-6[2438]: Exec: /usr/lib64/xen/bin/qemu-system-i386 qemu-dm-6
 -machine pc-0.10,accel=xen,max-ram-below-4g=4026531840,allow-unassigned=true,trad_compat=true -display none -nodefaults
 -device xen-platform,addr=3,device-id=0x0001,revision=0x2,class-id=0x0100,subvendor_id=0x5853,subsystem_id=0x0001
 -qmp unix:/var/run/xen/qmp-libxl-6,server,nowait -qmp unix:/var/run/xen/qmp-event-6,server,nowait -parallel null -xen-domid 6
 -m size=2048 -boot order=cdn -serial pty -smp maxcpus=2
 -vnc 127.0.0.1:1,to=1000,lock-key-sync=off -usb -device usb-tablet,port=2 -monitor null

 -device rtl8139,netdev=tapnet0,mac=82:f2:03:48:21:d3,addr=4 -netdev tap,id=tapnet0,ifname=tap6.0,script=no,downscript=no
 -device rtl8139,netdev=tapnet1,mac=3e:47:af:98:8d:dd,addr=5 -netdev tap,id=tapnet1,ifname=tap6.1,script=no,downscript=no
 -device rtl8139,netdev=tapnet2,mac=32:46:a2:3b:d8:fb,addr=6 -netdev tap,id=tapnet2,ifname=tap6.2,script=no,downscript=no
 -device rtl8139,netdev=tapnet3,mac=ee:10:3f:fc:51:74,addr=7 -netdev tap,id=tapnet3,ifname=tap6.3,script=no,downscript=no

 -drive file=/dev/sm/backend/f363af26-de62-fa6d-fb84-f0477c0a5595/46bf20ac-9c94-4d30-bdb2-1033b55b33e9,if=ide,index=0,media=disk,format=raw,force-lba=on
 -drive file=,if=ide,index=3,media=cdrom,force-lba=off -device VGA,vgamem_mb=8,rombar=1,romfile=,subvendor_id=0x5853,subsystem_id=0x0001,qemu-extended-regs=false
 -global PIIX4_PM.revision_id=0x1 -global ide-hd.ver=0.10.2 -global piix3-ide-xen.subvendor_id=0x5853
 -global piix3-ide-xen.subsystem_id=0x0001 -global piix3-usb-uhci.subvendor_id=0x5853 -global piix3-usb-uhci.subsystem_id=0x0001
 -global rtl8139.subvendor_id=0x5853 -global rtl8139.subsystem_id=0x0001 -trace enable=xen_platform_log -vnc-clipboard-socket-fd 4
```