### PR TITLE
UEFI: varstored integration for VM start/stop

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -29,6 +29,7 @@ let run_hotplug_scripts = ref true
 let hotplug_timeout = ref 300.
 let qemu_dm_ready_timeout = ref 300.
 let vgpu_ready_timeout = ref 30.
+let varstored_ready_timeout = ref 30.
 let use_upstream_qemu = ref false
 
 let watch_queue_length = ref 1000
@@ -54,6 +55,7 @@ let options = [
   "hotplug_timeout", Arg.Set_float hotplug_timeout, (fun () -> string_of_float !hotplug_timeout), "Time before we assume hotplug scripts have failed";
   "qemu_dm_ready_timeout", Arg.Set_float qemu_dm_ready_timeout, (fun () -> string_of_float !qemu_dm_ready_timeout), "Time before we assume qemu has become stuck";
   "vgpu-ready-timeout", Arg.Set_float vgpu_ready_timeout, (fun () -> string_of_float !vgpu_ready_timeout), "Time before we assume vgpu has become stuck or unresponsive";
+  "varstored-ready-timeout", Arg.Set_float varstored_ready_timeout, (fun () -> string_of_float !varstored_ready_timeout), "Time before we assume varstored has become stuck or unresponsive";
   "watch_queue_length", Arg.Set_int watch_queue_length, (fun () -> string_of_int !watch_queue_length), "Maximum number of unprocessed xenstore watch events before we restart";
   "use-upstream-qemu", Arg.Bool (fun x -> use_upstream_qemu := x), (fun () -> string_of_bool !use_upstream_qemu), "True if we want to use upsteam QEMU";
   "default-vbd-backend-kind", Arg.Set_string default_vbd_backend_kind, (fun () -> !default_vbd_backend_kind), "Default backend for VBDs";

--- a/xc/cancel_utils.ml
+++ b/xc/cancel_utils.ml
@@ -26,6 +26,7 @@ type key =
   | Domain of int
   | Qemu of int * int
   | Vgpu of int
+  | Varstored of int
   | TestPath of string
 
 let string_of = function
@@ -33,6 +34,7 @@ let string_of = function
   | Domain domid -> Printf.sprintf "domid %d" domid
   | Qemu (backend, frontend) -> Printf.sprintf "qemu backend = %d; frontend = %d" backend frontend
   | Vgpu domid -> Printf.sprintf "domid %d" domid
+  | Varstored domid -> Printf.sprintf "varstored %d" domid
   | TestPath x -> x
 
 let root = "/xenops/tasks"
@@ -51,6 +53,8 @@ let cancel_path_of ~xs = function
     Printf.sprintf "%s/device-model/cancel" (path_of frontend)
   | Vgpu domid ->
     Printf.sprintf "%s/vgpu/cancel" (path_of domid)
+  | Varstored domid ->
+    Printf.sprintf "%s/varstored/cancel" (path_of domid)
   | TestPath x -> x
 
 let shutdown_path_of ~xs = function
@@ -61,6 +65,7 @@ let shutdown_path_of ~xs = function
        		   break suspend if we cancel when the frontend shuts down. *)
     Printf.sprintf "%s/shutdown" (path_of backend)
   | Vgpu domid -> Printf.sprintf "%s/vgpu/shutdown" (path_of domid)
+  | Varstored domid -> Printf.sprintf "%s/varstored/shutdown" (path_of domid)
   | TestPath x -> x
 
 let cleanup_for_domain ~xs domid =

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1925,14 +1925,15 @@ module Dm_Common = struct
           best_effort "removing device model path from xenstore"
             (fun () -> xs.Xs.rm (device_model_path ~qemu_domid domid)))
     in
-    let stop_vgpu () = match (Vgpu.pid ~xs domid) with
+    let stop_other pidf name = match pidf ~xs domid with
       | None -> ()
-      | Some vgpu_pid ->
-        debug "vgpu: stopping vgpu with SIGTERM (domid = %d pid = %d)" domid vgpu_pid;
+      | Some pid ->
+        debug "%s: stopping %s with SIGTERM (domid = %d pid = %d)" name name domid pid;
         let open Generic in
-        best_effort "killing vgpu"
-          (fun () -> really_kill vgpu_pid)
+        best_effort (sprintf "killing %s" name)
+          (fun () -> really_kill pid)
     in
+    let stop_vgpu () = stop_other Vgpu.pid "vgpu" in
     stop_vgpu ();
     stop_qemu ()
 

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1637,6 +1637,7 @@ module Dm_Common = struct
     memory: int64;
     boot: string;
     firmware: Xenops_types.Vm.firmware_type option;
+    nvram: (string * string) list;
     serial: string option;
     monitor: string option;
     vcpus: int; (* vcpus max *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1636,6 +1636,7 @@ module Dm_Common = struct
   type info = {
     memory: int64;
     boot: string;
+    firmware: Xenops_types.Vm.firmware_type option;
     serial: string option;
     monitor: string option;
     vcpus: int; (* vcpus max *)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1015,6 +1015,9 @@ end
 
 module Qemu = DaemonMgmt(struct let pid_path domid = sprintf "/local/domain/%d/qemu-pid" domid end)
 module Vgpu = DaemonMgmt(struct let pid_path domid = sprintf "/local/domain/%d/vgpu-pid" domid end)
+module Varstored = DaemonMgmt(struct
+    let pid_path domid = sprintf "/local/domain/%d/varstored-pid" domid
+  end)
 
 module PCI = struct
 
@@ -1934,7 +1937,17 @@ module Dm_Common = struct
           (fun () -> really_kill pid)
     in
     let stop_vgpu () = stop_other Vgpu.pid "vgpu" in
+    let stop_varstored () =
+      stop_other Varstored.pid "varstored";
+      List.iter (fun path ->
+          debug "deleting %s" path;
+          Unixext.unlink_safe path)
+        [ efivars_init_path domid
+        ; efivars_save_path domid
+        ]
+    in
     stop_vgpu ();
+    stop_varstored ();
     stop_qemu ()
 
 end (* End of module Dm_Common *)
@@ -2685,6 +2698,63 @@ module Dm = struct
 
   (* the following functions depend on the functions above that use the qemu backend Q *)
 
+  let start_varstored ~xs ?(nvram=[]) ?(restore=false) task domid =
+    debug "Preparing to start varstored for UEFI boot";
+    let path = !Xc_resources.varstored in
+    let name = "varstored" in
+    let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuidm.to_string in
+    let reset_on_boot = match List.assoc "EFI-variables-on-boot" nvram with
+      | "persist" -> false
+      | "reset" -> true
+      | bad ->
+        sprintf "unsupported EFI-variables-on-boot %s, use 'persist' or 'reset'" bad
+        |> fun s -> Internal_error s
+        |> raise
+      | exception Not_found -> false
+    in
+    let default_backend = "xapidb" in
+    let backend = match List.assoc "EFI-variables-backend" nvram with
+      | x when x = default_backend -> x
+      | bad ->
+        sprintf "unsupported EFI-variables-backend %s, use 'xapidb'" bad
+        |> fun s -> Internal_error s
+        |> raise
+      | exception Not_found -> default_backend
+    in
+    let efivars_init = match List.assoc "EFI-variables" nvram with
+      | efivars when not restore ->
+        let efivars_init_path = efivars_init_path domid in
+        debug "Writing initial EFI variables to %s (length=%d)" efivars_init_path
+          (String.length efivars);
+        Unixext.write_string_to_file efivars_init_path efivars;
+        Some efivars_init_path
+      | ""  | _ -> None
+      | exception Not_found -> None
+    in
+
+    let open Fe_argv in
+    let (>>=) = bind in
+    let argf fmt = ksprintf (fun s -> [ "--arg"; s]) fmt in
+    let on cond value = if cond then value else return () in
+    let args =
+      Add.many [ "--domain"; string_of_int domid
+               ; "--device"; string_of_int 15
+               ; "--function"; string_of_int 0
+               ; "--backend"; backend ] >>= fun () ->
+      on (not reset_on_boot) @@ Add.many @@ argf "uuid:%s" vm_uuid >>= fun () ->
+      on restore @@ Add.arg "--resume" >>= fun () ->
+      Add.optional (argf "init:%s") efivars_init >>= fun () ->
+      Add.many @@ argf "save:%s" (efivars_save_path domid)
+    in
+    let args = Fe_argv.run args |> snd |> Fe_argv.argv in
+    let pid = start_daemon ~path ~args ~name ~domid ~fds:[] () in
+    (* FIXME UEFI: hack, varstored itself should write this out to signal that it is ready *)
+    let ready_path = Varstored.pid_path domid in
+    xs.Xs.write ready_path (Forkhelpers.getpid pid |> string_of_int);
+    wait_path ~pid ~task ~name ~domid ~xs ~ready_path ~timeout:!Xenopsd.varstored_ready_timeout
+      ~cancel:(Cancel_utils.Varstored domid) ();
+    Forkhelpers.dontwaitpid pid
+
   let start_vgpu ~xs task ?(restore=false) domid vgpus vcpus profile =
     let open Xenops_interface.Vgpu in
     match vgpus with
@@ -2758,6 +2828,10 @@ module Dm = struct
       | _ -> ()
     in
 
+    (* start varstored if appropriate *)
+    if info.firmware = Some Uefi then
+      start_varstored ~xs ~nvram:info.nvram task domid;
+
     (* Execute qemu-dm-wrapper, forwarding stdout to the syslog, with the key "qemu-dm-<domid>" *)
 
     let argv = (prepend_wrapper_args domid args.argv) in
@@ -2820,6 +2894,10 @@ module Dm = struct
   let restore_vgpu (task: Xenops_task.task_handle) ~xs domid vgpu vcpus =
     debug "Called Dm.restore_vgpu";
     start_vgpu ~xs task ~restore:true domid [vgpu] vcpus Profile.Qemu_trad
+
+  let restore_varstored (task: Xenops_task.task_handle) ~xs domid =
+    debug "Called Dm.restore_varstored";
+    start_varstored ~xs ~restore:true task domid
 
 end (* Dm *)
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -246,6 +246,7 @@ sig
   type info = {
     memory: int64;
     boot: string;
+    firmware: Xenops_types.Vm.firmware_type option;
     serial: string option;
     monitor: string option;
     vcpus: int; (* vcpus max *)

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -247,6 +247,7 @@ sig
     memory: int64;
     boot: string;
     firmware: Xenops_types.Vm.firmware_type option;
+    nvram: (string * string) list;
     serial: string option;
     monitor: string option;
     vcpus: int; (* vcpus max *)

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -339,6 +339,8 @@ let demu_restore_path : (_, _, _) format = "/var/lib/xen/demu-resume.%d"
 let var_run_xen_path = "/var/run/xen"
 let qmp_libxl_path = (sprintf "%s/qmp-libxl-%d") var_run_xen_path
 let qmp_event_path = (sprintf "%s/qmp-event-%d") var_run_xen_path
+let efivars_init_path = (sprintf "%s/efi-vars-init-%d.dat") var_run_xen_path
+let efivars_save_path = (sprintf "%s/efi-vars-save-%d.dat") var_run_xen_path
 
 (* Where qemu writes its state and is signalled *)
 let device_model_path ~qemu_domid domid = sprintf "/local/domain/%d/device-model/%d" qemu_domid domid

--- a/xc/device_common.mli
+++ b/xc/device_common.mli
@@ -98,6 +98,8 @@ val demu_restore_path: (int -> 'a, 'b, 'a) format
 val var_run_xen_path: string
 val qmp_libxl_path: int -> string
 val qmp_event_path: int -> string
+val efivars_init_path: int -> string
+val efivars_save_path: int -> string
 
 (** Directory in xenstore where qemu writes its state *)
 val device_model_path: qemu_domid:int -> int -> string

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -78,6 +78,7 @@ type create_info = {
   platformdata: (string * string) list;
   bios_strings: (string * string) list;
   has_vendor_device: bool;
+  is_uefi: bool;
 } [@@deriving rpc]
 
 type build_hvm_info = {
@@ -315,6 +316,8 @@ let make ~xc ~xs vm_info domain_config uuid =
     xs.Xs.writev (dom_path ^ "/platform") vm_info.platformdata;
 
     xs.Xs.writev (dom_path ^ "/bios-strings") vm_info.bios_strings;
+    if vm_info.is_uefi then
+      xs.Xs.write (dom_path ^ "/hvmloader/bios") "ovmf";
 
     (* If a toolstack sees a domain which it should own in this state then the
        		   domain is not completely setup and should be shutdown. *)

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -68,6 +68,7 @@ type create_info = {
   platformdata: (string * string) list;
   bios_strings: (string * string) list;
   has_vendor_device: bool;
+  is_uefi: bool;
 }
 val create_info_of_rpc: Rpc.t -> create_info
 val rpc_of_create_info: create_info -> Rpc.t

--- a/xc/stubdom.ml
+++ b/xc/stubdom.ml
@@ -40,6 +40,7 @@ let create ~xc ~xs domid =
     Domain.xsdata = [];
     Domain.bios_strings = [];
     Domain.has_vendor_device = false;
+    Domain.is_uefi = false;
   } in
   let stubdom_domid = Domain.make ~xc ~xs info Domain.(X86 { emulation_flags = [] }) stubdom_uuid in
   debug "jjd27: created stubdom with domid %d" stubdom_domid;

--- a/xc/xc_resources.ml
+++ b/xc/xc_resources.ml
@@ -28,6 +28,7 @@ let setup_vif_rules = ref "setup-vif-rules"
 let setup_pvs_proxy_rules = ref "setup-pvs-proxy-rules"
 let vgpu = ref "vgpu"
 let gimtool = ref "/opt/xensource/bin/gimtool"
+let varstored = ref "varstored"
 
 let alternatives = ref "/usr/lib/xapi/alternatives"
 
@@ -53,6 +54,7 @@ let nonessentials = [
   X_OK, "pci-flr-script", pci_flr_script, "path to the PCI function-level reset script";
   X_OK, "alternatives", alternatives, "path to the alternative xenguests";
   X_OK, "vgpu", vgpu, "path to the vgpu binary";
+  X_OK, "varstored", varstored, "path to the varstored binary";
   X_OK, "vncterm", vncterm, "path to the vncterm binary";
   X_OK, "gimtool", gimtool, "path to the gimtool binary";
   X_OK, "igmp-query-injector-script", igmp_query_injector_script, "path to the igmp query injector script";

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1333,7 +1333,7 @@ module VM = struct
       ty = Some ty;
       VmExtra.qemu_vbds = qemu_vbds;
     } ->
-      let make ?(boot_order="cd") ?(serial="pty") ?(monitor="null")
+      let make ?(boot_order="cd") ?firmware ?(serial="pty") ?(monitor="null")
           ?(nics=[]) ?(disks=[]) ?(vgpus=[])
           ?(pci_emulations=[]) ?(usb=Device.Dm.Disabled)
           ?(parallel=None)
@@ -1350,6 +1350,7 @@ module VM = struct
         let open Device.Dm in {
           memory = build_info.Domain.memory_max;
           boot = boot_order;
+          firmware = firmware;
           serial = Some serial;
           monitor = Some monitor;
           vcpus = build_info.Domain.vcpus; (* vcpus max *)
@@ -1414,6 +1415,7 @@ module VM = struct
           then Some (List.assoc "parallel" vm.Vm.platformdata)
           else None in
         Some (make ~video_mib:hvm_info.video_mib
+                ?firmware:hvm_info.firmware
                 ~video:hvm_info.video ~acpi:hvm_info.acpi
                 ?serial:hvm_info.serial ?keymap:hvm_info.keymap
                 ?vnc_ip:hvm_info.vnc_ip ~usb ~parallel

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1333,7 +1333,7 @@ module VM = struct
       ty = Some ty;
       VmExtra.qemu_vbds = qemu_vbds;
     } ->
-      let make ?(boot_order="cd") ?firmware ?(serial="pty") ?(monitor="null")
+      let make ?(boot_order="cd") ?firmware ?(nvram=[]) ?(serial="pty") ?(monitor="null")
           ?(nics=[]) ?(disks=[]) ?(vgpus=[])
           ?(pci_emulations=[]) ?(usb=Device.Dm.Disabled)
           ?(parallel=None)
@@ -1351,6 +1351,7 @@ module VM = struct
           memory = build_info.Domain.memory_max;
           boot = boot_order;
           firmware = firmware;
+          nvram = nvram;
           serial = Some serial;
           monitor = Some monitor;
           vcpus = build_info.Domain.vcpus; (* vcpus max *)
@@ -1416,6 +1417,7 @@ module VM = struct
           else None in
         Some (make ~video_mib:hvm_info.video_mib
                 ?firmware:hvm_info.firmware
+                ?nvram:hvm_info.nvram
                 ~video:hvm_info.video ~acpi:hvm_info.acpi
                 ?serial:hvm_info.serial ?keymap:hvm_info.keymap
                 ?vnc_ip:hvm_info.vnc_ip ~usb ~parallel

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1000,6 +1000,10 @@ module VM = struct
 
     let platformdata = vm.platformdata |> default "acpi_s3" "0" |> default "acpi_s4" "0" in
 
+    let is_uefi = match ty with
+      | HVM { firmware = Some Uefi; _ } -> true
+      | _ -> false in
+
     {
       Domain.ssidref = vm.ssidref;
       hvm = hvm;
@@ -1009,6 +1013,7 @@ module VM = struct
       platformdata = platformdata @ vcpus;
       bios_strings = vm.bios_strings;
       has_vendor_device = vm.has_vendor_device;
+      is_uefi;
     }
 
   let create_exn (task: Xenops_task.task_handle) memory_upper_bound vm =


### PR DESCRIPTION
Needs to be merged together with:
https://github.com/xapi-project/xcp-idl/pull/234
https://github.com/xapi-project/xen-api/pull/3675
https://github.com/xapi-project/xenopsd/pull/536
https://github.com/xapi-project/xenops-cli/pull/25

VM shutdown/resume and migration is out of scope of this PR (it is part of another ticket).



