### PR TITLE
CP-27114 cleanup /var/xen/qemu/root-<domid> for QEMU

### DIFF
--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -27,6 +27,23 @@ module Unix = struct
 
   let file_descr_of_rpc x = x |> Rpc.int_of_rpc |> file_descr_of_int
   let rpc_of_file_descr x = x |> int_of_file_descr |> Rpc.rpc_of_int
+
+  (** [rmtree path] removes a file or directory recursively without following
+  * symbolic links. It may raise [Failure] *)
+  let rmtree path =
+    let (//) = Filename.concat in
+    let rec rm path =
+      let st = Unix.lstat path in
+      match st.Unix.st_kind with
+      | Unix.S_DIR ->
+        Sys.readdir path |> Array.iter (fun file -> rm (path // file));
+        Unix.rmdir path
+      | _ -> Unix.unlink path
+    in try rm path with
+    | exn ->
+      let exn' = Printexc.to_string exn in
+      let msg  = Printf.sprintf "failed to remove %s: %s" path exn' in
+      failwith msg
 end
 
 let all = List.fold_left (&&) true

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -27,23 +27,6 @@ module Unix = struct
 
   let file_descr_of_rpc x = x |> Rpc.int_of_rpc |> file_descr_of_int
   let rpc_of_file_descr x = x |> int_of_file_descr |> Rpc.rpc_of_int
-
-  (** [rmtree path] removes a file or directory recursively without following
-  * symbolic links. It may raise [Failure] *)
-  let rmtree path =
-    let (//) = Filename.concat in
-    let rec rm path =
-      let st = Unix.lstat path in
-      match st.Unix.st_kind with
-      | Unix.S_DIR ->
-        Sys.readdir path |> Array.iter (fun file -> rm (path // file));
-        Unix.rmdir path
-      | _ -> Unix.unlink path
-    in try rm path with
-    | exn ->
-      let exn' = Printexc.to_string exn in
-      let msg  = Printf.sprintf "failed to remove %s: %s" path exn' in
-      failwith msg
 end
 
 let all = List.fold_left (&&) true
@@ -393,6 +376,7 @@ module FileFS = struct
     Unixext.mkdir_rec (Filename.dirname filename) 0o755;
     Unixext.write_string_to_file filename (Jsonrpc.to_string x)
   let exists path = Sys.file_exists (filename_of path)
+
   let rm path =
     List.iter
       (fun path ->
@@ -415,6 +399,24 @@ module FileFS = struct
            error "Failed to DB.delete %s : %s" path (Printexc.to_string e);
            ()
       ) (paths_of path)
+
+  (** [rmtree path] removes a file or directory recursively without following
+  * symbolic links. It may raise [Failure] *)
+  let rmtree path =
+    let (//) = Filename.concat in
+    let rec rm path =
+      let st = Unix.lstat path in
+      match st.Unix.st_kind with
+      | Unix.S_DIR ->
+        Sys.readdir path |> Array.iter (fun file -> rm (path // file));
+        Unix.rmdir path
+      | _ -> Unix.unlink path
+    in try rm path with
+    | exn ->
+      let exn' = Printexc.to_string exn in
+      let msg  = Printf.sprintf "failed to remove %s: %s" path exn' in
+      failwith msg
+
   let readdir path =
     let filename = filename_of path in
     if Sys.file_exists filename

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2303,11 +2303,8 @@ module Backend = struct
         QMP_Event.remove domid;
         xs.Xs.rm (sprintf "/libxl/%d" domid);
         let rm path =
-          try
-            Socket.Unix.rm path
-          with e ->
-            error "rm %s failed: %s (%s)" path (Printexc.to_string e) __LOC__
-        in
+          let msg = Printf.sprintf "removing %s" path in
+          Generic.best_effort msg (fun () -> Socket.Unix.rm path) in
         [ (* clean up QEMU socket leftover files *)
           Dm_Common.vnc_socket_path domid;
           (qmp_event_path domid);

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2313,7 +2313,7 @@ module Backend = struct
         Vusb.cleanup domid; (* unmounts devices in /var/xen/qemu/root-* *)
         let path = Printf.sprintf "/var/xen/qemu/root-%d" domid in
         Generic.best_effort (Printf.sprintf "removing %s" path)
-          (fun () -> Xenops_utils.Unix.rmtree path)
+          (fun () -> Xenops_utils.FileFS.rmtree path)
 
       let with_dirty_log domid ~f =
         finally


### PR DESCRIPTION
This implements removing the /var/xen/qemu/root-<domid> directory hierarchy after QEMU finishes.

Cleanup code is now split:
* Dm_Common.stop
* Qemu_upstream_compat.Dm.stop - removes /var/xen/qemu/root-<domid>
* Qemu_trad.Dm.stop - removes /var/xen/qemu/<pid>

Unlike /var/xen/qemu/<pid>,  /var/xen/qemu/root-<domid> is not expected to be empty such that removal has to be recursive. New code for this resides in Xenops_utils.Unix.rm.

This has been tested with device models qemu-trad and qemu-upstream-compat.