### PR TITLE
CA-265699: Tweak jemalloc config to reduce QEMU memory usage

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -398,6 +398,7 @@ def main(argv):
        qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.1"
     else:
        qemu_env["LD_PRELOAD"] = "/usr/lib64/libjemalloc.so.1:" + qemu_env["LD_PRELOAD"]
+    qemu_env["MALLOC_CONF"] = "narenas:1,tcache:false,lg_dirty_mult:22"
 
     core_dump_limit = enable_core_dumps()
     f.write("core dump limit: %d\n" % core_dump_limit)


### PR DESCRIPTION
Tweak the jemalloc configuration to reduce QEMU's memory usage:
* narenas: jemalloc normally creates several arenas. Instead, create
only one.
* tcache: Disable the thread-specific cache of objects.
* lg_dirty_mult: Make jemalloc more willing to purge dirty unused
pages.

Testing showed that these changes reduced QEMU's memory usage by
900 KiB. While these changes are likely to reduce allocation performance
somewhat, we don't use QEMU for anything performance sensitive.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>