### PR TITLE
Build dbgring tool by default

### DIFF
--- a/dbgring/jbuild
+++ b/dbgring/jbuild
@@ -2,6 +2,8 @@
 
 (executable (
   (name dbgring)
+  (public_name dbgring)
+  (package xapi-xenopsd-xc)
   (libraries (
     xapi-xenopsd
     xenctrl


### PR DESCRIPTION
This adds the dbgring tool to the xapi-xenopsd-xc package such that it
gets built.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>