### PR TITLE
CP-27285: Implement GVT-d as normal passthrough

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -157,9 +157,6 @@ def main(argv):
     trad_compat = 'true'
     igdpt = ''
 
-    if "-gfx_passthru" in argv[1:]:
-        igdpt = ',igd-passthru=on'
-
     qemu_args.extend(['-machine',
                       'pc-0.10,accel=xen,max-ram-below-4g=%lu,'
                       'allow-unassigned=true,trad_compat=%s%s'
@@ -204,10 +201,6 @@ def main(argv):
             continue
 
         if p == "-acpi":
-            del qemu_args[n]
-            continue
-
-        if p == "-gfx_passthru":
             del qemu_args[n]
             continue
 

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1657,7 +1657,7 @@ module Dm_Common = struct
       | Vgpu _ -> failwith "Unsupported vGPU configuration"
       | Std_vga -> ["-std-vga"]
       | Cirrus -> []
-      | GVT_d -> ["-std-vga"; "-gfx_passthru"]
+      | GVT_d -> ["-std-vga"] (* relies on pci-passthrough *)
     in
     let videoram_opt = ["-videoram"; string_of_int info.video_mib] in
     let vnc_opts_of ip_addr_opt auto port keymap ~domid =


### PR DESCRIPTION
This PR removes the argument '-gfx_passthru' for all the qemu profiles (qemu-trad and QEMU upstream). The gfx_passthrough argument is unnecessary after the changes in CP-24243.

Tested with a Windows VM in qemu-trad and qemu-upstream-compat profiles. For both profiles, after attaching a GVT-d passthrough VGPU to the VM and starting the VM:
* the vgpu_pci key in the VM.other-config field was populated with the corresponding pci device as expected, and /usr/log/daemon.log showed that -gfx_passthrough is not used anymore. 
* the windows guest displayed a new display device, which was found by the corresponding Intel Iris Pro driver, and the windows rebooted in Aero mode and was able to provide the corresponding Windows Experience Index for the attached VGPU.
```
dom0# xe vm-list uuid=d7dba5a2-5c7b-083f-89e8-bac2aece3118 params=uuid,name-label,platform,other-config
uuid ( RO)            : d7dba5a2-5c7b-083f-89e8-bac2aece3118
      name-label ( RW): Windows 7 SP1 GVT-d passthrough qemu-upstream-cmopat
        platform (MRW): timeoffset: -1; igd_passthrough: true; device-model: qemu-upstream-compat; hpet: true; apic: true; device_id: 0002; cores-per-socket: 2; pae: true; nx: true; viridian_time_ref_count: true; viridian: true; acpi: 1; viridian_reference_tsc: true
    other-config (MRW): vgpu_pci: 0/0000:00:02.0; xenrt-distro: win7sp1-x64; base_template_name: Windows 7 (64-bit); import_task: OpaqueRef:96bdafb4-bd2b-4092-a951-ffbc356a45f5; mac_seed: 3304523e-1338-4f37-6124-712a46af86bd; install-methods: cdrom
```
which matches the pci address in dom0 for the passed-through Iris vgpu:
```
dom0# lspci |grep Iris
00:02.0 Display controller: Intel Corporation Iris Pro Graphics P6300 (rev 0a)
```