### PR TITLE
CP-27545: pass -vgpu argument from xenopsd to xenguest when using nvidia vgpus

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -143,8 +143,12 @@ def main(argv):
     drive_args = get_drive_args('%d' % domid)
     qemu_args = ['qemu-dm-%d' % domid]
 
-    # read the size of lower MMIO hole provisioned by xenguest
     mmio_start = HVM_BELOW_4G_MMIO_START
+    # vGPU now requires extra space in lower MMIO hole by default
+    if '-vgpu' in argv:
+        mmio_start -= HVM_BELOW_4G_MMIO_LENGTH
+
+    # read the size of lower MMIO hole provisioned by xenguest
     mmio_size = xenstore_read("/local/domain/%d/data/mmio-hole-size" % domid)
     if mmio_size:
         mmio_start = (1 << 32) - int(mmio_size)

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -155,7 +155,7 @@ val set_action_request: xs:Xenstore.Xs.xsh -> domid -> string option -> unit
 val get_action_request: xs:Xenstore.Xs.xsh -> domid -> string option
 
 (** Restore a domain using the info provided *)
-val build: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> store_domid:int -> console_domid:int -> timeoffset:string -> extras:string list -> build_info -> string -> domid -> bool -> unit
+val build: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh -> store_domid:int -> console_domid:int -> timeoffset:string -> extras:string list -> vgpus:Xenops_interface.Vgpu.t list -> build_info -> string -> domid -> bool -> unit
 
 (** Restore a domain using the info provided *)
 val restore: Xenops_task.Xenops_task.task_handle -> xc: Xenctrl.handle -> xs: Xenstore.Xs.xsh

--- a/xc/stubdom.ml
+++ b/xc/stubdom.ml
@@ -49,7 +49,7 @@ let create ~xc ~xs domid =
 
 let build (task: Xenops_task.task_handle) ~xc ~xs ~dm ~store_domid ~console_domid info xenguest domid stubdom_domid =
   (* Now build it as a PV domain *)
-  let () = Domain.build task ~xc ~xs ~store_domid ~console_domid ~timeoffset:"" ~extras:[] {
+  let () = Domain.build task ~xc ~xs ~store_domid ~console_domid ~timeoffset:"" ~extras:[] ~vgpus:[] {
       Domain.memory_max=memory_kib;
       Domain.memory_target=memory_kib;
       Domain.kernel="/usr/lib/xen/boot/ioemu-stubdom.gz";

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1413,7 +1413,7 @@ module VM = struct
                    } in
                  ((make_build_info !Resources.pvinpvh_xen builder_spec_info), "")
               ) in
-        Domain.build task ~xc ~xs ~store_domid ~console_domid ~timeoffset ~extras build_info (choose_xenguest vm.Vm.platformdata) domid force;
+        Domain.build task ~xc ~xs ~store_domid ~console_domid ~timeoffset ~extras ~vgpus build_info (choose_xenguest vm.Vm.platformdata) domid force;
         Int64.(
           let min = to_int (div vm.Vm.memory_dynamic_min 1024L)
           and max = to_int (div vm.Vm.memory_dynamic_max 1024L) in


### PR DESCRIPTION
xenguest now takes a -vgpu parameter when building a VM that has a nvidia vgpu.
For other (v)gpu vendors, including pass-through for any vendor, this parameter
is not sent to xenguest.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>
