### PR TITLE
CA-291050: qemu: Don't unshare network namespace when hvm_serial is set

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -112,7 +112,11 @@ def prepare_exec():
 
     restrict_fsize()
 
-    unshare(CLONE_NEWNET | CLONE_NEWNS | CLONE_NEWIPC)
+    flags = CLONE_NEWNS | CLONE_NEWIPC
+    # hvm_serial may require network access so don't unshare the network.
+    if not hvm_serial:
+        flags |= CLONE_NEWNET
+    unshare(flags)
 
     sys.stdout.flush()
     sys.stderr.flush()
@@ -157,6 +161,9 @@ def main(argv):
     nic = xenstore_read("/local/domain/%d/platform/nic_type" % domid)
     if nic:
         qemu_args = map(lambda x: x.replace("rtl8139", nic), qemu_args)
+
+    global hvm_serial
+    hvm_serial = xenstore_read("/local/domain/%d/platform/hvm_serial" % domid)
 
     n = 0
 


### PR DESCRIPTION
hvm_serial is often used for Windows kernel debugging and it typically
requires that QEMU uses the network (either actively making a connection
or passively waiting for a connection). If hvm_serial is set, don't
unshare the network namespace otherwise the common debugging use case is
broken.

This is not a security risk since preventing QEMU from using the network
is a defense-in-depth and hvm_serial should only be used for debugging.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>