### PR TITLE
CA-265581: pass pipe_r to emu_manager, as is done in xenguest helper

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -929,7 +929,7 @@ module Suspend_restore_emu_manager : SUSPEND_RESTORE = struct
       let (store_mfn, console_mfn) =
         begin match
             with_conversion_script task "Emu_manager" hvm main_fd (fun pipe_r ->
-                with_emu_manager_restore task ~hvm ~store_port ~console_port ~extras manager_path domid uuid main_fd vgpu_fd (fun cnx ->
+                with_emu_manager_restore task ~hvm ~store_port ~console_port ~extras manager_path domid uuid pipe_r vgpu_fd (fun cnx ->
                     restore_libxc_record cnx domid uuid
                   )
               )


### PR DESCRIPTION
When upgrading from XS6.2, a conversion function needs to be used to
convert the VM save stream to the new format.

- Originally, the conversion function would send a pipe fd to xenguest.
- After the introduction of the emu-manager code, a copy-paste error
prevented the pipe from being passed to emu-manager (which will pass
it along to xenguest), causing a VM migration from XS 6.2 to fail.

This patch fixes the issue by reusing the proper pipe fd to connect the
conversion function to emu-manager. It does so by replacing main_fd in
the call to with_emu_manager for pipe_r. It's not necessary to modify
vgpu_fd in this case because XS 6.2 will never have vgpu_fds.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>