### PR TITLE
CA-270640: Avoid leaking threads on error

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1094,7 +1094,7 @@ module Suspend_restore_emu_manager : SUSPEND_RESTORE = struct
           (* Handle results returned by emu-manager *)
           let emu_manager_results = handle_results () in
           (* Wait for reader threads to complete *)
-          let thread_status = receive_thread_status threads_and_channels in
+          let[@inlined never] thread_status = receive_thread_status threads_and_channels in
           (* Chain all together, and we are done! *)
           let res =
             emu_manager_results >>= fun result ->


### PR DESCRIPTION
This moves the code around to make sure that the event syncronization calls are always triggered, even in presence of errors, to prevent thread leaks.

Warning: this has not yet been tested, but I would welcome any preliminary feedback