### PR TITLE
CA-265699: Don't use jemalloc for xs-clipboardd

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -387,17 +387,17 @@ def main(argv):
 
     f.write("Exec: %s %s\n" % (qemu_dm, " ".join(qemu_args)))
 
+    clipboardd = '/opt/xensource/libexec/xs-clipboardd'
+    call([clipboardd, "-d", str(domid), "-s", str(s2.fileno())], preexec_fn = lambda : (close_fds()))
+
+    s2.close()
+
     # set up library preload path for qemu such that it can use jemalloc
     qemu_env = os.environ
     if not qemu_env.has_key("LD_PRELOAD"):
        qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.1"
     else:
        qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.1:" + qemu_env["LD_PRELOAD"]
-
-    clipboardd = '/opt/xensource/libexec/xs-clipboardd'
-    call([clipboardd, "-d", str(domid), "-s", str(s2.fileno())], preexec_fn = lambda : (close_fds()))
-
-    s2.close()
 
     core_dump_limit = enable_core_dumps()
     f.write("core dump limit: %d\n" % core_dump_limit)


### PR DESCRIPTION
While using jemalloc for QEMU decreases its memory usage, using it for
xs-clipboardd increases its memory usage (by 428 KiB RSS on average in
my test). Revert back to the default glibc allocator.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>