### PR TITLE
CA-297602: Always create a physical-device node for HVM CD-ROMs

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -21,19 +21,12 @@ add)
         params=$(readlink -f $params || echo $params)
         frontend="/local/domain/${DOMID}/device/${TYPE}/${DEVID}"
         syslog "${XENBUS_PATH}: add params=\"${params}\""
-        # We don't have PV drivers for CDROM devices, so we prevent blkback
-        # from opening the physical-device
-        xenstore-exists "${PRIVATE}/no-physical-device"
-        if [ $? -ne 0 ]; then
-          physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
-          syslog "${XENBUS_PATH}: physical-device=${physical_device}"
-          xenstore-exists "${XENBUS_PATH}/physical-device"
-          if [ $? -eq 1 ]; then
-			syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
-            xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
-          fi
-        else
-          syslog "${XENBUS_PATH}: not writing physical-device because no-physical-device is present"
+        physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
+        syslog "${XENBUS_PATH}: physical-device=${physical_device}"
+        xenstore-exists "${XENBUS_PATH}/physical-device"
+        if [ $? -eq 1 ]; then
+                syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
+                xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
         fi
         xenstore-write "${HOTPLUG}/hotplug" "online"
         xenstore-write "${HOTPLUG_STATUS}" "connected"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -578,11 +578,6 @@ module Vbd_Common = struct
       "mode", string_of_mode x.mode;
       "params", x.params;
     ]);
-    (* We don't have PV drivers for HVM guests for CDROMs. We prevent
-       blkback from successfully opening the device since this can
-       prevent qemu CD eject (and subsequent vdi_deactivate) *)
-    let no_phys_device =
-      if hvm && (x.dev_type = CDROM) then ["no-physical-device", ""] else [] in
 
     Opt.iter
       (fun protocol ->
@@ -591,9 +586,8 @@ module Vbd_Common = struct
 
     let back = Hashtbl.fold (fun k v acc -> (k, v) :: acc) back_tbl [] in
     let front = Hashtbl.fold (fun k v acc -> (k, v) :: acc) front_tbl [] in
-    let priv = no_phys_device @ x.extra_private_keys in
 
-    Generic.add_device ~xs device back front priv [];
+    Generic.add_device ~xs device back front x.extra_private_keys [];
     device
 
   let add_wait (task: Xenops_task.task_handle) ~xc ~xs device =


### PR DESCRIPTION
To increase performance, OVMF can use PV drivers. A previous change to
XAPI (9d0eb8f80507, CA-50383) prevented the VBD backend from being
created for HVM CD-ROMs due to some interaction with blkback.  However,
blktap3 is now used as the backend for CDs and there doesn't seem to be
any issue with it. Therefore, remove the code which prevents creating
the physical-device node to allow OVMF to use PV drivers.