### PR TITLE
CA-282008 refactor qmp interaction for robustness

### DIFF
--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -37,6 +37,7 @@ exception Device_unrecognized of string
 exception Hotplug_script_expecting_field of device * string
 exception Unknown_device_type of string
 exception Unknown_device_protocol of string
+exception QMP_Error of int * string
 
 module D = Debug.Make(struct let name = "xenops" end)
 open D
@@ -338,22 +339,86 @@ let is_upstream_qemu domid =
     with_xs (fun xs -> xs.Xs.read (sprintf "/libxl/%d/dm-version" domid)) = "qemu_xen"
   with _ -> false
 
-let qmp_write_and_read domid ?(read_result=true) cmd  =
-  try
-    let open Qmp in
-    debug "QMP.Command for domid %d: %s" domid (string_of_message cmd);
-    let c = Qmp_protocol.connect (qmp_libxl_path domid) in
-    finally
-      (fun () ->
-         Qmp_protocol.negotiate c;
-         Qmp_protocol.write c cmd;
-         if read_result then
-           Some (Qmp_protocol.read c)
-         else None
-      )
-      (fun () -> Qmp_protocol.close c)
-  with e ->
-    error "Caught exception attempting to write qmp message: %s" (Printexc.to_string e);
-    None
+(** [make_id_generator] returns a function that creates unique IDs using
+ * an internal counter *)
+let make_id_generator name =
+  let count = ref 0 in
+  fun domid -> incr count; Printf.sprintf "%s-%06d-%d" name !count domid
 
-let qmp_write domid cmd = qmp_write_and_read ~read_result:false domid cmd |> ignore
+let make_qmp_id = make_id_generator "qmp"
+
+(** [qmp_send_cmd_internal connection domid cmd] sends [cmd] to QEMU, waits
+ * for the *matching* response, and returns the result. It uses an
+ * already open and negotiated [connection]. Commands are tagged with an
+ * identifier and the function waits for the matching response, skipping
+ * all other responses it receives while waiting.
+*)
+let qmp_send_cmd_internal connection domid cmd =
+  let id      = make_qmp_id domid in
+  let msg     = Qmp.Command(Some id, cmd) in
+  let msg'    = Qmp.string_of_message msg in
+  debug "QMP command for domid %d: %s" domid msg';
+  let rec wait_for_result id =
+    match Qmp_protocol.read connection with
+    (* no ID *)
+    | Qmp.Greeting(_)
+    | Qmp.Command(_, _)
+    | Qmp.Error(None, _)
+    | Qmp.Success(None, _)
+    | Qmp.Event(_) as resp ->
+      let resp' = Qmp.string_of_message resp in
+      debug "skipping QMP message while waiting for %s: %s (%s)"
+        id resp' __LOC__;
+      wait_for_result id
+
+    (* wrong ID *)
+    | Qmp.Success(Some id',_)
+    | Qmp.Error(Some id',_) as resp when id <> id' ->
+      let resp' = Qmp.string_of_message resp in
+      debug "skipping QMP message while waiting for %s: %s (%s)"
+        id resp' __LOC__;
+      wait_for_result id
+
+    (* correct ID *)
+    | Qmp.Success(Some id, _)
+    | Qmp.Error(Some id,_) as message ->
+        debug "received QMP response %s (%s)" id __LOC__;
+        message
+  in
+  Qmp_protocol.write connection msg;
+  wait_for_result id
+
+(* [qmp_send_cmd domid cmd] sends [cmd] to [domid] and checks that the
+ * result it returns is Success. Otherwise it will raise [QMP_Error].
+ *
+ * [qmp_send_cmd] can send optionally a file descriptor [send_fd]
+ * over the connection before it sends the command. This is required for
+ * some commands.
+*)
+let qmp_send_cmd ?send_fd domid cmd =
+  let connection = Qmp_protocol.connect (qmp_libxl_path domid) in
+  finally
+    (fun () ->
+       (* no mutex required: QMP never sends unrelated messages *)
+       Qmp_protocol.negotiate connection;
+       ( match send_fd with
+         | Some fd ->
+           let connection' = Qmp_protocol.to_fd connection in
+           Fd_send_recv.send_fd connection' " " 0 1 [] fd |> ignore
+         | None    -> ()
+       )
+       ;
+       match qmp_send_cmd_internal connection domid cmd with
+       | Qmp.(Success (_, result)) -> result
+       | message ->
+         let msg' = Qmp.string_of_message message in
+         error "QMP result for domid %d: %s (%s)" domid msg' __LOC__;
+         raise (QMP_Error(domid, msg'))
+       | exception e ->
+         let cmd' = Qmp.(string_of_message (Command(None,cmd))) in
+         error "sending QMP command '%s' to domain %d: %s (%s)"
+           cmd' domid (Printexc.to_string e) __LOC__;
+         raise (QMP_Error(domid, Printexc.to_string e)))
+    (fun () ->
+       Qmp_protocol.close connection)
+

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -34,6 +34,7 @@ exception Device_disconnect_timeout of device
 exception Device_error of device * string
 exception Device_unrecognized of string
 exception Hotplug_script_expecting_field of device * string
+exception QMP_Error of int * string (** domid, message *)
 
 val backend_path : xs:Xenstore.Xs.xsh -> endpoint -> Xenctrl.domid -> string
 val backend_path_of_device : xs:Xenstore.Xs.xsh -> device -> string
@@ -103,5 +104,8 @@ val xenops_domain_path: string
 val xenops_path_of_domain: Xenctrl.domid -> string
 val xenops_vgpu_path: Xenctrl.domid -> devid -> string
 val is_upstream_qemu: Xenctrl.domid -> bool
-val qmp_write_and_read: Xenctrl.domid -> ?read_result:bool -> Qmp.message -> Qmp.message option
-val qmp_write: Xenctrl.domid -> Qmp.message -> unit
+val qmp_send_cmd
+  : ?send_fd:Unix.file_descr (* send this fd ahead of command *)
+  -> Xenctrl.domid
+  -> Qmp.command
+  -> Qmp.result (** may raise QMP_Error *)


### PR DESCRIPTION
This commit addresses several shortcomings of xenopsd/qmp interaction:

- no uniform model of sending QMP commends and checking for errors
- a mix of low- and high-level interaction
- no pairing of commands and results

This commit provides:

- A new function `qmp_send_cmd` to send commands to Qmp. The function
  waits for the result of the command and checks it for success. In the
  case of an error, it raises an exception. The `qmp_send_cmd` can
  optionally send a file descriptor along with a command, as it is
  required for some commands.

- `qmd_send_cmd` is implemented internally by function
  qmp_send_cmd_internal that tags each command with an ID that is used
  to wait for the identically matched response. Other responses received
  in the meantime are logged but discarded.

- Interaction is now uniformly expressed using `qmp_send_cmd` except when
  setting up monitors.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>