### PR TITLE
CP-26858: Add support to NetSriovVf device in function device_by_id.

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -800,10 +800,7 @@ module NetSriovVf = struct
       (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) other_config))
       (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) extra_xenserver_keys));
 
-    let frontend = { domid = domid; kind = NetSriovVf; devid = devid } in
-    let backend = { domid = backend_domid; kind = NetSriovVf; devid = devid } in
-    let device = { backend = backend; frontend = frontend } in
-
+    let device = Device_common.make_nsv_device ~back_domid:backend_domid domid devid in
     add_device ~xs device (extra_xenserver_keys @ other_config);
     let rate_Mbps = match rate with
       | Some (0L, _) | None -> None

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -238,6 +238,14 @@ let readdir ~xs d = try xs.Xs.directory d with Xs_protocol.Enoent _ -> []
 let to_list ys = List.concat (List.map Opt.to_list ys)
 let list_kinds ~xs dir = to_list (List.map parse_kind (readdir ~xs dir))
 
+let filter_on_devids ~xs ?for_devids dir =
+  match for_devids with
+  | None -> List.filter_map parse_int (readdir ~xs dir)
+  | Some devids ->
+    devids |>
+    List.filter (fun devid->
+        try ignore(xs.Xs.read (sprintf "%s/%d" dir devid)); true with _->false)
+
 (* NB: we only read data from the frontend directory. Therefore this gives
    the "frontend's point of view", using data that we wrote into a subtree
    that is writable dom0 only (not by the frontend domain). *)
@@ -247,11 +255,7 @@ let list_frontends ~xs ?for_devids domid =
   List.concat (List.map
                  (fun k ->
                     let dir = sprintf "%s/%s" frontend_dir (string_of_kind k) in
-                    let devids = match for_devids with
-                      | None -> to_list (List.map parse_int (readdir ~xs dir))
-                      | Some devids ->(* check that any specified devids are present in frontend_dir *)
-                        List.filter (fun devid->try ignore(xs.Xs.read (sprintf "%s/%d" dir devid)); true with _->false) devids;
-                    in
+                    let devids = filter_on_devids ~xs ?for_devids dir in
                     to_list (List.map
                                (fun devid ->
                                   (* domain [domid] believes it has a frontend for
@@ -265,6 +269,25 @@ let list_frontends ~xs ?for_devids domid =
                                   with _ -> None
                                ) devids)
                  ) kinds)
+
+(* Network SR-IOV VF device *)
+let make_nsv_device ?(back_domid=0) front_domid devid =
+  let frontend = { domid = front_domid; kind = NetSriovVf; devid = devid } in
+  let backend = { domid = back_domid; kind = NetSriovVf; devid = devid } in
+  { backend = backend; frontend = frontend }
+
+let list_xenserver_devices ~xs ?for_devids domid =
+  let xenserver_dir = sprintf "/local/domain/%d/xenserver/device" domid in
+  let mk = function
+    | NetSriovVf ->
+      let dir = sprintf "%s/%s" xenserver_dir (string_of_kind NetSriovVf) in
+      let devids = filter_on_devids ~xs ?for_devids dir in
+      Some (List.map (make_nsv_device domid) devids)
+    | _ -> None
+  in
+  list_kinds ~xs xenserver_dir
+  |> List.filter_map mk
+  |> List.concat
 
 (* NB: we only read data from the backend directory. Therefore this gives
    the "backend's point of view". *)

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -74,6 +74,10 @@ val list_backends : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> device list
     directory.*)
 val list_frontends : xs:Xenstore.Xs.xsh -> ?for_devids:int list -> Xenctrl.domid -> device list
 
+val make_nsv_device : ?back_domid:int -> int -> int -> device
+
+val list_xenserver_devices: xs:Xenstore.Xs.xsh -> ?for_devids:int list -> Xenctrl.domid -> device list
+
 (** Return a list of devices connecting two domains. Ignore those whose kind 
     we don't recognise *)
 val list_devices_between : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> Xenctrl.domid -> device list


### PR DESCRIPTION
This change aims to add support to NetSriovVf device in device_by_id
function. Prior to this change, the function would find devices from
xenstore path "/xenops/domain/<domid>/device", which is used by PV
driver backed devices. With this change, the function will try to
find NetSriovVf devices from xenstore path
"/local/domain/<domid>/xenserver/device"

Signed-off-by: Ming Lu <ming.lu@citrix.com>