### PR TITLE
CA-296924 add "resuming" as a good DEMU state

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2710,6 +2710,7 @@ module Dm = struct
       let good_watches = [
         Watch.value_to_become state_path "initialising";
         Watch.value_to_become state_path "running";
+        Watch.value_to_become state_path "resuming";
       ] in
       let error_watch = Watch.value_to_become state_path "error" in
       if cancellable_watch cancel good_watches [ error_watch ] task ~xs ~timeout:3600. () then


### PR DESCRIPTION
When starting DEMU, we are expecting it to report a "good" state. This
adds "resuming" as a good state and avoids a race where we have missed
the two earlier states "initialising" and "running".

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>