### PR TITLE
CP-24831: improve selection of the runtime qemu backend in xenopsd

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2160,8 +2160,8 @@ module Dm = struct
     let module Q = (val Backend.of_profile profile) in
     Q.Dm.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel ()
 
-  let get_vnc_port ~xs domid =
-    let module Q = (val Backend.of_domid domid) in
+  let get_vnc_port ~xs ~dm domid =
+    let module Q = (val Backend.of_profile dm) in
     Q.Dm.get_vnc_port ~xs domid
 
   let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid ~dm domid =
@@ -2295,11 +2295,11 @@ let clean_shutdown (task: Xenops_task.task_handle) ~xs (x: device) = match x.bac
   | Vfb -> Vfb.clean_shutdown task ~xs x
   | Vkbd -> Vkbd.clean_shutdown task ~xs x
 
-let get_vnc_port ~xs domid =
+let get_vnc_port ~xs ~dm domid =
   (* Check whether a qemu exists for this domain *)
   let qemu_exists = Qemu.is_running ~xs domid in
   if qemu_exists
-  then Dm.get_vnc_port ~xs domid
+  then Dm.get_vnc_port ~xs ~dm domid
   else PV_Vnc.get_vnc_port ~xs domid
 
 let get_tc_port ~xs domid =

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2164,16 +2164,16 @@ module Dm = struct
     let module Q = (val Backend.of_domid domid) in
     Q.Dm.get_vnc_port ~xs domid
 
-  let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =
-    let module Q = (val Backend.of_domid domid) in
+  let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid ~dm domid =
+    let module Q = (val Backend.of_profile dm) in
     Q.Dm.suspend task ~xs ~qemu_domid domid
 
   let stop ~xs ~qemu_domid ~dm domid =
     let module Q = (val Backend.of_profile dm) in
     Q.Dm.stop ~xs ~qemu_domid domid
 
-  let with_dirty_log domid ~f =
-    let module Q = (val Backend.of_domid domid) in
+  let with_dirty_log dm domid ~f =
+    let module Q = (val Backend.of_profile dm) in
     Q.Dm.with_dirty_log domid ~f
 
   let cmdline_of_info ~xs ~dm info restore domid =

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2168,8 +2168,8 @@ module Dm = struct
     let module Q = (val Backend.of_domid domid) in
     Q.Dm.suspend task ~xs ~qemu_domid domid
 
-  let stop ~xs ~qemu_domid domid  =
-    let module Q = (val Backend.of_domid domid) in
+  let stop ~xs ~qemu_domid ~dm domid =
+    let module Q = (val Backend.of_profile dm) in
     Q.Dm.stop ~xs ~qemu_domid domid
 
   let with_dirty_log domid ~f =

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -34,7 +34,7 @@ open D
 
 (** Definition of available qemu profiles, used by the qemu backend implementations *)
 module Profile = struct
-  type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
+  type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream [@@deriving rpc]
   let fallback = Qemu_trad
   let all = [ Qemu_trad; Qemu_upstream_compat; Qemu_upstream ]
   module Name = struct

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2138,13 +2138,13 @@ end
 module Vbd = struct
   include Vbd_Common
 
-  let media_eject ~xs device =
-    let module Q = (val Backend.of_domid device.frontend.domid) in
+  let media_eject ~xs ~dm device =
+    let module Q = (val Backend.of_profile dm) in
     Q.Vbd.qemu_media_change ~xs device "" ""
 
-  let media_insert ~xs ~phystype ~params device =
+  let media_insert ~xs ~dm ~phystype ~params device =
     let _type = backendty_of_physty phystype in
-    let module Q = (val Backend.of_domid device.frontend.domid) in
+    let module Q = (val Backend.of_profile dm) in
     Q.Vbd.qemu_media_change ~xs device _type params
 
 end (* Vbd *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -56,7 +56,6 @@ module Profile = struct
     | x when x = Name.qemu_upstream        -> Qemu_upstream
     | x -> debug "unknown device-model profile %s: defaulting to fallback: %s" x (string_of fallback);
       fallback
-  let of_domid x = if is_upstream_qemu x then Qemu_upstream else Qemu_trad
 end
 
 (* keys read by vif udev script (keep in sync with api:scripts/vif) *)
@@ -2124,8 +2123,6 @@ module Backend = struct
     | Profile.Qemu_upstream_compat -> (module Qemu_upstream_compat : Intf)
     | Profile.Qemu_upstream        -> (module Qemu_upstream        : Intf)
 
-  let of_domid x = of_profile (Profile.of_domid x)
-
   let init() =
     Qemu_upstream.Dm.Event.init()
 end
@@ -2154,9 +2151,6 @@ module Dm = struct
   include Dm_Common
 
   let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel profile =
-    (* init_daemon must decide the backend based on a profile because the qemu daemon is not running
-       at the moment and Backend.of_domid uses is_upstream_qemu which depends on a running qemu.
-    *)
     let module Q = (val Backend.of_profile profile) in
     Q.Dm.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel ()
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -91,8 +91,8 @@ sig
 	val add : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> hvm:bool -> t -> Xenctrl.domid -> device
 
 	val release : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> device -> unit
-	val media_eject : xs:Xenstore.Xs.xsh -> device -> unit
-	val media_insert : xs:Xenstore.Xs.xsh -> phystype:physty -> params:string -> device -> unit
+	val media_eject : xs:Xenstore.Xs.xsh -> dm:Profile.t -> device -> unit
+	val media_insert : xs:Xenstore.Xs.xsh -> dm:Profile.t -> phystype:physty -> params:string -> device -> unit
 	val media_is_ejected : xs:Xenstore.Xs.xsh -> device -> bool
 
 	val clean_shutdown_async : xs:Xenstore.Xs.xsh -> device -> unit

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -261,11 +261,11 @@ sig
 	val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
 	val start_vnconly : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
 	val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
-	val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
+	val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
 	val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
 
-	val with_dirty_log: int -> f:(unit -> unit) -> unit
+	val with_dirty_log: Profile.t -> int -> f:(unit -> unit) -> unit
 end
 
 module Backend: sig

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -263,7 +263,7 @@ sig
 	val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
 	val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
-	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
+	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
 
 	val with_dirty_log: int -> f:(unit -> unit) -> unit
 end

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -250,7 +250,7 @@ sig
 		extras: (string * string option) list;
 	}
 
-	val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+	val get_vnc_port : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> int option
 	val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
 	val signal : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> domid:Xenctrl.domid -> ?wait_for:string -> ?param:string
@@ -272,5 +272,5 @@ module Backend: sig
 	val init : unit -> unit
 end
 
-val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+val get_vnc_port : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> int option
 val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -26,6 +26,9 @@ module Profile: sig
 	type t = Qemu_trad | Qemu_upstream_compat | Qemu_upstream
 	(** available qemu profiles *)
 
+	val rpc_of_t: t -> Rpc.t
+	val t_of_rpc: Rpc.t -> t
+
 	(** the fallback profile in case an invalid profile string is provided to [of_string] *)
 	val fallback : t
 

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -370,7 +370,7 @@ let sysrq ~xs domid key =
 	let path = xs.Xs.getdomainpath domid ^ "/control/sysrq" in
 	xs.Xs.write path (String.make 1 key)
 
-let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid domid =
+let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid ~dm domid =
 	let dom_path = xs.Xs.getdomainpath domid in
 	let xenops_dom_path = xenops_path_of_domain domid in
 	let uuid = get_uuid ~xc domid in
@@ -420,7 +420,7 @@ let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid domid =
 	log_exn_continue "Xenctrl.domain_destroy" (Xenctrl.domain_destroy xc) domid;
 
 	log_exn_continue "Error stoping device-model, already dead ?"
-	                 (fun () -> Device.Dm.stop ~xs ~qemu_domid domid) ();
+	                 (fun () -> Device.Dm.stop ~xs ~qemu_domid ~dm domid) ();
 	log_exn_continue "Error stoping vncterm, already dead ?"
 	                 (fun () -> Device.PV_Vnc.stop ~xs domid) ();
 

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -100,7 +100,7 @@ val shutdown_wait_for_ack: Xenops_task.Xenops_task.task_handle -> timeout:float 
 val sysrq: xs:Xenstore.Xs.xsh -> domid -> char -> unit
 
 (** destroy a domain *)
-val destroy: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> domid -> unit
+val destroy: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Device.Profile.t -> domid -> unit
 
 (** Pause a domain *)
 val pause: xc: Xenctrl.handle -> domid -> unit

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -154,7 +154,7 @@ val restore: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs: Xe
 type suspend_flag = Live | Debug
 
 (** suspend a domain into the file descriptor *)
-val suspend: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> hvm: bool -> string -> string -> domid
+val suspend: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> hvm: bool -> dm:Device.Profile.t -> string -> string -> domid
           -> Unix.file_descr -> suspend_flag list
           -> ?progress_callback: (float -> unit)
 		  -> qemu_domid: int

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1523,7 +1523,7 @@ module VM = struct
 				with_data ~xc ~xs task data true
 					(fun fd ->
 						let vm_str = Vm.sexp_of_t vm |> Sexplib.Sexp.to_string in
-						Domain.suspend task ~xc ~xs ~hvm ~progress_callback ~qemu_domid (choose_xenguest vm.Vm.platformdata) vm_str domid fd flags'
+						Domain.suspend task ~xc ~xs ~hvm ~dm:(dm_of ~vm) ~progress_callback ~qemu_domid (choose_xenguest vm.Vm.platformdata) vm_str domid fd flags'
 							(fun () ->
 								(* SCTX-2558: wait more for ballooning if needed *)
 								wait_ballooning task vm;

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2213,7 +2213,7 @@ module VBD = struct
 					let phystype = Device.Vbd.Phys in
 					(* We store away the disk so we can implement VBD.stat *)
 					xs.Xs.write (vdi_path_of_device ~xs device) (disk |> rpc_of_disk |> Jsonrpc.to_string);
-					Device.Vbd.media_insert ~xs ~phystype ~params:vdi.attach_info.Storage_interface.params device;
+					Device.Vbd.media_insert ~xs ~dm:(dm_of ~vm) ~phystype ~params:vdi.attach_info.Storage_interface.params device;
 					Device_common.add_backend_keys ~xs device "sm-data" vdi.attach_info.Storage_interface.xenstore_data
 				end
 			) Newest vm
@@ -2222,7 +2222,7 @@ module VBD = struct
 		on_frontend
 			(fun xc xs frontend_domid hvm ->
 				let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) Oldest (id_of vbd) in
-				Device.Vbd.media_eject ~xs device;
+				Device.Vbd.media_eject ~xs ~dm:(dm_of ~vm) device;
 				safe_rm xs (vdi_path_of_device ~xs device);
 				safe_rm xs (Device_common.backend_path_of_device ~xs device ^ "/sm-data");
 				Storage.dp_destroy task (Storage.id_of (string_of_int (frontend_domid_of_device device)) vbd.Vbd.id)

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1351,7 +1351,7 @@ module VM = struct
 
 	let create_device_model_exn vbds vifs vgpus saved_state xc xs task vm di =
 		let vmextra = DB.read_exn vm.Vm.id in
-		let qemu_dm = choose_qemu_dm vm.Vm.platformdata in
+		let qemu_dm = dm_of ~vm in
 		let xenguest = choose_xenguest vm.Vm.platformdata in
 		debug "chosen qemu_dm = %s" (Device.Profile.wrapper_of qemu_dm);
 		debug "chosen xenguest = %s" xenguest;

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1658,7 +1658,7 @@ module VM = struct
 						end
 					| Some di ->
 						let vnc = Opt.map (fun port -> { Vm.protocol = Vm.Rfb; port = port; path = "" })
-							(Device.get_vnc_port ~xs di.Xenctrl.domid) in
+							(Device.get_vnc_port ~xs ~dm:(dm_of ~vm) di.Xenctrl.domid) in
 						let tc = Opt.map (fun port -> { Vm.protocol = Vm.Vt100; port = port; path = "" })
 							(Device.get_tc_port ~xs di.Xenctrl.domid) in
 						let local x = Printf.sprintf "/local/domain/%d/%s" di.Xenctrl.domid x in


### PR DESCRIPTION
The function is_upstream_qemu is a somewhat fragile mechanism to select the
qemu profile from a domid because it uses a xenstore key that can be
manipulated by other processes outside xenopsd or race with threads inside
xenopsd. Manipulation of this key will lead to xenopsd selecting different
qemu profiles for the same domid, which can cause errors. An example of an
error caused by is_upstream_qemu is when Vm.shutdown is explicitly called on
a domid with a qemu-upstream profile. Vm.shutdown will eventually call Dm.stop,
which deletes this key. This races with the xenopsd xenstore watcher thread,
which can detect that the domid changed state to shutdown and then call
Dm.stop again via VM_check_state, causing the second Dm.stop that is executed
to run with the wrong qemu-trad profile because the first one deleted the key
that is_upstream_qemu uses to select the qemu-upstream profile.

This patch improves the robustness of this mechanism by making xenopsd remember
the profile that was used to start qemu. This removes all external dependencies
when selecting the profile while xenopsd is running, causing xenopsd to reuse
the same profile throughout the lifetime of the domid.

We use a new profile member in the VMExtra.persistent_t type, initialised directly from the
VM platform data during Vm.start, which is persistent by xenopsd throughout the lifetime of
the VM (from Vm.start through all migrate,suspend/resume .... until Vm.shutdown). As a
result, there's no need for using is_upstream_qemu or query xenstore anymore to decide
which profile a VM belongs to.

Tested using vm-start, migrate (local and remote), suspend/resume, vm-shutdown, and xenopsd restarts.

Signed-off-by: Marcus Granado marcus.granado@citrix.com