### PR TITLE
CP-27216: uid/gid save and restore of device file

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -308,6 +308,10 @@ let make ~xc ~xs vm_info domain_config uuid =
 
         (* ...and a few corresponding private nodes for us to use. *)
         mksubdirs xenops_dom_path device_dirs zeroperm;
+        (* add usb directory to save usb device uid/gid when passing through usb to deprivileged guests.
+                For example, /dev/bus/usb/001/003 which is 0/0(root/root)*)
+        mksubdirs dom_path ["usb"] (Xenbus_utils.rwperm_for_guest 0);
+
       );
 
     xs.Xs.writev dom_path (filtered_xsdata vm_info.xsdata);


### PR DESCRIPTION
This ticket is to make the uid/gid more accurate, as uid/gid of almost all the
usb devices in the path (eg. "/dev/bus/usb/001/003") is 0/0. But it
still can be other values. So we will save the uid/gid of the device file
when plugging it to vm and restore it in unplug step.

This PR is also along with https://github.com/xapi-project/xen-api/pull/3525 
Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>