### PR TITLE
CP-24772 part1: Moved miscellaneous options from qemu-wrapper to xenopsd

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -272,20 +272,6 @@ def main(argv):
             n += 2
             continue
 
-        if p == "-serial":
-            try:
-                serial_c = xenstore_read("/local/logconsole/@")
-            except:
-                pass
-            if serial_c:
-                if '%d' in serial_c:
-                    tmp_serial_c = serial_c  % (domid)
-                    qemu_args[n+1] = "file:" + tmp_serial_c
-                else:
-                    qemu_args[n+1] = "file:" + serial_c
-            n+=2
-            continue
-
         if p == "-std-vga":
             vga_type = 'VGA'
             vga_extra_props += ['qemu-extended-regs=false']

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -258,11 +258,6 @@ def main(argv):
             del qemu_args[n]
             continue
 
-        if p == "-usbdevice":
-            if qemu_args[n+1] == "tablet":
-                qemu_args[n] = "-device"
-                qemu_args[n+1] = "usb-tablet,port=2"
-
         if p == "-netdev":
             m = re.search(r',ifname=(tap[0-9]+\.[0-9]+)', qemu_args[n+1])
             tapfd = get_tap_fd(m.group(1))

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -209,12 +209,6 @@ def main(argv):
     # qemu_args.extend(['-chardev'] + ['socket,id=libxl-cmd,'
     #                   'path=/var/run/xen/qmp-libxl-%d,server,nowait' % domid])
 
-    qemu_args.extend(['-qmp'] + ['unix:/var/run/xen/qmp-libxl-%d,server,nowait'
-                                 % domid])
-
-    qemu_args.extend(['-qmp'] + ['unix:/var/run/xen/qmp-event-%d,server,nowait'
-                                 % domid])
-
     qemu_args.extend(argv[2:])
     qemu_args.extend(drive_args)
 

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -189,20 +189,6 @@ def main(argv):
                       'allow-unassigned=true,trad_compat=%s%s'
                       % (mmio_start, trad_compat, igdpt)])
 
-    platform_device = True
-    disable_pf = xenstore_read("/local/domain/%d/vm-data/disable_pf" % domid)
-    if disable_pf and int(disable_pf) == 1:
-        platform_device = False
-
-    if platform_device:
-        device_id = xenstore_read("/local/domain/%d/platform/device_id" % domid)
-        if not device_id:
-            device_id = "0001"
-        qemu_args.extend(['-device',
-                          'xen-platform,addr=3,device-id=0x%s,revision=0x2,'
-                          'class-id=0x0100,subvendor_id=0x5853,subsystem_id=0x%s'
-                          % (device_id, device_id)])
-
     # enable qmp for debugging
     # qemu_args.extend(['-qmp'] + ['tcp:localhost:4444,server,nowait'])
 
@@ -298,10 +284,6 @@ def main(argv):
     else:
         qemu_args += ["-device", ",".join([vga_type, "vgamem_mb=%d" % vgamem_mb] \
                                           + vga_extra_props)]
-
-    has_device = xenstore_read("/local/domain/%d/control/has-vendor-device" % domid)
-    if has_device and int(has_device) == 1:
-        qemu_args += ["-device", "xen-pvdevice,device-id=0xc000"]
 
     s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
     open_fds.append(s1.fileno())

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -312,13 +312,6 @@ def main(argv):
     if has_device and int(has_device) == 1:
         qemu_args += ["-device", "xen-pvdevice,device-id=0xc000"]
 
-    qemu_args += ["-global", "PIIX4_PM.revision_id=0x1"]
-    qemu_args += ["-global", "ide-hd.ver=0.10.2"]
-
-    for driver in ["piix3-ide-xen", "piix3-usb-uhci", "rtl8139"]:
-        qemu_args += ["-global", "%s.subvendor_id=0x5853" % driver,
-                      "-global", "%s.subsystem_id=0x0001" % driver]
-
     s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
     open_fds.append(s1.fileno())
     qemu_args += ["-vnc-clipboard-socket-fd", str(s1.fileno())]

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -215,9 +215,6 @@ def main(argv):
     qemu_args.extend(['-qmp'] + ['unix:/var/run/xen/qmp-event-%d,server,nowait'
                                  % domid])
 
-    # enable parallel for legacy reasons
-    qemu_args.extend(['-parallel', 'null'])
-
     qemu_args.extend(argv[2:])
     qemu_args.extend(drive_args)
 

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -188,7 +188,6 @@ def main(argv):
                       'pc-0.10,accel=xen,max-ram-below-4g=%lu,'
                       'allow-unassigned=true,trad_compat=%s%s'
                       % (mmio_start, trad_compat, igdpt)])
-    qemu_args.extend(['-display', 'none', '-nodefaults'])
 
     platform_device = True
     disable_pf = xenstore_read("/local/domain/%d/vm-data/disable_pf" % domid)
@@ -320,7 +319,6 @@ def main(argv):
         qemu_args += ["-global", "%s.subvendor_id=0x5853" % driver,
                       "-global", "%s.subsystem_id=0x0001" % driver]
 
-    qemu_args += ["-trace", "enable=xen_platform_log"]
     s1, s2 = socket.socketpair(socket.AF_UNIX, socket.SOCK_STREAM)
     open_fds.append(s1.fileno())
     qemu_args += ["-vnc-clipboard-socket-fd", str(s1.fileno())]
@@ -346,9 +344,6 @@ def main(argv):
         uid = pwd.getpwnam('qemu_base').pw_uid + domid
         gid = grp.getgrnam('qemu_base').gr_gid + domid
         qemu_args += ["-runas", "%d.%d" % (uid, gid)]
-
-    qemu_args += ["-sandbox", "on,obsolete=deny,elevateprivileges=allow,spawn=deny,resourcecontrol=deny"]
-    qemu_args += ["-S"]
 
     xenstore_write("/libxl/%d/dm-version" % domid, "qemu_xen")
 

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -159,7 +159,7 @@ def main(argv):
     f.write("Arguments: %s\n" % " ".join(argv[1:]))
 
     for n in range(len(argv)):
-        if argv[n] == "-d":
+        if argv[n] == "-xen-domid":
             domid = int(argv[n+1])
             break
 
@@ -269,15 +269,6 @@ def main(argv):
                 qemu_args[n] = "-device"
                 qemu_args[n+1] = "usb-tablet,port=2"
 
-        if p == "-d":
-            qemu_args[n] = "-xen-domid"
-
-        if p == "-m":
-            ram_size_mb = int(qemu_args[n+1])
-            qemu_args[n+1] = "size=%d" % ram_size_mb
-            n += 2
-            continue
-
         if p == "-netdev":
             m = re.search(r',ifname=(tap[0-9]+\.[0-9]+)', qemu_args[n+1])
             tapfd = get_tap_fd(m.group(1))
@@ -299,11 +290,6 @@ def main(argv):
                 else:
                     qemu_args[n+1] = "file:" + serial_c
             n+=2
-            continue
-
-        if p == "-boot":
-            qemu_args[n+1] = "order=" + qemu_args[n+1]
-            n += 2
             continue
 
         if p == "-std-vga":

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -258,12 +258,6 @@ def main(argv):
             del qemu_args[n]
             continue
 
-        if p == "-vcpus":
-            qemu_args[n] = "-smp"
-            qemu_args[n+1] = "maxcpus=" + qemu_args[n+1]
-            n += 2
-            continue
-
         if p == "-usbdevice":
             if qemu_args[n+1] == "tablet":
                 qemu_args[n] = "-device"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2260,6 +2260,10 @@ module Backend = struct
             ; usb
             ; [ "-smp"; "maxcpus=" ^ (string_of_int info.Dm_Common.vcpus)]
             ; (serial_device |> function None -> [] | Some x -> [ "-serial"; x ])
+            ; [ "-display"; "none"; "-nodefaults"]
+            ; [ "-trace"; "enable=xen_platform_log"]
+            ; [ "-sandbox"; "on,obsolete=deny,elevateprivileges=allow,spawn=deny,resourcecontrol=deny"]
+            ; [ "-S"]
             ] in
 
         (* Sort the VIF devices by devid *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1686,7 +1686,6 @@ module Dm_Common = struct
     in
     List.concat
       [ ( info.serial |> function None -> [] | Some x -> [ "-serial"; x ])
-      ; [ "-vcpus"; string_of_int info.vcpus]
       ; disp_options
       ; usb'
       ; List.concat disks'
@@ -1954,6 +1953,7 @@ module Backend = struct
               ; "-m"; Int64.to_string (Int64.div info.Dm_Common.memory 1024L)
               ; "-boot"; info.Dm_Common.boot
               ]
+            ; [ "-vcpus"; string_of_int info.Dm_Common.vcpus]
             ] in
 
         (* Sort the VIF devices by devid *)
@@ -2236,6 +2236,7 @@ module Backend = struct
               ; "-m"; "size=" ^ (Int64.to_string (Int64.div info.Dm_Common.memory 1024L))
               ; "-boot"; "order=" ^ info.Dm_Common.boot
               ]
+            ; [ "-smp"; "maxcpus=" ^ (string_of_int info.Dm_Common.vcpus)]
             ] in
 
         (* Sort the VIF devices by devid *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2256,6 +2256,10 @@ module Backend = struct
         let list2 = ["subvendor_id=0x5853"; "subsystem_id=0x0001"] in
         let global = List.map (fun x -> List.map (fun y -> x^"."^y) list2) list1 |> List.concat in
 
+        let qmp = ["libxl"; "event"] |>
+          List.map (fun x -> ["-qmp"; sprintf "unix:/var/run/xen/qmp-%s-%d,server,nowait" x domid]) |>
+          List.concat in
+
         let misc = List.concat
             [ [ "-xen-domid"; string_of_int domid
               ; "-m"; "size=" ^ (Int64.to_string (Int64.div info.Dm_Common.memory 1024L))
@@ -2272,6 +2276,7 @@ module Backend = struct
             ; [ "-global"; "ide-hd.ver=0.10.2"]
             ; (global |> List.map (fun x -> ["-global"; x]) |> List.concat)
             ; (info.Dm_Common.parallel |> function None -> [ "-parallel"; "null"] | Some x -> [ "-parallel"; x])
+            ; qmp
             ] in
 
         (* Sort the VIF devices by devid *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2252,6 +2252,10 @@ module Backend = struct
           with _ -> info.Dm_Common.serial
         in
 
+        let list1 = ["piix3-ide-xen"; "piix3-usb-uhci"; "rtl8139"] in
+        let list2 = ["subvendor_id=0x5853"; "subsystem_id=0x0001"] in
+        let global = List.map (fun x -> List.map (fun y -> x^"."^y) list2) list1 |> List.concat in
+
         let misc = List.concat
             [ [ "-xen-domid"; string_of_int domid
               ; "-m"; "size=" ^ (Int64.to_string (Int64.div info.Dm_Common.memory 1024L))
@@ -2264,6 +2268,9 @@ module Backend = struct
             ; [ "-trace"; "enable=xen_platform_log"]
             ; [ "-sandbox"; "on,obsolete=deny,elevateprivileges=allow,spawn=deny,resourcecontrol=deny"]
             ; [ "-S"]
+            ; [ "-global"; "PIIX4_PM.revision_id=0x1"]
+            ; [ "-global"; "ide-hd.ver=0.10.2"]
+            ; (global |> List.map (fun x -> ["-global"; x]) |> List.concat)
             ] in
 
         (* Sort the VIF devices by devid *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1691,7 +1691,6 @@ module Dm_Common = struct
            |> List.concat
         )
       ; ( info.monitor  |> function None -> [] | Some x -> [ "-monitor";  x])
-      ; ( info.parallel |> function None -> [] | Some x -> [ "-parallel"; x])
       ]
 
   let vnconly_cmdline ~info ?(extras=[]) domid =
@@ -1954,6 +1953,7 @@ module Backend = struct
             ; usb
             ; [ "-vcpus"; string_of_int info.Dm_Common.vcpus]
             ; (info.Dm_Common.serial |> function None -> [] | Some x -> [ "-serial"; x ])
+            ; (info.Dm_Common.parallel |> function None -> [] | Some x -> [ "-parallel"; x])
             ] in
 
         (* Sort the VIF devices by devid *)
@@ -2271,6 +2271,7 @@ module Backend = struct
             ; [ "-global"; "PIIX4_PM.revision_id=0x1"]
             ; [ "-global"; "ide-hd.ver=0.10.2"]
             ; (global |> List.map (fun x -> ["-global"; x]) |> List.concat)
+            ; (info.Dm_Common.parallel |> function None -> [ "-parallel"; "null"] | Some x -> [ "-parallel"; x])
             ] in
 
         (* Sort the VIF devices by devid *)

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -214,7 +214,7 @@ end
 module Dm :
 sig
   type usb_opt =
-    | Enabled of string list
+    | Enabled of (string * int) list
     | Disabled
   type disp_intf_opt =
     | Std_vga

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1232,7 +1232,7 @@ module VM = struct
         let usb =
           match usb_enabled, usb_tablet_enabled with
           | true, false -> Device.Dm.Enabled []
-          | true, true -> Device.Dm.Enabled ["tablet"]
+          | true, true -> Device.Dm.Enabled [("tablet", 2)]
           | false, _ -> Device.Dm.Disabled
         in
         let parallel =


### PR DESCRIPTION
This is miscellanous options except the display options (that will be part 2). I thought I'd split it to make it easier to review. I'm attaching results from dev testing.

[after_changes.txt](https://github.com/xapi-project/xenopsd/files/1745021/after_changes.txt)
[before_changes.txt](https://github.com/xapi-project/xenopsd/files/1745022/before_changes.txt)
