### PR TITLE
CP-26145: cancel vgpu-migration between incompatible hosts

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -40,6 +40,7 @@ let query _ _ _ = {
   features = [];
   instance_id = instance_id;
 }
+let cookie_vgpu_migration = "vgpu_migration"
 
 let backend = ref None
 let get_backend () = match !backend with
@@ -1657,7 +1658,7 @@ and perform ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : unit
            | [vgpu_id] ->
              let vgpu_url = make_url "/migrate-vgpu/" (VGPU_DB.string_of_id vgpu_id) in
              Open_uri.with_open_uri vgpu_url (fun vgpu_fd ->
-                 do_request vgpu_fd [] vgpu_url;
+                 do_request vgpu_fd [cookie_vgpu_migration, ""] vgpu_url;
                  Handshake.recv_success vgpu_fd;
                  debug "VM.migrate: Synchronisation point 1-vgpu";
                  first_handshake ();
@@ -2338,6 +2339,18 @@ module VM = struct
          let vm_id = VGPU_DB.vm_of vgpu_id in
          match context.transferred_fd with
          | Some transferred_fd ->
+
+           (* prevent vgpu-migration from pre-Jura to Jura and later *)
+           if not (List.mem_assoc cookie_vgpu_migration cookies) then
+               begin
+                  (* only Jura and later hosts send this cookie; fail the migration from pre-Jura hosts *)
+                  let msg = Printf.sprintf "VM.migrate: version of sending host incompatible with receiving host: no cookie %s" cookie_vgpu_migration in
+                  Xenops_migrate.(Handshake.send ~verbose:true transferred_fd (Handshake.Error msg));
+                  debug "VM.receive_vgpu: Synchronisation point 1-vgpu ERR %s" msg;
+                  raise (Internal_error msg)
+               end
+           ;
+
            debug "VM.receive_vgpu: passed fd %d" (Obj.magic transferred_fd);
            (* Store away the fd for VM_receive_memory/restore to use *)
            let info = {


### PR DESCRIPTION
    The vgpu-migration protocol had to be changed to prevent a race condition,
    causing vgpu-migration from pre-Jura to Jura hosts to block forever. The
    only way to recover is to restart xenopsd. 

    This patch interrupts the vgpu-migration if it detects the vgpu-migration
    operation between these invalid hosts, preventing the block from occurring.
    The vgpu-migration is interrupted before the VM state is saved -- therefore,
    the VM in the sending host continues to run unaffected.

    It works for vgpu-migration during both RPU and cross-pool migration.

    The interruption occurs by xenopsd raising an Internal_error exception at
    the receive_vgpu thread and sending a Handshake.error back to the main
    migration thread of the sending host, which will clean up the main migration
    threads in both the sender and receiver hosts.

    The distinction between pre-Jura and Jura/later hosts is done by sending a
    new cookie 'vgpu_migration' between the sender and receiver. This patch sends
    this cookie with an empty value, but in the future this value could contain
    either a version number of features that the receiver could parse to verify 
    if it agrees to receive the migrating VM.

    Signed-off-by: Marcus Granado <marcus.granado@citrix.com> 