### PR TITLE
CP-24770: create QEMU disk command line in xenopsd instead of qemu-wrapper

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -87,51 +87,6 @@ def xenstore_write(path, value):
 def xenstore_ls(path):
     return xenstore.ls("", path)
 
-def get_drive_args_for_backend(dom, backend):
-    args = []
-    index_map = dict(('xvd' + chr(ord('a') + i), i) for i in range(4))
-    vbd3 = "/local/domain/0/backend/" + backend + "/" + dom
-
-    medialist = xenstore_ls(vbd3)
-    if not medialist:
-        return args
-
-    for num in medialist:
-        dev = xenstore_read("%s/%s/dev" % (vbd3, num))
-        if dev not in index_map:
-            continue
-
-        path = ''
-        path_str = ''
-        keys = xenstore_ls("%s/%s" % (vbd3, num))
-        if "params" in keys:
-            path = xenstore_read("%s/%s/params" % (vbd3, num))
-            path_str = 'file=%s,' % path
-
-        # XXX This is a heuristic to determine if the disk is a CD. We should be told
-        # by the toolstack.
-        mode = xenstore_read("%s/%s/mode" % (vbd3, num))
-        media = 'cdrom' if dev == 'xvdd' and mode == 'r' else 'disk'
-        forcelba = 'on' if media == 'disk' else 'off'
-
-        format_str = ',format=raw' if path != '' else ''
-
-        if mode == 'r' and media != 'cdrom':
-            continue
-
-        # XXX What should cache=... be set to?
-        args.extend(["-drive", "%sif=ide,index=%d,media=%s%s,force-lba=%s" %
-                     (path_str, index_map[dev], media, format_str, forcelba)])
-
-    return args
-
-def get_drive_args(dom):
-    backends = ['vbd', 'vbd3', 'qdisk']
-    args = []
-    for backend in backends:
-        args.extend(get_drive_args_for_backend(dom, backend))
-    return args
-
 def close_fds():
     for i in open_fds:
         os.close(i)
@@ -171,7 +126,6 @@ def main(argv):
             break
 
     qemu_dm = '/usr/lib64/xen/bin/qemu-system-i386'
-    drive_args = get_drive_args('%d' % domid)
     qemu_args = ['qemu-dm-%d' % domid]
 
     mmio_start = HVM_BELOW_4G_MMIO_START
@@ -198,7 +152,6 @@ def main(argv):
                       % (mmio_start, trad_compat, igdpt)])
 
     qemu_args.extend(argv[2:])
-    qemu_args.extend(drive_args)
 
     # support toolstack override of NIC device model for debug purposes
     nic = xenstore_read("/local/domain/%d/platform/nic_type" % domid)

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1389,10 +1389,10 @@ module VM = struct
             then
               let index, bd = List.assoc id qemu_vbds in
               let path = qemu_device_of_vbd_frontend bd in
-              let media =
-                if vbd.Vbd.ty = Vbd.Disk
-                then Device.Dm.Disk else Device.Dm.Cdrom in
-              Some (index, path, media)
+              match vbd.Vbd.ty, vbd.mode with
+              | Vbd.Disk, ReadOnly -> None
+              | Vbd.Disk, _        -> Some (index, path, Device.Dm.Disk)
+              | _                  -> Some (index, path, Device.Dm.Cdrom)
             else None
           ) vbds in
         let usb_enabled =

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1385,7 +1385,7 @@ module VM = struct
       | HVM hvm_info ->
         let disks = List.filter_map (fun vbd ->
             let id = vbd.Vbd.id in
-            if hvm_info.Vm.qemu_disk_cmdline && (List.mem_assoc id qemu_vbds)
+            if (List.mem_assoc id qemu_vbds)
             then
               let index, bd = List.assoc id qemu_vbds in
               let path = qemu_device_of_vbd_frontend bd in


### PR DESCRIPTION
    This patch rebases commit ffddbbfb414d7a83ecde14f07fa0809941af5c9c                                                                                           
    > CP-24770: Xenopsd calls now the qemu-wrapper script passing in the right                                                                                           
    > parameters for disks and CD drives.                                                                                           
    > Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>  

    In particular, it simplifies the change to the VmExtra.qemu_vbds field after                                                                                           
    the VmExtra.non_persistent_t field was removed and qemu_vbds is available                                                                                           
    now only as part of the VmExtra.persistent_t field, which needs to be                                                                                           
    backwards-compatible with previous versions of xenopsd due to RPU and                                                                                           
    cross-pool migration: instead of making qemu_frontend optional, which would                                                                                           
    cause incompatibility with previous versions of the VmExtra.persistent_t                                                                                           
    field, it adds an extra option 'Empty' to the qemu_frontend type. The                                                                                           
    unmarshalling of this new option should be backwards-compatible for VMs                                                                                           
    started in previous versions of xenopsd.                                                                                           
                                                                                                                                                                                                                          
  
Tested with win7 guests and qemu-trad and qemu-upstream-compat profiles.
* verified that the -drive parameters are being passed as expected for disks and cdrom to qemu-wrapper in qemu-upstream after the patch (whereas before they were generated inside qemu-wrapper).
* verified that the -drive parameters are not being passed for qemu-trad
* verified that we can start vms whose cdrom is using index 2 instead of 3
* verified that a newly created RW disk is passed to the qemu-upstream disk parameters, but when this disk is made RO the corresponding disk parameters are not passed as expected.
