### PR TITLE
Migrate with unique UUID

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -71,7 +71,9 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xenstore.unix
     xenstore_transport
     xenstore_transport.unix
-     core
+    core
+    re
+    re.pcre
   ))
 ))
 |} version flags coverage_rewriter

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -2384,16 +2384,11 @@ module VM = struct
     Debug.with_thread_associated dbg
       (fun () ->
          let id, final_id =
-           let final_id = List.assoc "final_id" cookies in
            (* The URI is /service/xenops/memory/id *)
            let bits = Stdext.Xstringext.String.split '/' (Uri.path uri) in
            let id = bits |> List.rev |> List.hd in
-<<<<<<< HEAD
-           debug "VM.receive_memory id = %s" id;
-=======
            let final_id = match List.assoc_opt "final_id" cookies with Some x -> x | None -> id in
            debug "VM.receive_memory id = %s, final_id=%s" id final_id;
->>>>>>> 28441bb8... Fixups
            id, final_id
          in
          match context.transferred_fd with

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -67,6 +67,7 @@ module type S = sig
   module VM : sig
     val add: Vm.t -> unit
     val remove: Vm.t -> unit
+    val rename: Vm.id -> Vm.id -> unit
     val create: Xenops_task.task_handle -> int64 option -> Vm.t -> unit
     val build: ?restore_fd:Unix.file_descr -> Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list-> string list -> bool ->  unit (* XXX cancel *)
     val create_device_model: Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list -> bool -> unit

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -16,7 +16,7 @@ open Xenops_interface
 open Xenops_server_plugin
 open Xenops_utils
 
-let unimplemented x = raise (Unimplemented x) 
+let unimplemented x = raise (Unimplemented x)
 
 let simplified = false
 let init () = ()
@@ -51,6 +51,8 @@ module HOST = struct
 end
 module VM = struct
   let add _ = ()
+
+  let rename _ _ = ()
   let remove _ = ()
   let create _ _ _ = unimplemented "VM.create"
   let build ?restore_fd _ _ _ _ _ = unimplemented "VM.build"

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -225,3 +225,5 @@ val wait_xen_free_mem : xc:Xenctrl.handle -> ?maximum_wait_time_seconds:int -> i
 val allowed_xsdata_prefixes: string list
 
 val set_xsdata : xs:Xenstore.Xs.xsh -> domid -> (string * string) list -> unit
+
+val move_xstree : xs:Xenstore.Xs.xsh -> domid -> string -> string -> unit

--- a/xc/jbuild
+++ b/xc/jbuild
@@ -57,6 +57,8 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     mtime.clock.os
     ppx_deriving_rpc
     ppx_sexp_conv
+    re
+    re.pcre
   ))
 ))
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1123,6 +1123,22 @@ module VM = struct
              ) (minimal_local_kvs @ minimal_vm_kvs)
       )
 
+  let rename vm vm' =
+    with_xc_and_xs
+      (fun xc xs ->
+         match di_of_uuid ~xc ~xs Newest (uuid_of_string vm) with
+         | None -> ()
+         | Some di ->
+            begin
+              debug "Renaming domain %d from %s to %s" di.Xenctrl.domid vm vm';
+              Xenctrl.domain_sethandle xc di.Xenctrl.domid vm';
+              debug "Moving xenstore tree";
+              Domain.move_xstree xs di.Xenctrl.domid vm vm';
+
+              DB.rename vm vm'
+            end
+      )
+
   let remove vm =
     with_xc_and_xs
       (fun xc xs ->


### PR DESCRIPTION
When we do a migrate we currently construct a new domain on the destination with the same uuid as the source. Doubly confusing when we do a localhost migrate.

This PR uses a temporary (but related) uuids during the migration. In fact, it goes a little further than just the domain and actually renames _all_ of the VM's metadata, so all tags on queues and database objects as well as domain uuid and xenstore trees reflect the temporary name. When the VM is paused on the source it is renamed there first, then the destination is renamed back to the original uuid.