### PR TITLE
CP-25316: Send QMP stop message before saving device state

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2066,6 +2066,7 @@ module Backend = struct
       let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =
         Dm_Common.suspend task ~xs ~qemu_domid domid;
         let file = sprintf qemu_save_path domid in
+        qmp_write domid (Qmp.Command(None, Qmp.Stop));
         qmp_write domid (Qmp.Command(None, Qmp.Xen_save_devices_state file))
 
       let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel _ =

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2066,8 +2066,8 @@ module Backend = struct
       let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =
         Dm_Common.suspend task ~xs ~qemu_domid domid;
         let file = sprintf qemu_save_path domid in
-        qmp_write domid (Qmp.Command(None, Qmp.Stop));
-        qmp_write domid (Qmp.Command(None, Qmp.Xen_save_devices_state file))
+        qmp_write domid Qmp.(Command(None, Stop));
+        qmp_write domid Qmp.(Command(None, Xen_save_devices_state file))
 
       let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel _ =
         let pid = Dm_Common.init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeout ~cancel () in
@@ -2082,11 +2082,11 @@ module Backend = struct
       let with_dirty_log domid ~f =
         finally
           (fun() ->
-             qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log true));
+             qmp_write domid Qmp.(Command(None, Xen_set_global_dirty_log true));
              f()
           )
           (fun() ->
-             qmp_write domid (Qmp.Command(None, Qmp.Xen_set_global_dirty_log false));
+             qmp_write domid Qmp.(Command(None, Xen_set_global_dirty_log false));
           )
 
       let cmdline_of_info ~xs ~dm info restore domid =

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -341,6 +341,7 @@ let is_upstream_qemu domid =
 let qmp_write_and_read domid ?(read_result=true) cmd  =
   try
     let open Qmp in
+    debug "QMP.Command for domid %d: %s" domid (string_of_message cmd);
     let c = Qmp_protocol.connect (qmp_libxl_path domid) in
     finally
       (fun () ->


### PR DESCRIPTION
According to the design, xenopsd shall send the `stop` QMP message to stop QEMU before sending the `xen-save-devices-state` QMP command to get the QEMU save image. This is what libxl does and what happens implicitly when qemu-trad saves state. 

This patch adds this change and an extra debug line to track QMP messages sent to QEMU by xenopsd. This will add infrequent extra log lines, and most of these extra log lines are related to the QMP command Query_vnc, which we intend to remove soon anyway.

Tested successfully with vm.suspend/resume and vm.migrate.

Verified that the QMP.Stop command is being called as expected before QMP.Xen_save_devices_state:
```
Async.VM.suspend R:9feb1f745927|xenops] QMP.Command for domid 3: {"execute":"xen-set-global-dirty-log","arguments":{"enable":true}}
Async.VM.suspend R:9feb1f745927|xenops] QMP.Command for domid 3: {"execute":"stop"}
Async.VM.suspend R:9feb1f745927|xenops] QMP.Command for domid 3: {"execute":"xen-save-devices-state","arguments":{"filename":"/var/lib/xen/qemu-save.3"}}
Async.VM.suspend R:9feb1f745927|xenops] QMP.Command for domid 3: {"execute":"xen-set-global-dirty-log","arguments":{"enable":false}}
```
