### PR TITLE
CA-295092: cancel resume task if process_header raises an exception

### DIFF
--- a/lib/suspend_image.ml
+++ b/lib/suspend_image.ml
@@ -27,6 +27,7 @@ let wrap_exn f =
   try
     f ()
   with e ->
+    Backtrace.is_important e;
     `Error e
 
 let wrap f = wrap_exn (fun () -> return (f ()))


### PR DESCRIPTION
emu-manager waits until process_header is finished, and the resume
thread in xenopsd is waiting first for emu-manager to finish, and then
for the process_header threads.
If process_headers raises an exception the resume deadlocks.

The cancel callback on the task already has the right logic to send an
abort command to emu-manager, so call that as soon as we know we got an
error.
We need to do this before we attempt to Event.sync, because that would
deadlock as the other thread is xenopsd is not waiting for a reply from
this thread yet (it is waiting for emu-manager to finish first).

Tested this by raising an exception on purpose and xenopsd correctly canceled the resume task, and put the VM back into suspended state (so I could retry the resume):
```
Aug  2 12:25:49 xrtuk-07-02d xenopsd-xc: [error|xrtuk-07-02d|96 |Async.VM.resume_on R:44bcab071845|backtrace] 1/4 xenopsd-xc @ xrtuk-07-02d Raised at file pervasives.ml, line 32
Aug  2 12:25:49 xrtuk-07-02d xenopsd-xc: [error|xrtuk-07-02d|96 |Async.VM.resume_on R:44bcab071845|backtrace] 2/4 xenopsd-xc @ xrtuk-07-02d Called from file xenopsd/xc/domain.ml, line 
1051
Aug  2 12:25:49 xrtuk-07-02d xenopsd-xc: [error|xrtuk-07-02d|96 |Async.VM.resume_on R:44bcab071845|backtrace] 3/4 xenopsd-xc @ xrtuk-07-02d Called from file xenopsd/lib/suspend_image.m
l, line 28
Aug  2 12:25:49 xrtuk-07-02d xenopsd-xc: [error|xrtuk-07-02d|96 |Async.VM.resume_on R:44bcab071845|backtrace] 4/4 xenopsd-xc @ xrtuk-07-02d Called from file lib/backtrace.ml, line 114
Aug  2 12:25:49 xrtuk-07-02d xenopsd-xc: [error|xrtuk-07-02d|96 |Async.VM.resume_on R:44bcab071845|backtrace]
Aug  2 12:25:49 xrtuk-07-02d xenopsd-xc: [ warn|xrtuk-07-02d|96 |Async.VM.resume_on R:44bcab071845|mig64] Canceling task Async.VM.resume_on R:44bcab071845, error during resume: (Failur
e "Something bad")
Aug  2 12:25:49 xrtuk-07-02d xenopsd-xc: [ info|xrtuk-07-02d|96 |Async.VM.resume_on R:44bcab071845|emu-manager] Cancelling task 10; sending 'abort' to emu-manager pid: 16625
```

