### PR TITLE
CA-267368: Update timeoffset in non_persistent data of VM

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2011,7 +2011,19 @@ module VM = struct
     let _ = DB.update vm.Vm.id (fun d ->
         let non_persistent = match d with
           | None -> with_xc_and_xs (fun xc xs -> generate_non_persistent_state xc xs vm persistent)
-          | Some vmextra -> vmextra.VmExtra.non_persistent
+          | Some vmextra ->
+            (* Update timeoffset in non_persistent also *)
+            begin match vm.ty with
+              | HVM {timeoffset} ->
+                let c = VmExtra.(vmextra.non_persistent.create_info) in
+                let l = List.remove_assoc "timeoffset" c.Domain.platformdata in
+                { vmextra.VmExtra.non_persistent with
+                  VmExtra.create_info = { c with
+                                          Domain.platformdata = ("timeoffset", timeoffset) :: l
+                                        }
+                }
+              | _ -> vmextra.VmExtra.non_persistent
+            end
         in
         Some { VmExtra.persistent = persistent; VmExtra.non_persistent = non_persistent; }
       )


### PR DESCRIPTION
A scenario is: the timeoffset in persistent data of a running VM
(xenstore: /vm/<VM-UUID>/rtc/timeoffset) is changed, but the one in
non_persistent data (xenstore:
/local/domain/<DOM-ID>/platform/timeoffset) is not. Then doing a
localhost migration on this VM, the expected behavior is that the
timeoffset in non_persistent data should be updated as the one in
persistent data. This behavior is also expected by normal migration
(from one host to another). But localhost migration didn't result in
this behavior. This is what will be fixed in this commit.

Particularly, in the scenario described above, the non_persistent data
will be created/updated in `Xenops_server_xen.set_internal_state`, which
will be called from `xenops_server.VM.import_metadata` if the `domains`
field in VM `Metadata` is not `None`. The `domains` refers the VM on
source host in a migration.

Prior to this commit, Xenopsd would check if there is a non_persistent
data already. If there is (the case in localhost migration), then the
existing one would be re-used in `Domain.make`. This logic caused the
issue. With this commit, Xenopsd will update the timeoffset in
non_persistent data same as the value in persistent data.

Conservatively, this commit does not make change to re-generate
non_persistent data in `Xenops_server_xen.set_internal_state` always,
although it looks like only localhost migration will hit the logic to
reuse existing non_persistent data.

Signed-off-by: Ming Lu <ming.lu@citrix.com>