### PR TITLE
CP-26858: Update the xenstore path usage of network SR-IOV

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -820,6 +820,12 @@ module NetSriovVf = struct
     end;
     device
 
+  let hard_shutdown ~xs (x: device) =
+    debug "Device.NetSriovVf.hard_shutdown about to blow away backend and frontend paths";
+    Generic.safe_rm ~xs (frontend_ro_path_of_device ~xs x);
+    Generic.safe_rm ~xs (frontend_rw_path_of_device ~xs x);
+    Generic.safe_rm ~xs (backend_path_of_device ~xs x)
+
 end
 
 (*****************************************************************************)
@@ -2400,7 +2406,7 @@ end (* Dm *)
 
 let hard_shutdown (task: Xenops_task.task_handle) ~xs (x: device) = match x.backend.kind with
   | Vif -> Vif.hard_shutdown task ~xs x
-  | NetSriovVf -> raise (Unimplemented("network sr-iov"))
+  | NetSriovVf -> NetSriovVf.hard_shutdown ~xs x
   | Vbd _ | Tap -> Vbd.hard_shutdown task ~xs x
   | Pci -> PCI.hard_shutdown task ~xs x
   | Vfs -> Vfs.hard_shutdown task ~xs x

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -124,6 +124,7 @@ sig
     -> ?backend_domid:Xenctrl.domid
     -> ?other_config:((string * string) list)
     -> pci:Xenops_interface.Pci.address -> vlan:int64 option -> carrier:bool
+    -> ?extra_private_keys:(string * string) list
     -> ?extra_xenserver_keys:(string * string) list
     -> Xenops_task.task_handle ->  Xenctrl.domid
     -> device

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -61,8 +61,13 @@ let string_of_endpoint (x: endpoint) =
   sprintf "(domid=%d | kind=%s | devid=%d)" x.domid (string_of_kind x.kind) x.devid  
 
 let backend_path ~xs (backend: endpoint) (domu: Xenctrl.domid) = 
-  sprintf "%s/backend/%s/%u/%d" 
+  let p = match backend.kind with
+    | NetSriovVf -> "xenserver/backend"
+    | _ -> "backend"
+  in
+  sprintf "%s/%s/%s/%u/%d" 
     (xs.Xs.getdomainpath backend.domid) 
+    p
     (string_of_kind backend.kind)
     domu backend.devid
 
@@ -71,8 +76,13 @@ let backend_path_of_device ~xs (x: device) = backend_path ~xs x.backend x.fronte
 
 (** Location of the frontend in xenstore: this is owned by the guest. *)
 let frontend_rw_path_of_device ~xs (x: device) = 
-  sprintf "%s/device/%s/%d"
+  let p = match x.frontend.kind with
+    | NetSriovVf -> "xenserver/device"
+    | _ -> "device"
+  in
+  sprintf "%s/%s/%s/%d"
     (xs.Xs.getdomainpath x.frontend.domid)
+    p
     (string_of_kind x.frontend.kind)
     x.frontend.devid
 
@@ -219,6 +229,7 @@ let parse_frontend_link x =
 
 let parse_backend_link x = 
   match Stdext.Xstringext.String.split '/' x with 
+  | [ ""; "local"; "domain"; domid; "xenserver"; "backend"; kind; _; devid ]
   | [ ""; "local"; "domain"; domid; "backend"; kind; _; devid ] ->
     begin
       match parse_int domid, parse_kind kind, parse_int devid with

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -469,9 +469,11 @@ let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid domid =
   xs.Xs.rm dom_path;
   xs.Xs.rm xenops_dom_path;
   debug "VM = %s; domid = %d; deleting backends" (Uuid.to_string uuid) domid;
-  let backend_path = xs.Xs.getdomainpath 0 ^ "/backend" in
-  let all_backend_types = try xs.Xs.directory backend_path with _ -> [] in
-  List.iter (fun ty -> log_exn_rm ~xs (Printf.sprintf "%s/%s/%d" backend_path ty domid)) all_backend_types;
+  List.iter (fun path ->
+      let backend_path = xs.Xs.getdomainpath 0 ^ path in
+      let all_backend_types = try xs.Xs.directory backend_path with _ -> [] in
+      List.iter (fun ty -> log_exn_rm ~xs (Printf.sprintf "%s/%s/%d" backend_path ty domid)) all_backend_types
+  ) ["/backend"; "/xenserver/backend"];
 
   (* If all devices were properly un-hotplugged, then zap the private tree in
      	 * xenstore.  If there was some error leave the tree for debugging / async

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2588,8 +2588,10 @@ module VIF = struct
                    end;
                  ) vm_t
              | Network.Sriov _ ->
-                 debug "Ignoring unplug on network SR-IOV VF backed VIF = %s.\
-                   It would be unplugged until its PCI device is unplugged." (id_of vif)
+               Xenops_task.with_subtask task (Printf.sprintf "NetSriovVf.hard_shutdown %s" (id_of vif))
+                 (fun () -> Device.hard_shutdown task ~xs device);
+               debug "Unplug on network SR-IOV VF backed VIF = %s. \
+                 It would be unplugged until its PCI device is unplugged." (id_of vif)
            end;
            let domid = device.Device_common.frontend.Device_common.domid in
            let interfaces = interfaces_of_vif domid vif.id vif.position in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2547,7 +2547,8 @@ module VIF = struct
                   let (_: Device_common.device) = 
                     (with_common_params Device.NetSriovVf.add)
                        ~pci ~vlan:vif.vlan ~carrier:vif.carrier
-                       ~extra_xenserver_keys:(static_ip_setting @ xenopsd_backend @ ["mac", mac])
+                       ~extra_private_keys:([id] @ xenopsd_backend)
+                       ~extra_xenserver_keys:(static_ip_setting @ [("mac", mac)])
                        task frontend_domid
                   in
                   ()


### PR DESCRIPTION
There are 3 commits in this PR:
1. Revert to use Device.Generic.add_device on network SR-IOV
2. Add logic to cleanup xenstore paths of net-sriov-vf
3. Add device_kind_of function in module VIF

Signed-off-by: Ming Lu <ming.lu@citrix.com>