### PR TITLE
CA-286115: Remove race between DB and xenstore watch thread

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -918,14 +918,13 @@ module VM = struct
   let create_exn (task: Xenops_task.task_handle) memory_upper_bound vm =
     let k = vm.Vm.id in
     with_xc_and_xs (fun xc xs ->
-      let _ = DB.update k (fun vmextra ->
-         let persistent, non_persistent =
-           match vmextra with
-           | Some x ->
-             debug "VM = %s; reloading stored domain-level configuration" vm.Vm.id;
-             x.VmExtra.persistent, x.VmExtra.non_persistent
-           | None -> begin
-               debug "VM = %s; has no stored domain-level configuration, regenerating" vm.Vm.id;
+      (* Ensure the DB contains something for this VM - this is to avoid a race with the *)
+        let _ = DB.update k (function
+          | Some x ->
+              debug "VM = %s; reloading stored domain-level configuration" vm.Vm.id;
+              Some x
+            | None -> begin
+              debug "VM = %s; has no stored domain-level configuration, regenerating" vm.Vm.id;
                let persistent =
                  { VmExtra.build_info = None
                  ; ty = Some vm.ty
@@ -941,8 +940,13 @@ module VM = struct
                        ~default:false
                  } in
                let non_persistent = generate_non_persistent_state xc xs vm persistent in
-               persistent, non_persistent
-             end in
+               Some VmExtra.{persistent; non_persistent}
+             end) in
+         let _ = DB.update k (fun vmextra ->
+           let persistent, non_persistent = match vmextra with
+           | Some x -> VmExtra.(x.persistent, x.non_persistent)
+           | None -> failwith "Interleaving problem"
+           in
          let open Memory in
          let overhead_bytes = compute_overhead persistent non_persistent in
          let resuming = non_persistent.VmExtra.suspend_memory_bytes <> 0L in


### PR DESCRIPTION
The xenstore watch @introduceDomain will be emitted whenever a new
domain turns up. We have a thread that reacts to this and installs watches
for the new domain if it's one xenopsd is interested in. The problem occurs
here because xenopsd decides whether a domain is interesting or not based on
whether it has metadata about the VM in its VmExtra database, `DB`. This
was only stored on completion of the VM_create call, which is after the
domain is created, and hence there was a race between the two threads. This
commit ensures there is an entry in the VmExtra database before the
domain is created, thus removing the race.

Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>