### PR TITLE
CA-292656: Use qemu-upstream-compat if profile is unknown

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -57,8 +57,8 @@ module Profile = struct
        sprintf "unsupported device-model profile %s: use %s" x Name.qemu_upstream_compat
        |> fun s -> Internal_error s
        |> raise
-    | x -> debug "unknown device-model profile %s: defaulting to fallback: %s" x (string_of fallback);
-      fallback
+    | x -> debug "unknown device-model profile %s: defaulting to %s" x Name.qemu_upstream_compat;
+      Qemu_upstream_compat
 
   (* XXX remove again *)
   let of_domid x = if is_upstream_qemu x then Qemu_upstream else Qemu_trad


### PR DESCRIPTION
If the profile is unknown, use qemu-upstream-compat. In general,
qemu-trad should not be used but the fallback must remain as qemu-trad
at this point to avoid breaking PV guests. This was detected because
there was a typo in the Other Install Media template.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>