### PR TITLE
CA-273775: Fix race in VM_receive_memory, and improve error handling

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1680,29 +1680,34 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : unit
 
       (* set up the destination domain *)
       debug "VM.receive_memory creating domain and restoring VIFs";
-      (try
-         perform_atomics (
-           simplify [VM_create (id, Some memory_limit);] @
-           (* Perform as many operations as possible on the destination domain before pausing the original domain *)
-           (atomics_of_operation (VM_restore_vifs id))
-         ) t;
-         Handshake.send s Handshake.Success
-       with e ->
-         Handshake.send s (Handshake.Error (Printexc.to_string e));
-         raise e
-      );
-      debug "VM.receive_memory: Synchronisation point 1";
 
-      debug "VM.receive_memory restoring VM";
-      (* Check if there is a separate vGPU data channel *)
-      let vgpu_info = Stdext.Opt.of_exception (fun () -> Hashtbl.find vgpu_receiver_sync id) in
-      perform_atomics (
-        List.map (fun vgpu_id -> VGPU_start (vgpu_id, true)) (VGPU_DB.ids id) @ [
-          VM_restore (id, FD s, Opt.map (fun x -> FD x.vgpu_fd) vgpu_info);
-        ]) t;
-      debug "VM.receive_memory restore complete";
-      (* Tell the vGPU receive thread that we're done *)
-      Opt.iter (fun x -> Event.send x.vgpu_channel () |> Event.sync) vgpu_info;
+      finally (fun ()->
+        (try
+           perform_atomics (
+             simplify [VM_create (id, Some memory_limit);] @
+             (* Perform as many operations as possible on the destination domain before pausing the original domain *)
+             (atomics_of_operation (VM_restore_vifs id))
+           ) t;
+           Handshake.send s Handshake.Success
+         with e ->
+           Handshake.send s (Handshake.Error (Printexc.to_string e));
+           raise e
+        );
+        debug "VM.receive_memory: Synchronisation point 1";
+
+        debug "VM.receive_memory restoring VM";
+        (* Check if there is a separate vGPU data channel *)
+        let vgpu_info = Stdext.Opt.of_exception (fun () -> Hashtbl.find vgpu_receiver_sync id) in
+        perform_atomics (
+          List.map (fun vgpu_id -> VGPU_start (vgpu_id, true)) (VGPU_DB.ids id) @ [
+            VM_restore (id, FD s, Opt.map (fun x -> FD x.vgpu_fd) vgpu_info);
+          ]) t;
+        debug "VM.receive_memory restore complete";
+      ) (fun ()->
+        (* Tell the vGPU receive thread that we're done, so that it can clean up vgpu_receiver_sync id and terminate *)
+        let vgpu_info = Stdext.Opt.of_exception (fun () -> Hashtbl.find vgpu_receiver_sync id) in
+        Opt.iter (fun x -> Event.send x.vgpu_channel () |> Event.sync) vgpu_info;
+      );
       debug "VM.receive_memory: Synchronisation point 2";
 
       begin try

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1660,6 +1660,8 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : unit
                  do_request vgpu_fd [] vgpu_url;
                  Handshake.recv_success vgpu_fd;
                  debug "VM.migrate: Synchronisation point 1-vgpu";
+                 Handshake.send ~verbose:true mem_fd Handshake.Success;
+                 debug "VM.migrate: Synchronisation point 1-vgpu ACK";
                  first_handshake ();
                  save ~vgpu_fd:(FD vgpu_fd) ();
                );
@@ -1682,6 +1684,21 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : unit
       debug "VM.receive_memory creating domain and restoring VIFs";
 
       finally (fun ()->
+
+        (* If we have a vGPU, wait for the vgpu-1 ACK, which indicates that the vgpu_receiver_sync entry for
+           this vm id has already been initialised by the parallel receive_vgpu thread in this receiving host
+         *)
+        (match VGPU_DB.ids id with
+         | [] -> ()
+         | _  -> begin
+           Handshake.recv_success s;
+           debug "VM.receive_memory: Synchronisation point 1-vgpu ACK";
+           (* After this point, vgpu_receiver_sync is initialised by the corresponding receive_vgpu thread
+              and therefore can be used by this VM_receive_memory thread
+            *)
+         end
+        );
+
         (try
            perform_atomics (
              simplify [VM_create (id, Some memory_limit);] @


### PR DESCRIPTION
This patch series fixes two issues:

1) in case the VM_receive_memory thread raises an exception either in the VM_create or VM_restore operations, it should still kill the corresponding receive_vgpu thread.
2) there's a race in which the VM_receive_memory thread does not wait for the vgpu_receiver_sync table to be initialised in the receive_vgpu thread counterpart, also in the receiving host. The signal from the receiving host's receive_vgpu thread that the vgpu_receiver_sync table is already initialised reaches the sending host via the 'Synchronisation point 1-vgpu', but there's no signal from the sending host to the receiving host's VM_receive_memory thread. We add this missing signal from the sending host to the receiving host's VM_receivie_memory thread and call it 'Synchronisation point 1-vgpu ACK', and make sure that this ACK message is always processed by both sending and receiving hosts in the case a VGPU migration is used.

Devtests for VM.migration passed both without and with VGPU. With VGPU migration, we see in the logs:
- sender:
```
|10|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.migrate: Synchronisation point 1-vgpu
|10|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.migrate: Synchronisation point 1-vgpu ACK
|10|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.migrate: Synchronisation point 1
|10|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.migrate: Synchronisation point 2
|10|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.migrate: Synchronisation point 3
|10|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.migrate: Synchronisation point 4
```
- receiver:
```
|66|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.receive_vgpu: Synchronisation point 1-vgpu
|20|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.receive_memory: Synchronisation point 1-vgpu ACK
|20|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.receive_memory: Synchronisation point 1
|20|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.receive_memory: Synchronisation point 2
|66|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.receive_vgpu: Synchronisation point 2-vgpu
|20|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.receive_memory: Synchronisation point 3
|20|Async.VM.pool_migrate R:084d7c004377|xenops_server] VM.receive_memory: Synchronisation point 4
```
