### PR TITLE
Revert "CP-28088: Tell xenguest about GVT-g"

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -684,8 +684,6 @@ let xenguest_args_hvm ~domid ~store_port ~store_domid ~console_port ~console_dom
   ]
   @ (vgpus |> function
     | [Xenops_interface.Vgpu.{implementation = Nvidia _}] -> ["-vgpu"]
-    | [Xenops_interface.Vgpu.{implementation = GVT_g _; physical_pci_address}] ->
-      ["-gvtg"; Xenops_interface.Pci.string_of_address physical_pci_address]
     | _ -> []
   )
   @ xenguest_args_base ~domid ~store_port ~store_domid ~console_port ~console_domid ~memory


### PR DESCRIPTION
We're currently reverting the corresponding xenguest change 2a09b3c1e272
(CA-289607: xenguest: Include GVT-g device in MMIO hole calculation).
Treating GVT-g as passthrough device was technically incorrect initially
and the problem itself was present due to the other reasons.
(See CA-293487).

This reverts commit 49ec3aa8cbf7c86e941d623b8dd4be9fe082327c.