### PR TITLE
Include the c_stubs in the xapi-xenopsd installation.

### DIFF
--- a/c_stubs/jbuild
+++ b/c_stubs/jbuild
@@ -2,6 +2,7 @@
 
 (library (
   (name c_stubs)
+  (public_name xapi-xenopsd.c_stubs)
   (wrapped false)
   (c_names (
     poll_stubs


### PR DESCRIPTION
See following diff:
```
$ diff xapi-xenopsd.install.orig xapi-xenopsd.install
3a4,12
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/statdev.cmi" {"c_stubs/statdev.cmi"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/statdev.cmx" {"c_stubs/statdev.cmx"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/statdev.cmt" {"c_stubs/statdev.cmt"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/statdev.ml" {"c_stubs/statdev.ml"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/c_stubs.cma" {"c_stubs/c_stubs.cma"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/libc_stubs_stubs.a" {"c_stubs/libc_stubs_stubs.a"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/c_stubs.cmxa" {"c_stubs/c_stubs.cmxa"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/c_stubs.a" {"c_stubs/c_stubs.a"}
>   "_build/install/default/lib/xapi-xenopsd/c_stubs/c_stubs.cmxs" {"c_stubs/c_stubs.cmxs"}
103a113,115
> ]
> stublibs: [
>   "_build/install/default/lib/stublibs/dllc_stubs_stubs.so"
```