### PR TITLE
CA-284857: call usb_reset_detach unconditionally

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1536,8 +1536,7 @@ module Vusb = struct
              raise Device_not_connected
       )
       (fun () ->
-         if List.mem id (qom_list ~xs ~domid) then
-           usb_reset_detach ~hostbus ~hostport ~domid ~privileged
+         usb_reset_detach ~hostbus ~hostport ~domid ~privileged
       )
 
 end


### PR DESCRIPTION
When calling usb_detach in usb_reset.py, we shouldn't reply on the
result of qom-list as when the vusb is successfully unpluged, the
qom-list will return nothing of the vusb, but we still need to do detach
work. So this is a wrong judgement.
This is somehow related to https://github.com/xapi-project/xen-api/pull/3517. 
Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>