### PR TITLE
Use hex address in qemu command line for NICs

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2430,7 +2430,7 @@ module Backend = struct
           let ifname          = sprintf "tap%d.%d" domid devid in
           let uuid, _  as tap = tap_open ifname in
           let args =
-            [ "-device"; sprintf "rtl8139,netdev=tapnet%d,mac=%s,addr=%d" devid mac (devid + 4)
+            [ "-device"; sprintf "rtl8139,netdev=tapnet%d,mac=%s,addr=%x" devid mac (devid + 4)
             ; "-netdev"; sprintf "tap,id=tapnet%d,fd=%s" devid uuid
             ] in
           (tap::fds, args@argv) in


### PR DESCRIPTION
The address in the qemu command line needs to be in hexadecimal
notation.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>