### PR TITLE
CA-289887: qemu-wrapper: Detect raw disks

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -129,7 +129,7 @@ def get_drive_args_for_backend(dom, backend):
     return args
 
 def get_drive_args(dom):
-    backends = ['vbd3', 'qdisk']
+    backends = ['vbd', 'vbd3', 'qdisk']
     args = []
     for backend in backends:
         args.extend(get_drive_args_for_backend(dom, backend))


### PR DESCRIPTION
VMs with raw disks (i.e. using a RawHBA SR) have a backend of "vbd" in
xenstore rather than "vbd3". Search for this in xenstore as well
otherwise QEMU won't open them.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>