### PR TITLE
jbuild: remove ppx_deriving_rpc from libraries

### DIFF
--- a/xc/jbuild
+++ b/xc/jbuild
@@ -55,8 +55,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     profiling
     qmp
     mtime.clock.os
-    ppx_deriving_rpc
-    ppx_sexp_conv
+    ppx_sexp_conv.runtime-lib
     re
     re.pcre
   ))


### PR DESCRIPTION
Also link only against ppx_sexp_conv.runtime-lib

This may be related to https://discuss.ocaml.org/t/reducing-mirageos-image-size-using-ocamlclean/2481