### PR TITLE
CA-294081: Backport CA-292860: Ensure MTU is set for TAP devices

### DIFF
--- a/scripts/vif-real
+++ b/scripts/vif-real
@@ -249,6 +249,7 @@ online)
 
 add)
     if [ "${TYPE}" = "tap" ] ; then
+        handle_mtu
         add_to_bridge
     fi
     ;;


### PR DESCRIPTION
If the VM does not have PV drivers installed, then the tap device
will not be removed.  This means the bridge drops it's MTU down to
the tap device's default MTU of 1500.

Signed-off-by: Bob Ball <bob.ball@citrix.com>