### PR TITLE
CA-285426: Increase qemu save file limit

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -65,7 +65,7 @@ def unshare(flags):
         raise OSError(ctypes.get_errno(), os.strerror(ctypes.get_errno()))
 
 def restrict_fsize():
-    limit = 32 * 1024
+    limit = 256 * 1024
     setrlimit(RLIMIT_FSIZE, (limit, limit))
 
 def enable_core_dumps():


### PR DESCRIPTION
With the recent vCPU hotplug changes, QEMU now saves some vCPU state
which increases the save file size. With many vCPUs, the limit is
tripped and suspend/migration fails. Increase the limit to 256 KiB.
With the maximum number of vCPUs and emulated devices, the save file
size was ~70 KB so this should be more than enough while still
preventing the guest from using much disk space.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>