### PR TITLE
CA-287881 use "raw" format for Blockdev_change_medium

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2121,8 +2121,13 @@ module Backend = struct
                                  Qmp.(other |> as_msg |> string_of_message))) in
                  finally
                    (fun () ->
-                      let path = sprintf "/dev/fdset/%d" fd_info.Qmp.fdset_id in
-                      let cmd  = Qmp.(Blockdev_change_medium (cd, path)) in
+                      let path   = sprintf "/dev/fdset/%d" fd_info.Qmp.fdset_id in
+                      let medium = Qmp.
+                        { medium_device   = cd
+                        ; medium_filename = path
+                        ; medium_format   = Some "raw"
+                        } in
+                      let cmd  = Qmp.(Blockdev_change_medium medium) in
                       qmp_send_cmd domid cmd |> ignore)
                    (fun () ->
                       let cmd = Qmp.(Remove_fd fd_info.fdset_id) in


### PR DESCRIPTION
QMP command Blockdev_change_medium implements CD changes. It now is more
explicit about the format of the CD and specifies "raw".

This depends on a corresponding change in the qmp libary that is packaged as xs-opam - which in turn will require a new release. Don't merge this yet.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>