### PR TITLE
CA-288207 fix finally()

### DIFF
--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -82,7 +82,9 @@ let finally f g =
     result
   with e ->
     Backtrace.is_important e;
-    g ();
+    (try g () with exn ->
+       debug "ignoring exception in finally() block: %s"
+         (Printexc.to_string exn));
     raise e
 
 


### PR DESCRIPTION
In the old implementation of finally() (shown below), an exception
raised by g() in the with-block would escape:

```
let finally f g =
  try
    let result = f () in
    g ();
    result
  with e ->
    Backtrace.is_important e;
    g ();
    raise e
```

Whether this is the correct behaviour or not is debatable but it lost
the exception e, which was the primary failure. This commit changes the
behaviour to ignore exceptions raised by g() in the with-block and to
always re-raise e.

This problem was hit in CA-288207: during cleanup of a cancelled task,
g() in a finally block raised an exception that escaped and lost the
original exception. This does resolve the behaviour observed
(migration fails with internal error about contacting
QEMU) but it does not resolve it completely. In testing I have seen a
failure with another internal error, unrelated to QEMU.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>