### PR TITLE
CP-25898 add tap_open() primitive

### DIFF
--- a/c_stubs/jbuild
+++ b/c_stubs/jbuild
@@ -8,6 +8,7 @@
     poll_stubs
     sockopt_stubs
     statdev_stubs
+    stub_tap_open
     xenctrlext_stubs
   ))
   (c_library_flags (:include xentoollog_flags.sexp))

--- a/c_stubs/stub_tap_open.c
+++ b/c_stubs/stub_tap_open.c
@@ -1,0 +1,63 @@
+/*
+ * (c) Citrix 
+ *
+ * This could be replaced by https://github.com/mirage/ocaml-tuntap
+ * if more features are required.
+ */
+
+#include <string.h>
+#include <unistd.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <linux/if_tun.h>
+#include <fcntl.h>
+
+
+#include <caml/mlvalues.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+#include <caml/memory.h>
+
+#define PATH_NET_TUN "/dev/net/tun"
+
+/* open /dev/net/tun and set it up
+ * external _tap_open : string -> Unix.file_descr = "stub_tap_open"
+ */
+CAMLprim value stub_tap_open(value ocaml_ifname)
+{
+    CAMLparam1(ocaml_ifname);
+    unsigned int features;
+    struct ifreq ifr;
+    char *ifname = String_val(ocaml_ifname);
+
+    memset(&ifr, 0, sizeof(ifr));
+
+    size_t len = strlen(ifname);
+    if (len == 0) {
+        caml_failwith("empty string argument in " __FILE__);
+    }
+    if (len >= IFNAMSIZ) {
+        caml_failwith("string argument too long in "__FILE__);
+    }
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+
+    int fd = open(PATH_NET_TUN, O_RDWR);
+    if (fd < 0) {
+        caml_failwith("open(" PATH_NET_TUN ") failed in " __FILE__);
+    }
+
+    if (ioctl(fd, TUNGETFEATURES, &features) == -1) {
+        close(fd);
+        caml_failwith("TUNGETFEATURES failed in " __FILE__);
+    }
+
+    ifr.ifr_flags = IFF_TAP | IFF_NO_PI | (features & IFF_ONE_QUEUE);
+    if (ioctl(fd, TUNSETIFF, (void *) &ifr) != 0) {
+        close(fd);
+        caml_failwith("ioctl failed in " __FILE__);
+    }
+
+    fcntl(fd, F_SETFL, O_NONBLOCK);
+    CAMLreturn(Val_int(fd));
+}
+


### PR DESCRIPTION
We need to open /dev/net/tun with specific ioctl calls. This could be
implemented by either using a library like

  https://github.com/mirage/ocaml-tuntap

or we can implement the specific use case directly and avoid the new
dependency. This commit is a direct implementation of the required
functionality. It is accessible from OCaml as:

external _tap_open : string -> Unix.file_descr = "stub_tap_open"

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>