### PR TITLE
CA-287333: Xenopsd should report storage backtraces in JSON, not as an S-expression

### DIFF
--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -26,7 +26,7 @@ let transform_exception f x =
   try f x
   with
   | Backend_error_with_backtrace(code, backtrace :: params) as e ->
-    let backtrace = Backtrace.t_of_sexp (Sexplib.Sexp.of_string backtrace) in
+    let backtrace = Backtrace.Interop.of_json "SM" backtrace in
     let exn = Storage_backend_error(code, params) in
     Backtrace.add exn backtrace;
     Backtrace.reraise e exn


### PR DESCRIPTION
Currently, attaching a VBD to a VDI on a GFS2 SR causing a storage backend error and accompanying backtrace.

Unfortunately, while Xapi-storage-script reports this backtraces in JSON format, Xenopsd expects an S-expression. This causes an S-expression parsing failure, obfuscating the actual error and making debugging very difficult.

This commit patches Xenopsd's backtrace handling to expect a backtrace in JSON, and should enable easier debugging of the VDI attach error.

Signed-off-by: Akanksha Mathur <akanksha.mathur@citrix.com>