### PR TITLE
CP-24775 remove with_dirty_log() code and calls

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1982,9 +1982,6 @@ module Backend = struct
       (** [stop xenstore qemu_domid domid] stops a domain *)
       val stop: xs:Xenstore.Xs.xsh -> qemu_domid:int -> int -> unit
 
-      (** [with_dirty_log domid f] executes f in a context where the dirty log is enabled *)
-      val with_dirty_log: int -> f:(unit -> 'a) -> 'a
-
       (** [cmdline_of_info xenstore info restore domid] creates the command line arguments to pass to the qemu wrapper script *)
       val qemu_args: xs:Xenstore.Xs.xsh -> dm:Profile.t -> Dm_Common.info
         -> bool -> int -> Dm_Common.qemu_args
@@ -2040,8 +2037,6 @@ module Backend = struct
         | Some qemu_pid ->
           Generic.best_effort "removing core files from /var/xen/qemu"
             (fun () -> Unix.rmdir ("/var/xen/qemu/"^(string_of_int qemu_pid)))
-
-      let with_dirty_log domid ~f = f()
 
       let qemu_args ~xs ~dm info restore domid =
         let common = Dm_Common.qemu_args ~xs ~dm info restore domid in
@@ -2393,16 +2388,6 @@ module Backend = struct
         Generic.best_effort (Printf.sprintf "removing %s" path)
           (fun () -> Xenops_utils.FileFS.rmtree path)
 
-      let with_dirty_log domid ~f =
-        finally
-          (fun() ->
-             qmp_send_cmd domid Qmp.(Xen_set_global_dirty_log true) |> ignore;
-             f()
-          )
-          (fun() ->
-             qmp_send_cmd domid Qmp.(Xen_set_global_dirty_log false) |> ignore
-          )
-
       let tap_open ifname =
         let uuid = Uuidm.to_string (Uuidm.create `V4) in
         let fd   = Tuntap.tap_open ifname in
@@ -2655,10 +2640,6 @@ module Dm = struct
   let stop ~xs ~qemu_domid ~dm domid =
     let module Q = (val Backend.of_profile dm) in
     Q.Dm.stop ~xs ~qemu_domid domid
-
-  let with_dirty_log dm domid ~f =
-    let module Q = (val Backend.of_profile dm) in
-    Q.Dm.with_dirty_log domid ~f
 
   let qemu_args ~xs ~dm info restore domid =
     let module Q = (val Backend.of_profile dm) in

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -290,7 +290,6 @@ sig
   val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
   val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> unit
 
-  val with_dirty_log: Profile.t -> int -> f:(unit -> 'a) -> 'a
   val after_suspend_image: xs:Xenstore.Xs.xsh -> dm:Profile.t -> qemu_domid:int -> int -> unit
 end
 

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1190,7 +1190,7 @@ type suspend_flag = Live | Debug
       manager_path domid fd vgpu_fd
 *)
 
-  let suspend_emu_manager' ~(task: Xenops_task.task_handle) ~xc ~xs ~domain_type ~dm ~manager_path ~domid
+  let suspend_emu_manager ~(task: Xenops_task.task_handle) ~xc ~xs ~domain_type ~dm ~manager_path ~domid
       ~uuid ~main_fd ~vgpu_fd ~flags ~progress_callback ~qemu_domid ~do_suspend_callback =
     let open Suspend_image in let open Suspend_image.M in
     let open Emu_manager in
@@ -1305,13 +1305,6 @@ type suspend_flag = Live | Debug
             `Error (Emu_manager_protocol_failure)
         in
         wait_for_message ()
-      )
-
-  let suspend_emu_manager ~(task: Xenops_task.task_handle) ~xc ~xs ~domain_type ~dm ~manager_path ~domid
-      ~uuid ~main_fd ~vgpu_fd ~flags ~progress_callback ~qemu_domid ~do_suspend_callback =
-    Device.Dm.with_dirty_log dm domid ~f:(fun () ->
-        suspend_emu_manager' ~task ~xc ~xs ~domain_type ~dm ~manager_path ~domid
-          ~uuid ~main_fd ~vgpu_fd ~flags ~progress_callback ~qemu_domid ~do_suspend_callback
       )
 
   let write_qemu_record domid uuid fd =


### PR DESCRIPTION
Once the emu-manager work is merged, the call to
xen-set-global-log-dirty in the toolstack is not needed anymore. This
commit removes it.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>