### PR TITLE
CP-26862: Set RLIMIT_FSIZE for QEMU

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -27,6 +27,7 @@ import ctypes.util
 import os
 import fcntl
 import struct
+from resource import getrlimit, RLIMIT_CORE, RLIMIT_FSIZE, setrlimit
 
 import xen.lowlevel.xs as xs
 
@@ -72,8 +73,11 @@ def unshare(flags):
     if ret < 0:
         raise OSError(ctypes.get_errno(), os.strerror(ctypes.get_errno()))
 
+def restrict_fsize():
+    limit = 32 * 1024
+    setrlimit(RLIMIT_FSIZE, (limit, limit))
+
 def enable_core_dumps():
-    from resource import getrlimit, RLIMIT_CORE, setrlimit
 
     limit = 64 * 1024 * 1024
     oldlimits = getrlimit(RLIMIT_CORE)
@@ -418,6 +422,8 @@ def main(argv):
         except IOError, e:
             print "Warning: writing pid to '%s' tasks file: %s" \
                 % (cgroup_slice, e)
+
+    restrict_fsize()
 
     unshare(CLONE_NEWNET | CLONE_NEWNS | CLONE_NEWIPC)
 


### PR DESCRIPTION
During a migration, QEMU is given a writable file descriptor to write
its save image. This could allow a denial of service since a rogue QEMU
could fill up the filesystem backing the file descriptor. To prevent
this, set the hard and soft limits of RLIMIT_FSIZE to 32 KiB. This is
enough for QEMU to save its migration state. QEMU is still free to write
to its emulated disks since this limit does not apply to block devices.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>