### PR TITLE
CP-27171: remove qemu-upstream profile as valid option in the xapi vm record

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -53,7 +53,10 @@ module Profile = struct
   let of_string  = function
     | x when x = Name.qemu_trad            -> Qemu_trad
     | x when x = Name.qemu_upstream_compat -> Qemu_upstream_compat
-    | x when x = Name.qemu_upstream        -> Qemu_upstream
+    | x when x = Name.qemu_upstream        ->
+       sprintf "unsupported device-model profile %s: use %s" x Name.qemu_upstream_compat
+       |> fun s -> Internal_error s
+       |> raise
     | x -> debug "unknown device-model profile %s: defaulting to fallback: %s" x (string_of fallback);
       fallback
 


### PR DESCRIPTION
The last version of the upstream qemu design makes it clear that the profile
qemu-upstream-compat will be incompatible with the future qemu-upstream one.

Therefore, we should prevent users from incorrectly using the unimplemented
qemu-upstream profile as an alias for the qemu-upstream-compat profile, before
qemu-upstream-compat becomes a supported feature.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>