### PR TITLE
Support toolstack override of NIC device model for debug purposes

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -165,14 +165,13 @@ def main(argv):
                       'allow-unassigned=true,trad_compat=%s%s'
                       % (mmio_start, trad_compat, igdpt)])
 
-    # enable qmp for debugging
-    # qemu_args.extend(['-qmp'] + ['tcp:localhost:4444,server,nowait'])
-
-    # qemu_args.extend(['-chardev'] + ['socket,id=libxl-cmd,'
-    #                   'path=/var/run/xen/qmp-libxl-%d,server,nowait' % domid])
-
     qemu_args.extend(argv[2:])
     qemu_args.extend(drive_args)
+
+    # support toolstack override of NIC device model for debug purposes
+    nic = xenstore_read("/local/domain/%d/platform/nic_type" % domid)
+    if nic:
+        qemu_args = map(lambda x: x.replace("rtl8139", nic), qemu_args)
 
     n = 0
 


### PR DESCRIPTION
This basically adapts the same code from qemu-dm-wrapper for qemu-trad.
QEMU builds e1000 as an alternative model that is sometimes used for
debugging (e.g. netsted virt) and testing.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>