### PR TITLE
CP-25570: connect to VNC console in qemu-upstream VMs using a Unix socket

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -190,10 +190,6 @@ def main(argv):
             del qemu_args[n]
             continue
 
-        if p == "-vncunused":
-            del qemu_args[n]
-            continue
-
         if p == "-priv":
             del qemu_args[n]
             continue

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -267,17 +267,6 @@ def main(argv):
             del qemu_args[n]
             continue
 
-        if p == "-vnc":
-            # Pass QEMU a range of ports, then use QMP to find the port it picked.
-            # There is a hack here
-            #    Disable lock-key-sync
-            #    lock-key-sync expects vnclient to send different keysym for
-            #    alphabet keys (different for lowercase and uppercase). XC
-            #    can't do it atm, disable lock-key-sync
-            qemu_args[n+1] = "127.0.0.1:1,to=1000,lock-key-sync=off"
-            n += 2
-            continue
-
         if p == "-loadvm":
             loadvm_path = qemu_args[n+1]
             if qemu_trad_image.is_trad_image(loadvm_path):

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1648,18 +1648,17 @@ module Dm_Common = struct
     let videoram_opt = ["-videoram"; string_of_int info.video_mib] in
     let vnc_opts_of ip_addr_opt auto port keymap ~domid =
       let ip_addr = Opt.default "127.0.0.1" ip_addr_opt in
-      let vnc_arg = match domid with
-        | None when auto -> Printf.sprintf "%s:1"  ip_addr
-        | None           -> Printf.sprintf "%s:%d" ip_addr port
+      let unused_opt, vnc_arg = match domid with
+        | None when auto -> ["-vncunused"], Printf.sprintf "%s:1"  ip_addr
+        | None           -> [], Printf.sprintf "%s:%d" ip_addr port
           (*
               Disable lock-key-sync
               #  lock-key-sync expects vnclient to send different keysym for
               #  alphabet keys (different for lowercase and uppercase). XC
               #  can't do it at the moment, so disable lock-key-sync
           *)
-        | Some domid     -> Printf.sprintf "%s,lock-key-sync=off" (Socket.Unix.path (vnc_socket_path domid))
+        | Some domid     -> [], Printf.sprintf "%s,lock-key-sync=off" (Socket.Unix.path (vnc_socket_path domid))
       in
-      let unused_opt = if auto then ["-vncunused"] else [] in
       let vnc_opt = ["-vnc"; vnc_arg] in
       let keymap_opt = match keymap with Some k -> ["-k"; k] | None -> [] in
       List.flatten [unused_opt; vnc_opt; keymap_opt]

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -52,6 +52,12 @@ module Profile: sig
   val of_string : string -> t
 end
 
+(** Represent an IPC endpoint *)
+module Socket :
+sig
+	type t = Unix of string | Port of int
+end
+
 module Generic :
 sig
   val rm_device_state : xs:Xenstore.Xs.xsh -> device -> unit
@@ -140,7 +146,7 @@ sig
   val start : ?statefile:string -> xs:Xenstore.Xs.xsh -> ?ip:string -> Xenctrl.domid -> unit
   val stop : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
 
-  val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
+  val get_vnc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Socket.t option
   val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 end
 
@@ -250,7 +256,7 @@ sig
     extras: (string * string option) list;
   }
 
-  val get_vnc_port : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> int option
+  val get_vnc_port : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> Socket.t option
   val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option
 
   val signal : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> domid:Xenctrl.domid -> ?wait_for:string -> ?param:string
@@ -280,5 +286,5 @@ sig
   val qom_list : xs:Xenstore.Xs.xsh -> domid:Xenctrl.domid -> string list
 end
 
-val get_vnc_port : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> int option
+val get_vnc_port : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> Socket.t option
 val get_tc_port : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> int option

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1680,7 +1680,9 @@ module VM = struct
                halted_vm
            end
          | Some di ->
-           let vnc = Opt.map (fun port -> { Vm.protocol = Vm.Rfb; port = port; path = "" })
+           let vnc = Opt.map (function
+                 | Device.Socket.Port port -> { Vm.protocol = Vm.Rfb; port = port; path = "" }
+                 | Device.Socket.Unix path -> { Vm.protocol = Vm.Rfb; port = 0 ; path = path })
                (Device.get_vnc_port ~xs ~dm:(dm_of ~vm) di.Xenctrl.domid) in
            let tc = Opt.map (fun port -> { Vm.protocol = Vm.Vt100; port = port; path = "" })
                (Device.get_tc_port ~xs di.Xenctrl.domid) in


### PR DESCRIPTION
instead of using a network connection. This makes it easier to separate qemu-upstream in its own network namespace. A nice side-effect is that xenopsd knows the Unix path of the socket that was used when starting the qemu-upstream process and therefore QMP queries to qemu-upstream are not necessary anymore, simplifying the qemu-upstream backend.                                           

qemu-trad and PV VMs are not affected and continue to use a network connection for the VNC console.                                                                                           
                                                                                                            
This change depends on replacing the parameter for the VNC console from a network port to a Unix socket path when starting qemu-upstream, using the same matching vnc_socket_path used to connect to the console.

After this change, qemu-upstream will be started using 

    >  -vnc unix:/var/run/xen/vnc-<domid>,lock-key-sync=off
    >    A replacement for qemu-trad's -vncunused -vnc 127.0.0.1:1
                                                                                                    
instead of                                                                                                                                                               
                                                                                                                   
    >  -vnc 127.0.0.1:1,to=1000,lock-key-sync=off
    >    Equivalent to qemu-trad's -vncunused -vnc 127.0.0.1:1

This change depends on removing the corresponding vnc console parameter transformation in the qemu-upstream wrapper. The comment for the lock-key-sync=off option was moved from this wrapper.                                                                                                               
                                                                                                                                                                          
Signed-off-by: Marcus Granado <marcus.granado@citrix.com>   

----
Tests:

**Before change:**

_qemu-upstream:_ forkexecd: [ info|st45|0 ||forkexecd] qemu-dm-36[20159]: Arguments: 36 --syslog -d 36 -m 2048 -boot dc -serial pty -vcpus 2 -videoram 4 **-vncunused -vnc 127.0.0.1:1** -usb -usbdevice tablet -acpi -monitor null -device rtl8139,netdev=tapnet0,mac=1a:d6:a8:13:0d:dc,addr=4 -netdev tap,id=tapnet0,ifname=tap36.0,script=no,downscript=no

_qemu-trad:_ forkexecd: [ info|st45|0 ||forkexecd] qemu-dm-37[22415]: Arguments: qemu-dm-37 --syslog -d 37 -m 2048 -boot dc -serial pty -vcpus 2 -videoram 4 **-vncunused -vnc 127.0.0.1:1** -usb -usbdevice tablet -acpi -monitor null -net nic,vlan=0,macaddr=ca:22:79:17:4f:ce,model=rtl8139 -net tap,vlan=0,bridge=xenbr0,ifname=tap37.0

**After change:**

_qemu-upstream:_ forkexecd: [ info|st45|0 ||forkexecd] qemu-dm-16[22992]: Arguments: 16 --syslog -d 16 -m 2048 -boot dc -serial pty -vcpus 2 -videoram 4 **-vncunused -vnc unix:/var/run/xen/vnc-16,lock-key-sync=off** -usb -usbdevice tablet -acpi -monitor null -device rtl8139,netdev=tapnet0,mac=ea:c6:80:f2:cb:e3,addr=4 -netdev tap,id=tapnet0,ifname=tap16.0,script=no,downscript=no

_qemu-trad:_ forkexecd: [ info|st45|0 ||forkexecd] qemu-dm-19[32008]: Arguments: qemu-dm-19 --syslog -d 19 -m 2048 -boot dc -serial pty -vcpus 2 -videoram 4 **-vncunused -
vnc 127.0.0.1:1** -usb -usbdevice tablet -acpi -monitor null -net nic,vlan=0,macaddr=c2:be:98:51:e1:91,model=rtl8139 -net tap,vlan=0,bridge=xenbr0,ifname=tap19.0