### PR TITLE
CP-27216: no need to pass uid/gid

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1447,9 +1447,6 @@ module Vusb = struct
                  ; hostbus ^ "-" ^ hostport
                  ; "-d"
                  ; string_of_int domid
-                 ; "-i"
-                 ; "0"
-                 ; "0"
                  ]
       in
       exec_usb_reset_script argv


### PR DESCRIPTION
As restore uid/gid of usb device file will be included in usb_reset script, so pass
uid/gid to usb_reset script is not needed anymore.

Another PR https://github.com/xapi-project/xen-api/pull/3525 is related with this.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>