### PR TITLE
cp-24831: persist qemu backend profile when importing VM metadata in migration

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1892,7 +1892,10 @@ module VM = struct
       | _ -> persistent
     in
     let persistent = { persistent with VmExtra.profile = profile_of ~vm } in
-    debug "vm %s: persisting metadata %s" k (persistent |> VmExtra.rpc_of_persistent_t |> Jsonrpc.to_string);
+    persistent |> VmExtra.rpc_of_persistent_t |> Jsonrpc.to_string |> fun state_new ->
+      debug "vm %s: persisting metadata %s" k state_new;
+      (if state_new <> state then debug "vm %s: different original metadata %s" k state)
+    ;
     let non_persistent = match DB.read k with
       | None -> with_xc_and_xs (fun xc xs -> generate_non_persistent_state xc xs vm)
       | Some vmextra -> vmextra.VmExtra.non_persistent

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1891,6 +1891,8 @@ module VM = struct
         end
       | _ -> persistent
     in
+    let persistent = { persistent with VmExtra.profile = profile_of ~vm } in
+    debug "vm %s: persisting metadata %s" k (persistent |> VmExtra.rpc_of_persistent_t |> Jsonrpc.to_string);
     let non_persistent = match DB.read k with
       | None -> with_xc_and_xs (fun xc xs -> generate_non_persistent_state xc xs vm)
       | Some vmextra -> vmextra.VmExtra.non_persistent


### PR DESCRIPTION
During the execution of a VM_migrate operation, xenopsd transmits the VM
metadata using the function `Remote.VM.import_metadata`, which is executed on
the destination host. This function will eventually call `set_internal_state`
on the destination host, which recomputes some fields the VMExtra metadata for
the VM about to be received as a result of the migration, before persisting it
in the destination host.

This patch recomputes the profile field in VMExtra as well before persisting
this metadata, which is necessary to guarantee that the received metadata will
contain a profile consistent with the destination host. This is specially
significant if the destination host is a newer version of xenopsd, which could
associate different qemu backend profiles for the received VM metadata.

An extra line of debugging for each vm migrate operation is added, to permit to
check which VMExtra fields are being persisted on the new host.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>

--
Test migrating a qemu-upstream VM between Inverness and post-Inverness:

* *before change:* notice that the VM extra data has no persistent profile in its metadata after migration of a qemu-upstream VM from Inverness to post-Inverness. This will cause the VM to use the (incorrect) fallback profile when starting in the destination host:
```
$ find /var/run/nonpersistent # in the receiving host
./xenopsd/classic/extra/c3d14673-f984-9346-9429-7b02354ca0f8

$ cat /var/run/nonpersistent/xenopsd/classic/extra/c3d14673-f984-9346-9429-7b02354ca0f8

{"persistent": {"build_info": {"memory_max": 2097152, "memory_target": 2097152, "kernel": "\/usr\/libexec\/xen\/boot\/hvmloader", "vcpus": 2, "priv": ["BuildHVM", {"shadow_multiplier": 1.000000, "video_mib": 4}]}, "ty": ["HVM", {"hap": true, "shadow_multiplier": 1.000000, "timeoffset": "-26401", "video_mib": 4, "video": "Cirrus", "acpi": true, "serial": "pty", "pci_emulations": [], "pci_passthrough": false, "boot_order": "dc", "qemu_disk_cmdline": false, "qemu_stubdom": false}], 
"last_start_time": 1509633801.367612,
"nomigrate": false,
"nested_virt": false},

"non_persistent": {"create_info": {"ssidref": 0, "hvm": true, "hap": true, "name": "win7sp1 qemu-upstream 1", "xsdata": {"vm-data": ""}, "platformdata": {"acpi_s4": "0", "acpi_s3": "0", "featureset": "178bfbff-96b82203-2fd3fbff-00018df7-00000000-00000000-00000000-00000000-00000000", "generation-id": "", "timeoffset": "-26401", "usb": "true", "usb_tablet": "true", "device-model": "qemu-upstream", "hpet": "true", "apic": "true", "device_id": "0002", "cores-per-socket": "2", "pae": "true", "nx": "true", "viridian_time_ref_count": "true", "viridian": "true", "acpi": "1", "viridian_reference_tsc": "true", "vcpu\/number": "2", "vcpu\/current": "2", "vcpu\/1\/affinity": "1111111111111111111111111111111111111111111111111111111111111111", "vcpu\/0\/affinity": "1111111111111111111111111111111111111111111111111111111111111111", "vcpu\/weight": "256", "vcpu\/cap": "0"}, "bios_strings": {"bios-vendor": "Xen", "bios-version": "", "system-manufacturer": "Xen", "system-product-name": "HVM domU", "system-version": "", "system-serial-number": "", "enclosure-asset-tag": "", "hp-rombios": "", "oem-1": "Xen", "oem-2": "MS_VM_CERT\/SHA1\/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"}, "has_vendor_device": true}, "vcpu_max": 2, "vcpus": 2, "shadow_multiplier": 1.000000, "memory_static_max": 2147483648, "suspend_memory_bytes": 0, "qemu_vbds": [], "qemu_vifs": [], "pci_msitranslate": true, "pci_power_mgmt": false, "pv_drivers_detected": false}}
```

* *after the change:* the VM extra data has its persistent profile information recomputed properly (notice the `profile:Qemu_upstream` field at the end of the persistent metadata):
```
{"persistent": {"build_info": {"memory_max": 2097152, "memory_target": 2097152, "kernel": "\/usr\/libexec\/xen\/boot\/hvmloader", "vcpus": 2, "priv": ["BuildHVM", {"shadow_multiplier": 1.000000, "video_mib": 4}]}, "ty": ["HVM", {"hap": true, "shadow_multiplier": 1.000000, "timeoffset": "-26415", "video_mib": 4, "video": "Cirrus", "acpi": true, "serial": "pty", "pci_emulations": [], "pci_passthrough": false, "boot_order": "dc", "qemu_disk_cmdline": false, "qemu_stubdom": false}],
"last_start_time": 1509642722.627968,
"nomigrate": false,
"nested_virt": false,
"profile": "Qemu_upstream"},

"non_persistent": {"create_info": {"ssidref": 0, "hvm": true, "hap": true, "name": "win7sp1 qemu-upstream 2", "xsdata": {"vm-data": ""}, "platformdata": {"acpi_s4": "0", "acpi_s3": "0", "featureset": "178bfbff-96b82203-2fd3fbff-00018df7-00000000-00000000-00000000-00000000-00000000", "generation-id": "", "timeoffset": "-26401", "usb": "true", "usb_tablet": "true", "device-model": "qemu-upstream", "hpet": "true", "apic": "true", "device_id": "0002", "cores-per-socket": "2", "pae": "true", "nx": "true", "viridian_time_ref_count": "true", "viridian": "true", "acpi": "1", "viridian_reference_tsc": "true", "vcpu\/number": "2", "vcpu\/current": "2", "vcpu\/1\/affinity": "1111111111111111111111111111111111111111111111111111111111111111", "vcpu\/0\/affinity": "1111111111111111111111111111111111111111111111111111111111111111", "vcpu\/weight": "256", "vcpu\/cap": "0"}, "bios_strings": {"bios-vendor": "Xen", "bios-version": "", "system-manufacturer": "Xen", "system-product-name": "HVM domU", "system-version": "", "system-serial-number": "", "enclosure-asset-tag": "", "hp-rombios": "", "oem-1": "Xen", "oem-2": "MS_VM_CERT\/SHA1\/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d"}, "has_vendor_device": true}, "vcpu_max": 2, "vcpus": 2, "shadow_multiplier": 1.000000, "memory_static_max": 2147483648, "suspend_memory_bytes": 0, "qemu_vbds": [[["403c5300-0588-6fce-9bae-99fb47c01074", "xvda"], [0, ["Name", "\/dev\/sm\/backend\/6b4bf8c8-1f45-5528-b535-235ae324d339\/43209ae7-1548-4312-aa46-b94d29d381c8"]]]], "qemu_vifs": [], "pci_msitranslate": true, "pci_power_mgmt": false, "pv_drivers_detected": true}}
```
and it works as well for a VM that uses the qemu-trad profile:
```
{"persistent": {"build_info": {"memory_max": 2097152, "memory_target": 2097152, "kernel": "\/usr\/libexec\/xen\/boot\/hvmloader", "vcpus": 2, "priv": ["BuildHVM", {"shadow_multiplier": 1.000000, "video_mib": 4}]}, "ty": ["HVM", {"hap": true, "shadow_multiplier": 1.000000, "timeoffset": "-26391", "video_mib": 4, "video": "Cirrus", "acpi": true, "serial": "pty", "pci_emulations": [], "pci_passthrough": false, "boot_order": "dc", "qemu_disk_cmdline": false, "qemu_stubdom": false}],
"last_start_time": 1509643924.758117, 
"nomigrate": false, 
"nested_virt": false, 
"profile": "Qemu_trad"}, 
```