### PR TITLE
CA-285245 add addr parameters to QEMU command line

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -178,7 +178,8 @@ def main(argv):
 
     vga_type = 'cirrus-vga'
     vgamem_mb = 4
-    vga_extra_props = ["rombar=1,romfile=", "subvendor_id=0x5853,subsystem_id=0x0001"]
+    vga_extra_props = ["rombar=1,romfile=",
+                       "subvendor_id=0x5853,subsystem_id=0x0001,addr=2"]
     upgraded_save_image = None
     serial_c = ''
     tmp_serial_c = ''

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2422,11 +2422,14 @@ module Backend = struct
             ] in
 
         (* Sort the VIF devices by devid *)
-        let nics = List.stable_sort (fun (_,_,a) (_,_,b) -> compare a b) info.Dm_Common.nics in
-        if List.length nics > Dm_Common.max_emulated_nics then
-          debug "Limiting the number of emulated NICs to %d" Dm_Common.max_emulated_nics;
+        let nics = List.stable_sort
+          (fun (_,_,a) (_,_,b) -> compare a b) info.Dm_Common.nics in
+        let nic_count = List.length nics in
+        let nic_max   = Dm_Common.max_emulated_nics in
+        if nic_count > nic_max then
+          debug "Limiting the number of emulated NICs to %d" nic_max;
         (* Take the first 'max_emulated_nics' elements from the list. *)
-        let nics = Xapi_stdext_std.Listext.List.take Dm_Common.max_emulated_nics nics in
+        let nics = Xapi_stdext_std.Listext.List.take nic_max nics in
 
         (* add_nic is used in a fold: it adds fd and command line args
          * for a nic to the existing fds and arguments (fds, argv)


### PR DESCRIPTION
These commits add an `addr` parameter for some QEMU devices:

* VGA: addr=2
* cirrus-vga: addr=2
* xen-pvdevice: addr=4+(number of NICs)

Examples for relevant `QEMU` arguments before (top) and after applying
these commits. In the case of xen-pvdevice, the machine has 7 NICs
(7+4=11=0xb), 

```
cirrus-vga,vgamem_mb=4,rombar=1,romfile=,subvendor_id=0x5853,subsystem_id=0x0001
cirrus-vga,vgamem_mb=4,rombar=1,romfile=,subvendor_id=0x5853,subsystem_id=0x0001,addr=2
	
VGA,vgamem_mb=8,rombar=1,romfile=,subvendor_id=0x5853,subsystem_id=0x0001,qemu-extended-regs=false
VGA,vgamem_mb=8,rombar=1,romfile=,subvendor_id=0x5853,subsystem_id=0x0001,addr=2,qemu-extended-regs=false

xen-pvdevice,device-id=0xc000
xen-pvdevice,device-id=0xc000,addr=b
```
