### PR TITLE
CA-285751: Fix VIF.get_state to return Vif.active as reality

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2940,15 +2940,11 @@ module VIF = struct
               let open Xenops_interface.Pci in
               let pci_state = PCI.get_state' vm pci in
               let open Xenops_interface.Pci in
-              begin match pci_state.plugged with
-              | true ->
-                { unplugged_vif with
-                  Vif.active = true;
-                  plugged = true;
-                  device = Some device;
-                }
-              | false -> unplugged_vif
-              end
+              { unplugged_vif with
+                Vif.active = get_active vm vif;
+                plugged = pci_state.plugged;
+                device = Some device;
+              }
             | Network.Local _ | Network.Remote _ ->
               let path = Device_common.kthread_pid_path_of_device ~xs d in
               let kthread_pid = try xs.Xs.read path |> int_of_string with _ -> 0 in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2937,12 +2937,10 @@ module VIF = struct
             let device = "vif" ^ (string_of_int domid) ^ "." ^ (string_of_int vif.position) in
             match vif.backend with
             | Network.Sriov pci ->
-              let open Xenops_interface.Pci in
               let pci_state = PCI.get_state' vm pci in
-              let open Xenops_interface.Pci in
               { unplugged_vif with
                 Vif.active = get_active vm vif;
-                plugged = pci_state.plugged;
+                plugged = Xenops_interface.Pci.(pci_state.plugged);
                 device = Some device;
               }
             | Network.Local _ | Network.Remote _ ->


### PR DESCRIPTION
The issue to be fixed in this commit is that SR-IOV VF backed vif
didn't return the real Vif.active when the SR-IOV VF (PCI) is not
plugged. This makes XAPI think this VIF should be removed and set its
currently_attached as false in a rebooting scenario. Consequently, XAPI
would find the metadata of VM changed, and push new memtadata to
Xenopsd, during which XAPI filtered out the un-attached vifs in new
metadata. Finally, this vif would not be created in the guest.

The fix is to make VIF.get_state return real value of active, nomorally
it is true, so that XAPI will not set this vif as non-attached.

Signed-off-by: Ming Lu <ming.lu@citrix.com>