### PR TITLE
Revert changes to hotplug rules and direct-io-safe

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -565,7 +565,6 @@ module Vbd_Common = struct
       "mode", string_of_mode x.mode;
       "params", params;
       "qemu-params", qemu_params;
-      "direct-io-safe", "1";
     ];
     (* We don't have PV drivers for HVM guests for CDROMs. We prevent
        blkback from successfully opening the device since this can


### PR DESCRIPTION
We've found that things continue to work without these patches. I've tested VM export / import, xenmotion, suspend/resume, start/stop, and these all worked fine without these patches.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>