### PR TITLE
CP-27581: Move MMIO hole size key to a persistent location

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -149,7 +149,7 @@ def main(argv):
         mmio_start -= HVM_BELOW_4G_MMIO_LENGTH
 
     # read the size of lower MMIO hole provisioned by xenguest
-    mmio_size = xenstore_read("/local/domain/%d/data/mmio-hole-size" % domid)
+    mmio_size = xenstore_read("/local/domain/%d/vm-data/mmio-hole-size" % domid)
     if mmio_size:
         mmio_start = (1 << 32) - int(mmio_size)
 


### PR DESCRIPTION
This complements the changes to xenguest and hvmloader which in complex
serves as additional protection from unpredictable MMIO hole size
fluctuations that might occur for a variety of reasons. Although,
it's expected that all migration streams starting from Kolkata
will have this key, we still need to guess the size of MMIO hole for
the VMs from the previous releases (Jura and older) and handle them as
default cases - hence there is still the special handling for legacy
and vGPU VMs.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>