### PR TITLE
CP-28088: Tell xenguest about GVT-g

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -674,6 +674,8 @@ let xenguest_args_hvm ~domid ~store_port ~store_domid ~console_port ~console_dom
   ]
   @ (vgpus |> function
     | [Xenops_interface.Vgpu.{implementation = Nvidia _}] -> ["-vgpu"]
+    | [Xenops_interface.Vgpu.{implementation = GVT_g _; physical_pci_address}] ->
+      ["-gvtg"; Xenops_interface.Pci.string_of_address physical_pci_address]
     | _ -> []
   )
   @ xenguest_args_base ~domid ~store_port ~store_domid ~console_port ~console_domid ~memory


### PR DESCRIPTION
If a VM is started with a GVT-g device, then we need to tell xenguest about it,
and which PCI device is used.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>