### PR TITLE
CA-292693: use the corresponding QMP device of a cdrom userdevice

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2098,12 +2098,12 @@ module Backend = struct
 
       let qemu_media_change ~xs device _type params =
         Vbd_Common.qemu_media_change ~xs device _type params;
-        let cd    = cd_of device.backend.devid in
-        let domid = device.frontend.domid in
-        if params = "" then
-          qmp_send_cmd domid Qmp.(Eject(cd, Some true)) |> ignore
-        else
-          try
+        try
+          let cd    = cd_of device.backend.devid in
+          let domid = device.frontend.domid in
+          if params = "" then
+            qmp_send_cmd domid Qmp.(Eject(cd, Some true)) |> ignore
+          else
             let as_msg cmd = Qmp.(Success(Some __LOC__, cmd)) in
             let fd_cd      = Unix.openfile params [ Unix.O_RDONLY ] 0o640 in
             finally
@@ -2131,11 +2131,11 @@ module Backend = struct
                       qmp_send_cmd domid cmd |> ignore))
               (fun () ->
                  Unix.close fd_cd)
-          with
-          | Unix.Unix_error(Unix.ECONNREFUSED, "connect", p) -> raise(Internal_error (Printf.sprintf "Failed to connnect QMP socket: %s" p))
-          | Unix.Unix_error(Unix.ENOENT, "open", p) -> raise(Internal_error (Printf.sprintf "Failed to open CD Image: %s" p))
-          | Internal_error(_) as e -> raise e
-          | e -> raise(Internal_error (Printf.sprintf "Get unexpected error trying to change CD: %s" (Printexc.to_string e)))
+        with
+        | Unix.Unix_error(Unix.ECONNREFUSED, "connect", p) -> raise(Internal_error (Printf.sprintf "Failed to connnect QMP socket: %s" p))
+        | Unix.Unix_error(Unix.ENOENT, "open", p) -> raise(Internal_error (Printf.sprintf "Failed to open CD Image: %s" p))
+        | Internal_error(_) as e -> raise e
+        | e -> raise(Internal_error (Printf.sprintf "Get unexpected error trying to change CD: %s" (Printexc.to_string e)))
     end (* Backend.Qemu_upstream_compat.Vbd *)
 
     (** Implementation of the Vcpu functions that use the dispatcher for the qemu-upstream-compat backend *)


### PR DESCRIPTION
Currently, only the cdrom with the userdevice index 3 can be used,
because the QMP cdrom used is just the static QEMU device "ide1-cd1".

This patch finds the QEMU device dynamically from the cdrom backend device,
so that a cdrom with any userdevice index can be used.

Tested by starting a VM with a cdrom with different userdevice indexes:

  device ( RO): xvda
  userdevice ( RW): 0
  xenopsd-xc: [debug||14 |Async.VBD.insert R:320a814efd63|xenops] QMP command for domid 11: {"execute":"blockdev-change-medium","id":"qmp-000002-11","arguments":{"device":"ide0-cd0","filename":"/dev/fdset/0","format":"raw"}}

  device ( RO): xvdc
  userdevice ( RW): 2
  xenopsd-xc: [debug||43 |Async.VBD.insert R:b91f84a29dea|xenops] QMP command for domid 12: {"execute":"blockdev-change-medium","id":"qmp-000006-12","arguments":{"device":"ide1-cd0","filename":"/dev/fdset/0","format":"raw"}}

  device ( RO): xvdd
  userdevice ( RW): 3
  xenopsd-xc: [debug||16 |Async.VBD.insert R:7c399fd2c050|xenops] QMP command for domid 14: {"execute":"blockdev-change-medium","id":"qmp-000018-14","arguments":{"device":"ide1-cd1","filename":"/dev/fdset/0","format":"raw"}}

In all situations above, `mount /dev/cdrom /mnt && ls /mnt` succeeded in
the guest and produced the contents of the cdrom.

Signed-off-by: Marcus Granado <marcus.granado@citrix.com>