### PR TITLE
CA-267368: Move/Remove non_persistent data

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -126,10 +126,7 @@ module VmExtra = struct
 
   type non_persistent_t = {
     create_info: Domain.create_info;
-    vcpu_max: int;
     vcpus: int;
-    shadow_multiplier: float;
-    memory_static_max: int64;
     suspend_memory_bytes: int64;
     qemu_vbds: (Vbd.id * (int * qemu_frontend)) list;
     qemu_vifs: (Vif.id * (int * qemu_frontend)) list;
@@ -753,9 +750,9 @@ module VM = struct
 
   let dm_of ~vm = dm_of vm.Vm.id
 
-  let compute_overhead persistent non_persistent =
+  let compute_overhead persistent vcpu_max memory_static_max shadow_multiplier =
     let open VmExtra in
-    let static_max_mib = Memory.mib_of_bytes_used non_persistent.memory_static_max in
+    let static_max_mib = Memory.mib_of_bytes_used memory_static_max in
     let model =
       match persistent.ty with
       | Some (PV _)      -> Memory.Linux.overhead_mib
@@ -763,8 +760,7 @@ module VM = struct
       | Some (HVM _)     -> Memory.HVM.overhead_mib
       | None             -> failwith "cannot compute memory overhead: unable to determine domain type"
     in
-    model static_max_mib non_persistent.vcpu_max non_persistent.shadow_multiplier |>
-    Memory.bytes_of_mib
+    model static_max_mib vcpu_max shadow_multiplier |> Memory.bytes_of_mib
 
   let shutdown_reason = function
     | Reboot -> Domain.Reboot
@@ -922,10 +918,7 @@ module VM = struct
     } in
     {
       VmExtra.create_info = create_info;
-      vcpu_max = vm.vcpu_max;
       vcpus = vm.vcpus;
-      shadow_multiplier = (match vm.Vm.ty with Vm.HVM { Vm.shadow_multiplier = sm } -> sm | _ -> 1.);
-      memory_static_max = vm.memory_static_max;
       suspend_memory_bytes = 0L;
       qemu_vbds = [];
       qemu_vifs = [];
@@ -967,8 +960,14 @@ module VM = struct
            | Some x -> VmExtra.(x.persistent, x.non_persistent)
            | None -> failwith "Interleaving problem"
            in
+         let shadow_multiplier = match vm.Vm.ty with
+           | Vm.HVM { Vm.shadow_multiplier = sm } -> sm
+           | _ -> 1.
+         in
          let open Memory in
-         let overhead_bytes = compute_overhead persistent non_persistent in
+         let overhead_bytes =
+           compute_overhead persistent vm.vcpu_max vm.memory_static_max shadow_multiplier
+         in
          let resuming = non_persistent.VmExtra.suspend_memory_bytes <> 0L in
          (* If we are resuming then we know exactly how much memory is needed. If we are
                live migrating then we will only know an upper bound. If we are starting from

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -106,6 +106,7 @@ module VmExtra = struct
     nested_virt: bool;(* platform:nested_virt at boot time *)
     profile: Device.Profile.t option;
     suspend_memory_bytes: int64;
+    qemu_vbds: (Vbd.id * (int * qemu_frontend)) list;
   } [@@deriving rpc]
 
   let default_persistent_t =
@@ -117,6 +118,7 @@ module VmExtra = struct
     ; nested_virt = false
     ; profile = None
     ; suspend_memory_bytes = 0L
+    ; qemu_vbds = []
     }
 
   (* override rpc code generated for persistent_t. It is important that
@@ -127,7 +129,6 @@ module VmExtra = struct
     |> persistent_t_of_rpc
 
   type non_persistent_t = {
-    qemu_vbds: (Vbd.id * (int * qemu_frontend)) list;
     qemu_vifs: (Vif.id * (int * qemu_frontend)) list;
     pci_msitranslate: bool;
     pci_power_mgmt: bool;
@@ -844,6 +845,7 @@ module VM = struct
       nested_virt = false;
       profile = profile_of ~vm;
       suspend_memory_bytes = 0L;
+      qemu_vbds = [];
     } |> VmExtra.rpc_of_persistent_t |> Jsonrpc.to_string
 
   let mkints n =
@@ -866,7 +868,6 @@ module VM = struct
 
   let generate_non_persistent_state xc xs vm =
     VmExtra.{
-      qemu_vbds = [];
       qemu_vifs = [];
       pci_msitranslate = vm.Vm.pci_msitranslate;
       pci_power_mgmt = vm.Vm.pci_power_mgmt;
@@ -951,6 +952,7 @@ module VM = struct
                        ~default:false
                  ; profile = profile_of ~vm
                  ; suspend_memory_bytes = 0L
+                 ; qemu_vbds = []
                  } in
                let non_persistent = generate_non_persistent_state xc xs vm in
                Some VmExtra.{persistent; non_persistent}
@@ -1224,9 +1226,8 @@ module VM = struct
     | {
       VmExtra.build_info = Some build_info;
       ty = Some ty;
-    },{
-        VmExtra.qemu_vbds = qemu_vbds
-      } ->
+      VmExtra.qemu_vbds = qemu_vbds;
+    }, _ ->
       let make ?(boot_order="cd") ?(serial="pty") ?(monitor="null")
           ?(nics=[]) ?(disks=[]) ?(vgpus=[])
           ?(pci_emulations=[]) ?(usb=Device.Dm.Disabled)
@@ -2364,9 +2365,9 @@ module VBD = struct
                 we will. Also this causes the SMRT tests to fail, as they demand the loopback VBDs *)
              Opt.iter (fun q ->
                  let _ = DB.update_exn vm (fun vm_t ->
-                     let non_persistent = { vm_t.VmExtra.non_persistent with
-                                            VmExtra.qemu_vbds = (vbd.Vbd.id, q) :: vm_t.VmExtra.non_persistent.VmExtra.qemu_vbds} in
-                     Some { vm_t with VmExtra.non_persistent = non_persistent }
+                     let persistent = { vm_t.VmExtra.persistent with
+                                            VmExtra.qemu_vbds = (vbd.Vbd.id, q) :: vm_t.VmExtra.persistent.VmExtra.qemu_vbds} in
+                     Some { vm_t with VmExtra.persistent = persistent }
                    )
                  in ()
                ) qemu_frontend
@@ -2422,14 +2423,14 @@ module VBD = struct
                 (* If we have a qemu frontend, detach this too. *)
                 let _ = DB.update vm (
                     Opt.map (fun vm_t ->
-                        let non_persistent = vm_t.VmExtra.non_persistent in
-                        if List.mem_assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds then begin
-                          let _, qemu_vbd = List.assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds in
+                        let persistent = vm_t.VmExtra.persistent in
+                        if List.mem_assoc vbd.Vbd.id persistent.VmExtra.qemu_vbds then begin
+                          let _, qemu_vbd = List.assoc vbd.Vbd.id persistent.VmExtra.qemu_vbds in
                           (* destroy_vbd_frontend ignores 'refusing to close' transients' *)
                           destroy_vbd_frontend ~xc ~xs task qemu_vbd;
-                          let non_persistent = { non_persistent with
-                                                 VmExtra.qemu_vbds = List.remove_assoc vbd.Vbd.id non_persistent.VmExtra.qemu_vbds } in
-                          { vm_t with VmExtra.non_persistent = non_persistent }
+                          let persistent = { persistent with
+                                             VmExtra.qemu_vbds = List.remove_assoc vbd.Vbd.id persistent.VmExtra.qemu_vbds } in
+                          { vm_t with VmExtra.persistent = persistent }
                         end else
                           vm_t
                       )

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -126,7 +126,6 @@ module VmExtra = struct
 
   type non_persistent_t = {
     create_info: Domain.create_info;
-    vcpus: int;
     suspend_memory_bytes: int64;
     qemu_vbds: (Vbd.id * (int * qemu_frontend)) list;
     qemu_vifs: (Vif.id * (int * qemu_frontend)) list;
@@ -918,7 +917,6 @@ module VM = struct
     } in
     {
       VmExtra.create_info = create_info;
-      vcpus = vm.vcpus;
       suspend_memory_bytes = 0L;
       qemu_vbds = [];
       qemu_vifs = [];
@@ -1881,10 +1879,7 @@ module VM = struct
                | None -> false
              end;
              xsdata_state = xsdata_state;
-             vcpu_target = begin match vme with
-               | Some x -> x.VmExtra.non_persistent.VmExtra.vcpus
-               | None -> 0
-             end;
+             vcpu_target = vm.vcpus;
              memory_target = memory_target;
              memory_actual = memory_actual;
              memory_limit = memory_limit;


### PR DESCRIPTION
The issue in CA-267368 is that 'timeoffset' of a HVM VM fails to be written to xenstore path "/local/domain/DOM-ID/platform/timeoffset" in a localhost migration.
The cause is Xenopsd stores 'timeoffset' into two places: persistent data and non_persistent data. While in a localhost migration, Xenopsd would not re-generate the non_persistent data since it has existed already. This makes 'timeoffset' data in non_persistent data out of sync with the one in persistent data.
Per @jonludlam and @mseri comments, actually root cause is Xenopsd "has a 'nonpersistent' state that's persisted."
Therefore, in these commits, each data in non_persistent data will be:
1. either removed if it will not be changed since creation. It can be re-generated once it is needed, or
2. moved into persistent data if it will be changed during the VM's lifecycle recognized by Xenopsd.
Eventually, non_persistent data is removed completely.

Signed-off-by: Ming Lu <ming.lu@citrix.com>