### PR TITLE
CA-285507: MultipleUSBPassthrough xenopsd internal error: Device_common.QMP_Error

### DIFF
--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -35,6 +35,7 @@ exception Device_error of device * string
 exception Device_unrecognized of string
 exception Hotplug_script_expecting_field of device * string
 exception QMP_Error of int * string (** domid, message *)
+exception QMP_connection_error of int * string
 
 val backend_path : xs:Xenstore.Xs.xsh -> endpoint -> Xenctrl.domid -> string
 val backend_path_of_device : xs:Xenstore.Xs.xsh -> device -> string

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2198,8 +2198,11 @@ module VUSB = struct
            let privileged = is_privileged vm in
            Device.Vusb.vusb_unplug ~xs ~privileged ~domid:frontend_domid ~id:(snd vusb.Vusb.id) ~hostbus:vusb.Vusb.hostbus ~hostport:vusb.Vusb.hostport
         ) Newest vm
-    with (Does_not_exist(_,_)) ->
+    with
+    | (Does_not_exist(_,_)) ->
       debug "VM = %s; VUSB = %s; Ignoring missing domain" vm (id_of vusb)
+    | (Device_not_connected) ->
+      debug "VM = %s; VUSB = %s; Ignoring missing device" vm (id_of vusb)
 
 end
 


### PR DESCRIPTION
Duplicate ID ehci error is raised when multiple usb devices are passed to one vm. USB controller should be plugged only once when more than one usb device use the same controller.

This PR depends on https://github.com/xapi-project/xenopsd/pull/463