### PR TITLE
lib/jbuild: link only ppx_sexp_conv.runtime-lib

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -64,7 +64,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xcp.storage
     xcp.updates
     sexplib
-    ppx_sexp_conv
+    ppx_sexp_conv.runtime-lib
     uutf
     ezxenstore
     xenstore


### PR DESCRIPTION
The full ppx rewriter should not be linked in the library. Apologies, I missed it earlier