### PR TITLE
CA-292873: Allow "xl destroy" to work with QEMU upstream VMs

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -345,6 +345,7 @@ def main(argv):
                             preexec_fn=prepare_exec)
 
     xenstore_write("/local/domain/%d/qemu-pid" % domid, "%d" % qemu.pid)
+    xenstore_write("/local/domain/%d/image/device-model-pid" % domid, "%d" % qemu.pid)
 
     # Redirect output from QEMU to logger
     os.dup2(qemu.stdout.fileno(), 0)


### PR DESCRIPTION
Xen documents /local/domain/%d/image/device-model-pid as the xenstore
path for QEMU's pid and libxl relies on this path to correctly destroy a
domain. Set this path in qemu-wrapper which makes "xl destroy" work with
QEMU upstream VMs.  qemu-trad watches for @releaseDomain itself which is
why "xl destroy" works with qemu-trad VMs.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>