### PR TITLE
CA-284768: Fix race between metadata DB updates

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1401,16 +1401,17 @@ module VM = struct
         );
 
         debug "VM = %s; domid = %d; Domain build completed" vm.Vm.id domid;
-        let k = vm.Vm.id in
-        let d = DB.read_exn vm.Vm.id in
-        let persistent = { d.VmExtra.persistent with
-                           VmExtra.build_info = Some build_info;
-                           ty = Some vm.ty;
-                         } in
-        DB.write k {
-          VmExtra.persistent = persistent;
-          VmExtra.non_persistent = d.VmExtra.non_persistent;
-        }
+        let _ = DB.update_exn vm.Vm.id (fun d ->
+          let persistent = { d.VmExtra.persistent with
+                             VmExtra.build_info = Some build_info;
+                             ty = Some vm.ty;
+                           } in
+          Some {
+            VmExtra.persistent = persistent;
+            VmExtra.non_persistent = d.VmExtra.non_persistent;
+          }
+        )
+        in ()
       ) (fun () -> Opt.iter Bootloader.delete !kernel_to_cleanup)
 
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2975,23 +2975,31 @@ module Actions = struct
 
   let maybe_update_pv_drivers_detected ~xc ~xs domid path =
     let vm = get_uuid ~xc domid |> Uuidm.to_string in
-    Opt.iter
-      (function { VmExtra.persistent; non_persistent } ->
-        if not non_persistent.VmExtra.pv_drivers_detected then begin
-          (* If the new value for this device is 4 then PV drivers are present *)
-          try
-            let value = xs.Xs.read path in
-            if value = "4" (* connected *) then begin
-              let non_persistent = { non_persistent with VmExtra.pv_drivers_detected = true } in
-              debug "VM = %s; found PV driver evidence on %s (value = %s)" vm path value;
-              DB.write vm { VmExtra.persistent; non_persistent };
-              Updates.add (Dynamic.Vm vm) internal_updates
-            end
-          with Xs_protocol.Enoent _ ->
-            warn "Watch event on %s fired but couldn't read from it" path;
-            () (* the path must have disappeared immediately after the watch fired. Let's treat this as if we never saw it. *)
-        end
-      ) (DB.read vm)
+    let updated =
+      DB.update vm (
+        Opt.map
+          (function { VmExtra.persistent; non_persistent } as vmextra ->
+            if not non_persistent.VmExtra.pv_drivers_detected then begin
+              (* If the new value for this device is 4 then PV drivers are present *)
+              try
+                let value = xs.Xs.read path in
+                if value = "4" (* connected *) then begin
+                  let non_persistent = { non_persistent with VmExtra.pv_drivers_detected = true } in
+                  debug "VM = %s; found PV driver evidence on %s (value = %s)" vm path value;
+                  { VmExtra.persistent; non_persistent }
+                end else
+                  vmextra
+              with Xs_protocol.Enoent _ ->
+                warn "Watch event on %s fired but couldn't read from it" path;
+                (* the path must have disappeared immediately after the watch fired. Let's treat this as if we never saw it. *)
+                vmextra
+            end else
+              vmextra
+          )
+        )
+    in
+    if updated then
+      Updates.add (Dynamic.Vm vm) internal_updates
 
   let interesting_paths_for_domain domid uuid =
     let open Printf in [


### PR DESCRIPTION
This passed a (smallish) stress test where VMs underwent many lifecycle operations.