### PR TITLE
CP-27212: Update toolstack part when calling usb_reset.py

### DIFF
--- a/xc/device.mli
+++ b/xc/device.mli
@@ -285,8 +285,8 @@ end
 
 module Vusb :
 sig
-  val vusb_plug : xs:Xenstore.Xs.xsh -> domid:Xenctrl.domid -> id:string -> hostbus:string -> hostport: string -> version: string-> unit
-  val vusb_unplug : xs:Xenstore.Xs.xsh -> domid:Xenctrl.domid -> id:string -> unit
+  val vusb_plug : xs:Xenstore.Xs.xsh -> privileged:bool -> domid:Xenctrl.domid -> id:string -> hostbus:string -> hostport: string -> version: string-> unit
+  val vusb_unplug : xs:Xenstore.Xs.xsh -> privileged:bool -> domid:Xenctrl.domid -> id:string -> hostbus:string -> hostport:string -> unit
   val qom_list : xs:Xenstore.Xs.xsh -> domid:Xenctrl.domid -> string list
 end
 

--- a/xc/xc_resources.ml
+++ b/xc/xc_resources.ml
@@ -31,6 +31,8 @@ let gimtool = ref "/opt/xensource/bin/gimtool"
 
 let alternatives = ref "/usr/lib/xapi/alternatives"
 
+let usb_reset_script = ref "/opt/xensource/libexec/usb_reset.py"
+
 
 open Unix
 


### PR DESCRIPTION
According to deprivileged qemu design for usb passthrough part:
    1. before passing through USB device
    a) if it's the first USB device to pass through,
        1) bind mount /dev,/sys in chroot directory.
        2) create and join cgroup devices:/qemu-<domid>.
        3) blacklist all and add a minimal white list("c 1:3 r", allow read /dev/null) to cgroup allow list.
    b) change uid, gid of the device file.
    c) add device to cgroup allow list if no device of the same type is allowed.
    then xenopsd/device should
    d) call Device_add using QMP

    2. after stopping passing through USB device or the VM is shut down,
    the function vusb_unplug in xenopsd/device should
    a) call Device_del using QMP
    and then call a function vusb_cleanup in usb_reset.py to execute:
    b) restore uid, gid of the device file.
    c) remove device from cgroup allow list if no device of the same type is allowed.

    3. after QEMU dies (explicitly by xenopsd or implicitly by xenopsd detecting that the domain disappeared), the
    function QEMU.stop in xenopsd/device will call a function vm_cleanup in usb_reset.py to execute:
    a) remove the cgroup if one has been created.
    b) umount /dev, /sys from chroot directory ifthey are mounted.

This ticket is to refine toolstack part to call usb_reset.py correctly:
1. Refine the parameters passed to the caller in xenopsd.
2. QEMU will be deprivileged by default. But when pci-passthrough is enabled, then qemu will be privileged.
So vusb cleanup after stopping passing through USB device or the VM is shut down can be ignored if qemu is privileged.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xapi-project/xenopsd/461)
<!-- Reviewable:end -->
