### PR TITLE
CA-285400: Ensure tap devices are not held open

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -187,6 +187,12 @@ def main(argv):
     while n < len(qemu_args):
         p = qemu_args[n]
 
+        if p == "-netdev":
+            params = qemu_args[n + 1].split(',')
+            for param in params:
+                if param.startswith('fd='):
+                    open_fds.append(int(param.split('=')[1]))
+
         if p == "--syslog":
             del qemu_args[n]
             continue


### PR DESCRIPTION
Since xenopsd now opens the tap device file descriptors, they are
inherited by the clipboard daemon which prevents the tap devices from
being properly removed when the guest unplugs emulated NICs. This can
cause some weird networking issues.

Ideally, we would use Python 3's pass_fds subprocess option to only keep
the required fd open for the clipboard daemon, but since we're using
Python 2.7, this is not available. Instead, just make sure to close all
the tap fds before execing the clipboard daemon.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>