### PR TITLE
CP-26859: Update guest permission on "*/xenserver/attr" path

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -779,14 +779,11 @@ module NetSriovVf = struct
   let add_device ~xs device xenserver_list =
     Mutex.execute Generic.device_serialise_m (fun () ->
         let extra_xenserver_device_path = Device_common.extra_xenserver_path_of_device ~xs device in
-        let extra_xenserver_attr_path = Device_common.extra_xenserver_path_of_attr ~xs device in
         debug "adding net-sriov-vf device  B%d  F%d" device.backend.domid device.frontend.domid;
         Xs.transaction xs (fun t ->
             t.Xst.mkdirperms extra_xenserver_device_path
               (Xenbus_utils.rwperm_for_guest device.frontend.domid);
             t.Xst.writev extra_xenserver_device_path xenserver_list;
-            t.Xst.mkdirperms extra_xenserver_attr_path
-              (Xenbus_utils.rwperm_for_guest device.frontend.domid);
           )
       )
 

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -188,12 +188,6 @@ let extra_xenserver_path_of_device ~xs (x: device) =
     (string_of_kind x.backend.kind)
     x.frontend.devid
 
-let extra_xenserver_path_of_attr ~xs (x: device) =
-  sprintf "%s/xenserver/attr/%s/%d"
-    (xs.Xs.getdomainpath x.frontend.domid)
-    (string_of_kind x.backend.kind)
-    x.frontend.devid
-
 let device_of_backend (backend: endpoint) (domu: Xenctrl.domid) = 
   let frontend = { domid = domu;
                    kind = (match backend.kind with

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -57,7 +57,6 @@ val get_private_path_by_uuid : Uuidm.t -> string
 val get_private_data_path_of_device : device -> string
 
 val extra_xenserver_path_of_device: xs:Xenstore.Xs.xsh -> device -> string
-val extra_xenserver_path_of_attr: xs:Xenstore.Xs.xsh -> device -> string
 
 val string_of_endpoint : endpoint -> string
 val string_of_device : device -> string

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -257,6 +257,7 @@ let make ~xc ~xs vm_info uuid =
               "drivers";
               "control";
               "attr";
+              "xenserver/attr";
               "data";
               "messages";
               "vm-data";


### PR DESCRIPTION
This path "/local/domain//xenserver/attr" is created for guest
agent to report IP addresses on non-PV driver backed network device.

This change makes the guest agent has permission to read and write under
this path.

Signed-off-by: Ming Lu ming.lu@citrix.com