### PR TITLE
CP-25681: Prevent leakage of QEMU runtime files

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2231,7 +2231,11 @@ module Backend = struct
         Dm_Common.stop ~xs ~qemu_domid domid;
         QMP_Event.remove domid;
         xs.Xs.rm (sprintf "/libxl/%d" domid);
-        Dm_Common.vnc_socket_path domid |> Socket.Unix.rm
+        [ (* clean up QEMU socket leftover files *)
+          Dm_Common.vnc_socket_path domid;
+          (qmp_event_path domid);
+          (qmp_libxl_path domid);
+        ] |> List.iter Socket.Unix.rm
 
       let with_dirty_log domid ~f =
         finally


### PR DESCRIPTION
The original idea of this patch was to prevent files /var/run/xen/vnc-* accumulating between host reboots (contents in /var/run are cleaned up between reboots).
While testing the initial commit, I noticed that also /var/run/xen/qemu-event-<domid> and /var/run/xen/qemu-libxl-<domid> were also accumulating, and added corresponding commits for them.

Tested while rebooting VMs and the host, and files are removed after being used. QMP events and commands seem to be working fine when paying with the VM and observing the logs.
