### PR TITLE
Revert "CP-24770: Xenopsd calls now the qemu-wrapper script passing in the right parameters for disks and CD drives."

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -96,6 +96,44 @@ def xenstore_write(path, value):
 def xenstore_ls(path):
     return xenstore.ls("", path)
 
+def get_drive_args(dom):
+    args = []
+    index_map = dict(('xvd' + chr(ord('a') + i), i) for i in range(4))
+    vbd3 = "/local/domain/0/backend/vbd3/" + dom
+
+    medialist = xenstore_ls(vbd3)
+    if not medialist:
+        return args
+
+    for num in medialist:
+        dev = xenstore_read("%s/%s/dev" % (vbd3, num))
+        if dev not in index_map:
+            continue
+
+        path = ''
+        path_str = ''
+        keys = xenstore_ls("%s/%s" % (vbd3, num))
+        if "params" in keys:
+            path = xenstore_read("%s/%s/params" % (vbd3, num))
+            path_str = 'file=%s,' % path
+
+        # XXX This is a heuristic to determine if the disk is a CD. We should be told
+        # by the toolstack.
+        mode = xenstore_read("%s/%s/mode" % (vbd3, num))
+        media = 'cdrom' if dev == 'xvdd' and mode == 'r' else 'disk'
+        forcelba = 'on' if media == 'disk' else 'off'
+
+        format_str = ',format=raw' if path != '' else ''
+
+        if mode == 'r' and media != 'cdrom':
+            continue
+
+        # XXX What should cache=... be set to?
+        args.extend(["-drive", "%sif=ide,index=%d,media=%s%s,force-lba=%s" %
+                     (path_str, index_map[dev], media, format_str, forcelba)])
+
+    return args
+
 def close_fds():
     for i in open_fds:
         os.close(i)
@@ -126,6 +164,7 @@ def main(argv):
             break
 
     qemu_dm = '/usr/lib64/xen/bin/qemu-system-i386'
+    drive_args = get_drive_args('%d' % domid)
     qemu_args = ['qemu-dm-%d' % domid]
 
     # read the size of lower MMIO hole provisioned by xenguest
@@ -181,6 +220,7 @@ def main(argv):
     qemu_args.extend(['-parallel', 'null'])
 
     qemu_args.extend(argv[2:])
+    qemu_args.extend(drive_args)
 
     n = 0
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -118,7 +118,7 @@ module VmExtra = struct
     shadow_multiplier: float;
     memory_static_max: int64;
     suspend_memory_bytes: int64;
-    qemu_vbds: (Vbd.id * (int * qemu_frontend option)) list;
+    qemu_vbds: (Vbd.id * (int * qemu_frontend)) list;
     qemu_vifs: (Vif.id * (int * qemu_frontend)) list;
     pci_msitranslate: bool;
     pci_power_mgmt: bool;
@@ -1148,14 +1148,13 @@ module VM = struct
 
   (* NB: the arguments which affect the qemu configuration must be saved and
      	   restored with the VM. *)
-  let create_device_model_config vm vmextra vbds vifs vgpus vusbs =
-    match vmextra.VmExtra.persistent, vmextra.VmExtra.non_persistent with
+  let create_device_model_config vm vmextra vbds vifs vgpus vusbs = match vmextra.VmExtra.persistent, vmextra.VmExtra.non_persistent with
     | { VmExtra.build_info = None }, _
     | { VmExtra.ty = None }, _ -> raise (Domain_not_built)
     | {
-        VmExtra.build_info = Some build_info;
-        ty = Some ty;
-      },{
+      VmExtra.build_info = Some build_info;
+      ty = Some ty;
+    },{
         VmExtra.qemu_vbds = qemu_vbds
       } ->
       let make ?(boot_order="cd") ?(serial="pty") ?(monitor="null")
@@ -1212,14 +1211,10 @@ module VM = struct
       | HVM hvm_info ->
         let disks = List.filter_map (fun vbd ->
             let id = vbd.Vbd.id in
-            if (List.mem_assoc id qemu_vbds)
+            if hvm_info.Vm.qemu_disk_cmdline && (List.mem_assoc id qemu_vbds)
             then
-              let index, bd_opt = List.assoc id qemu_vbds in
-              let path =
-                match bd_opt with
-                | Some bd -> block_device_of_vbd_frontend bd
-                | None -> ""
-              in
+              let index, bd = List.assoc id qemu_vbds in
+              let path = block_device_of_vbd_frontend bd in
               let media =
                 if vbd.Vbd.ty = Vbd.Disk
                 then Device.Dm.Disk else Device.Dm.Cdrom in
@@ -2199,12 +2194,13 @@ module VBD = struct
              let qemu_domid = Opt.default (this_domid ~xs) (get_stubdom ~xs frontend_domid) in
              let qemu_frontend = match Device_number.spec device_number with
                | Device_number.Ide, n, _ when n < 4 ->
-                 let index = Device_number.to_disk_number device_number in
-                 let bd_opt =
-                   vbd.Vbd.backend |>
-                   Opt.map (fun _ -> create_vbd_frontend ~xc ~xs task qemu_domid vdi)
-                 in
-                Some (index, bd_opt)
+                 begin match vbd.Vbd.backend with
+                   | None -> None
+                   | Some _ ->
+                     let bd = create_vbd_frontend ~xc ~xs task qemu_domid vdi in
+                     let index = Device_number.to_disk_number device_number in
+                     Some (index, bd)
+                 end
                | _, _, _ -> None in
              (* Remember what we've just done *)
              Mutex.execute dB_m (fun () ->
@@ -2274,7 +2270,7 @@ module VBD = struct
                         if List.mem_assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds then begin
                           let _, qemu_vbd = List.assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds in
                           (* destroy_vbd_frontend ignores 'refusing to close' transients' *)
-                          Opt.iter (fun x -> destroy_vbd_frontend ~xc ~xs task x) qemu_vbd;
+                          destroy_vbd_frontend ~xc ~xs task qemu_vbd;
                           let non_persistent = { non_persistent with
                                                  VmExtra.qemu_vbds = List.remove_assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds } in
                           DB.write vm { vm_t with VmExtra.non_persistent = non_persistent }


### PR DESCRIPTION
Reverts xapi-project/xenopsd#447