### PR TITLE
CP-24770: create QEMU disk command line in xenopsd instead of qemu-wrapper

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -87,54 +87,6 @@ def xenstore_write(path, value):
 def xenstore_ls(path):
     return xenstore.ls("", path)
 
-def get_drive_args_for_backend(dom, backend):
-    args = []
-    index_map = dict(('xvd' + chr(ord('a') + i), i) for i in range(4))
-    vbd3 = "/local/domain/0/backend/" + backend + "/" + dom
-
-    medialist = xenstore_ls(vbd3)
-    if not medialist:
-        return args
-
-    for num in medialist:
-        dev = xenstore_read("%s/%s/dev" % (vbd3, num))
-        if dev not in index_map:
-            continue
-
-        path = ''
-        path_str = ''
-        keys = xenstore_ls("%s/%s" % (vbd3, num))
-        if "params" in keys:
-            path = xenstore_read("%s/%s/params" % (vbd3, num))
-            nbd_prefix = "nbd:unix:"
-            if path.startswith(nbd_prefix):
-                path = path + ":exportname=qemu_node"
-            path_str = 'file=%s,' % path
-
-        # XXX This is a heuristic to determine if the disk is a CD. We should be told
-        # by the toolstack.
-        mode = xenstore_read("%s/%s/mode" % (vbd3, num))
-        media = 'cdrom' if dev == 'xvdd' and mode == 'r' else 'disk'
-        forcelba = 'on' if media == 'disk' else 'off'
-
-        format_str = ',format=raw' if path != '' else ''
-
-        if mode == 'r' and media != 'cdrom':
-            continue
-
-        # XXX What should cache=... be set to?
-        args.extend(["-drive", "%sif=ide,index=%d,media=%s%s,force-lba=%s" %
-                     (path_str, index_map[dev], media, format_str, forcelba)])
-
-    return args
-
-def get_drive_args(dom):
-    backends = ['vbd', 'vbd3', 'qdisk']
-    args = []
-    for backend in backends:
-        args.extend(get_drive_args_for_backend(dom, backend))
-    return args
-
 def close_fds():
     for i in open_fds:
         os.close(i)
@@ -174,7 +126,6 @@ def main(argv):
             break
 
     qemu_dm = '/usr/lib64/xen/bin/qemu-system-i386'
-    drive_args = get_drive_args('%d' % domid)
     qemu_args = ['qemu-dm-%d' % domid]
 
     mmio_start = HVM_BELOW_4G_MMIO_START
@@ -201,7 +152,6 @@ def main(argv):
                       % (mmio_start, trad_compat, igdpt)])
 
     qemu_args.extend(argv[2:])
-    qemu_args.extend(drive_args)
 
     # support toolstack override of NIC device model for debug purposes
     nic = xenstore_read("/local/domain/%d/platform/nic_type" % domid)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2497,8 +2497,13 @@ module Backend = struct
             | Dm_Common.Disk  -> "force-lba=on"
             | Dm_Common.Cdrom -> "force-lba=off"
           in
-          List.map (fun (index, file, media) -> [
-              "-drive"; String.concat "," ([
+          List.map (fun (index, file, media) ->
+            let file = file ^ match String.startswith "nbd:unix:" file with
+              | true  -> ":exportname=qemu_node"
+              | false -> ""
+            in
+            [ "-drive"; String.concat ","
+             ([
                 sprintf "file=%s" file;
                 "if=ide";
                 sprintf "index=%d" index;

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1757,9 +1757,6 @@ module Dm_Common = struct
     disp_options, wait_for_port
 
   let qemu_args ~xs ~dm info restore ?(domid_for_vnc=false) domid =
-    let disks' = List.map (fun (index, file, media) -> [
-          "-drive"; sprintf "file=%s,if=ide,index=%d,media=%s" file index (string_of_media media)
-        ]) info.disks in
 
     let restorefile = sprintf qemu_restore_path domid in
     let disp_options, wait_for_port = if domid_for_vnc
@@ -1769,7 +1766,6 @@ module Dm_Common = struct
     let argv =
       List.concat
         [ disp_options
-        ; List.concat disks'
         ; ( info.acpi |> function false -> [] | true -> [ "-acpi" ])
         ; ( restore   |> function false -> [] | true -> [ "-loadvm"; restorefile ])
         ; ( info.pci_emulations
@@ -2489,6 +2485,31 @@ module Backend = struct
             ; xen_platform_device
             ] in
 
+        let disks' =
+          let format_of_media (media:Dm_Common.media) file =
+            match media, file with
+            | Dm_Common.Disk, _   -> ["format=raw"]
+            | Dm_Common.Cdrom, "" -> []
+            | Dm_Common.Cdrom, _  -> ["format=raw"]
+          in
+          let lba_of_media (media:Dm_Common.media) =
+            match media with
+            | Dm_Common.Disk  -> "force-lba=on"
+            | Dm_Common.Cdrom -> "force-lba=off"
+          in
+          List.map (fun (index, file, media) -> [
+              "-drive"; String.concat "," ([
+                sprintf "file=%s" file;
+                "if=ide";
+                sprintf "index=%d" index;
+                sprintf "media=%s" (Dm_Common.string_of_media media);
+                lba_of_media media;
+              ] @ (format_of_media media file))
+            ])
+            info.Dm_Common.disks
+          |> List.concat
+        in
+
         (* Sort the VIF devices by devid *)
         let nics = List.stable_sort
           (fun (_,_,a) (_,_,b) -> compare a b) info.Dm_Common.nics in
@@ -2554,12 +2575,12 @@ module Backend = struct
         |> function
         |  _, []    ->
           Dm_Common.
-            { argv   = common.argv   @ misc @ pv_device pv_device_addr @ none
+            { argv   = common.argv   @ misc @ disks' @ pv_device pv_device_addr @ none
             ; fd_map = common.fd_map
             }
         | fds, argv ->
           Dm_Common.
-            { argv   = common.argv   @ misc @ pv_device pv_device_addr @ argv
+            { argv   = common.argv   @ misc @ disks' @ pv_device pv_device_addr @ argv
             ; fd_map = common.fd_map @ fds
             }
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1343,10 +1343,10 @@ module VM = struct
             then
               let index, bd = List.assoc id qemu_vbds in
               let path = block_device_of_vbd_frontend bd in
-              let media =
-                if vbd.Vbd.ty = Vbd.Disk
-                then Device.Dm.Disk else Device.Dm.Cdrom in
-              Some (index, path, media)
+              match vbd.Vbd.ty, vbd.mode with
+              | Vbd.Disk, ReadOnly -> None
+              | Vbd.Disk, _        -> Some (index, path, Device.Dm.Disk)
+              | _                  -> Some (index, path, Device.Dm.Cdrom)
             else None
           ) vbds in
         let usb_enabled =

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1339,7 +1339,7 @@ module VM = struct
       | HVM hvm_info ->
         let disks = List.filter_map (fun vbd ->
             let id = vbd.Vbd.id in
-            if hvm_info.Vm.qemu_disk_cmdline && (List.mem_assoc id qemu_vbds)
+            if (List.mem_assoc id qemu_vbds)
             then
               let index, bd = List.assoc id qemu_vbds in
               let path = block_device_of_vbd_frontend bd in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -72,6 +72,7 @@ let choose_emu_manager x = choose_alternative _emu_manager !Xc_resources.emu_man
 
 
 type qemu_frontend =
+  | Empty
   | Name of string (* block device path or bridge name *)
   | Device of Device_common.device
   [@@deriving rpc]
@@ -268,6 +269,7 @@ let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
     Device device
 
 let block_device_of_vbd_frontend = function
+  | Empty  -> ""
   | Name x -> x
   | Device device ->
     let open Device_common in
@@ -275,6 +277,7 @@ let block_device_of_vbd_frontend = function
 
 let destroy_vbd_frontend ~xc ~xs task disk =
   match disk with
+  | Empty
   | Name _ -> ()
   | Device device ->
     Xenops_task.with_subtask task "Vbd.clean_shutdown"
@@ -2401,12 +2404,10 @@ module VBD = struct
              let qemu_domid = Opt.default (this_domid ~xs) (get_stubdom ~xs frontend_domid) in
              let qemu_frontend = match Device_number.spec device_number with
                | Device_number.Ide, n, _ when n < 4 ->
+                 let index = Device_number.to_disk_number device_number in
                  begin match vbd.Vbd.backend with
-                   | None -> None
-                   | Some _ ->
-                     let bd = create_vbd_frontend ~xc ~xs task qemu_domid vdi in
-                     let index = Device_number.to_disk_number device_number in
-                     Some (index, bd)
+                   | None   -> Some (index, Empty)
+                   | Some _ -> Some (index, create_vbd_frontend ~xc ~xs task qemu_domid vdi)
                  end
                | _, _, _ -> None in
              (* Remember what we've just done *)


### PR DESCRIPTION
    This patch rebases commit ffddbbfb414d7a83ecde14f07fa0809941af5c9c                                                                                           
    > CP-24770: Xenopsd calls now the qemu-wrapper script passing in the right                                                                                           
    > parameters for disks and CD drives.                                                                                           
    > Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>  

    In particular, it simplifies the change to the VmExtra.qemu_vbds field after                                                                                           
    the VmExtra.non_persistent_t field was removed and qemu_vbds is available                                                                                           
    now only as part of the VmExtra.persistent_t field, which needs to be                                                                                           
    backwards-compatible with previous versions of xenopsd due to RPU and                                                                                           
    cross-pool migration: instead of making qemu_frontend optional, which would                                                                                           
    cause incompatibility with previous versions of the VmExtra.persistent_t                                                                                           
    field, it adds an extra option 'Empty' to the qemu_frontend type. The                                                                                           
    unmarshalling of this new option should be backwards-compatible for VMs                                                                                           
    started in previous versions of xenopsd.                                                                                           
                                                                                                                                                                                                                          
  
Tested with win7 guests and qemu-trad and qemu-upstream-compat profiles.
* verified that the -drive parameters are being passed as expected for disks and cdrom to qemu-wrapper in qemu-upstream after the patch (whereas before they were generated inside qemu-wrapper).
* verified that the -drive parameters are not being passed for qemu-trad
* verified that we can start vms whose cdrom is using index 2 instead of 3
* verified that a newly created RW disk is passed to the qemu-upstream disk parameters, but when this disk is made RO the corresponding disk parameters are not passed as expected.
