### PR TITLE
CP-29054, CA-295847: support actions-after-qemu-crash in upstream qemu

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -298,23 +298,23 @@ def main(argv):
     sys.stdout.flush()
     sys.stderr.flush()
 
-    qemu = subprocess.Popen(qemu_args, executable=qemu_dm, env=qemu_env,
-                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                            preexec_fn=prepare_exec)
-
-    xenstore_write("/local/domain/%d/qemu-pid" % domid, "%d" % qemu.pid)
-    xenstore_write("/local/domain/%d/image/device-model-pid" % domid, "%d" % qemu.pid)
-
-    # Redirect output from QEMU to logger
-    os.dup2(qemu.stdout.fileno(), 0)
-    qemu.stdout.close()
-
     # Close all unneeded fds
     open_fds.extend([1, 2])
-    close_fds()
 
-    os.execvp('logger', ['logger', '-p', 'daemon.info', '-t',
-                         'qemu-dm-%d[%d]' % (domid, qemu.pid)])
+    pid = os.getpid()
+    logger = subprocess.Popen(['logger', '-p', 'daemon.info', '-t'
+                              , 'qemu-dm-%d[%d]' % (domid, pid)], executable='logger',
+                              stdin=subprocess.PIPE,
+                              preexec_fn=close_fds)
+    # Redirect stdin of logger to QEMU's stdout
+    os.dup2(logger.stdin.fileno(), 1)
+    os.dup2(logger.stdin.fileno(), 2)
+    logger.stdin.close()
+    prepare_exec()
+    xenstore_write("/local/domain/%d/qemu-pid" % domid, "%d" % pid)
+    xenstore_write("/local/domain/%d/image/device-model-pid" % domid, "%d" % pid)
+
+    os.execve(qemu_dm, qemu_args, qemu_env)
 
 if __name__ == '__main__':
     raise SystemExit(main(sys.argv))

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2890,10 +2890,10 @@ module Dm = struct
               end
           in
           if not (Qemu.SignalMask.has Qemu.signal_mask domid) then
-            match (Qemu.pid ~xs domid) with
-            | None -> (* after expected qemu stop or domain xs tree destroyed: this event arrived too late, nothing to do *)
+            match xs.Xs.read (Qemu.pid_path domid) with
+            | exception _ -> (* after expected qemu stop or domain xs tree destroyed: this event arrived too late, nothing to do *)
               debug "domid=%d qemu-pid=%d: already removed from xenstore during domain destroy" domid (getpid qemu_pid);
-            | Some _ ->
+            | _ ->
               (* before expected qemu stop: qemu-pid is available in domain xs tree: signal action to take *)
               xs.Xs.write (Qemu.pid_path_signal domid) crash_reason
         ))


### PR DESCRIPTION
By default this is disabled in xenopsd.conf, but can be enabled and very useful for debugging/development.
Not just for qemu crashes, but also when qemu rejects command-line arguments.