### PR TITLE
CP-28951: Call xapi to send message when receive xen lowmem event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ install:
 	install -D ./scripts/setup-pvs-proxy-rules $(DESTDIR)/$(LIBEXECDIR)/setup-pvs-proxy-rules
 	install -D ./scripts/common.py $(DESTDIR)/$(LIBEXECDIR)/common.py
 	install -D ./scripts/igmp_query_injector.py $(DESTDIR)/$(LIBEXECDIR)/igmp_query_injector.py
+	install -D ./scripts/send_message.py $(DESTDIR)/$(LIBEXECDIR)/send_message.py
 	install -D ./scripts/qemu-wrapper $(DESTDIR)/$(QEMU_WRAPPER_DIR)/qemu-wrapper
 	DESTDIR=$(DESTDIR) SBINDIR=$(SBINDIR) QEMU_WRAPPER_DIR=$(QEMU_WRAPPER_DIR) LIBEXECDIR=$(LIBEXECDIR) ETCDIR=$(ETCDIR) ./scripts/make-custom-xenopsd.conf
 
@@ -66,6 +67,7 @@ uninstall:
 	rm -f $(DESTDIR)/$(LIBEXECDIR)/setup-pvs-proxy-rules
 	rm -f $(DESTDIR)/$(LIBEXECDIR)/common.py*
 	rm -f $(DESTDIR)/$(LIBEXECDIR)/igmp_query_injector.py*
+	rm -f $(DESTDIR)/$(LIBEXECDIR)/send_message.py*
 	rm -f $(DESTDIR)/$(QEMU_WRAPPER_DIR)/qemu-wrapper
 
 .DEFAULT_GOAL := release

--- a/scripts/send_message.py
+++ b/scripts/send_message.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import XenAPI
+import argparse
+
+def build_parser():
+    parser = argparse.ArgumentParser(prog='send_message.py', description='Call xapi to send message')
+    parser.add_argument('--name', dest='name', required=True, metavar='msg_name', type=str,
+                        help='message name')
+    parser.add_argument('--priority', dest='priority', required=True, metavar='message_priority', type=int,
+                        help='message priority')
+    parser.add_argument('--class', dest='cls', required=True, metavar='message_class', type=str,
+                        help='message class')
+    parser.add_argument('--uuid', dest='uuid', required=True, metavar='obj_uuid', type=str,
+                        help='uuid of the object this message is associated with')
+    parser.add_argument('--body', dest='body', required=True, metavar='message_body', type=str,
+                        help='message body')
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
+    session = XenAPI.xapi_local()
+    session.xenapi.login_with_password('root', '', '', 'send_message.py')
+
+    try:
+        session.xenapi.message.create(args.name, args.priority, args.cls, args.uuid, args.body)
+    finally:
+        session.xenapi.logout()
+
+
+if __name__ == '__main__':
+    main()

--- a/xc/jbuild
+++ b/xc/jbuild
@@ -57,6 +57,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     ppx_sexp_conv.runtime-lib
     re
     re.pcre
+    xeneventchn
   ))
 ))
 

--- a/xc/xc_resources.ml
+++ b/xc/xc_resources.ml
@@ -16,6 +16,7 @@ let vif_script = ref "/usr/lib/xcp/scripts/vif"
 let vbd_script = ref "/etc/xen/scripts/block"
 let pci_flr_script = ref "/usr/lib/xcp/lib/pci-flr"
 let igmp_query_injector_script = ref "/usr/libexec/xenopsd/igmp_query_injector.py"
+let send_message_script = ref "/usr/libexec/xenopsd/send_message.py"
 
 let vncterm = ref "vncterm"
 let xenguest = ref "xenguest"
@@ -56,5 +57,6 @@ let nonessentials = [
   X_OK, "vncterm", vncterm, "path to the vncterm binary";
   X_OK, "gimtool", gimtool, "path to the gimtool binary";
   X_OK, "igmp-query-injector-script", igmp_query_injector_script, "path to the igmp query injector script";
+  X_OK, "send-message-script", send_message_script, "path to the script of sending message to xapi";
 ] @ Resources.hvm_guests @ Resources.pv_guests @ Resources.pvinpvh_guests
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -3493,6 +3493,26 @@ let look_for_xenctrl () =
       exit 1;
     end
 
+let watch_xen_event () =
+  let open Xeneventchn in
+  let handle = init () in
+  let virq_enomem_port = bind_virq handle Enomem in
+  let host_uuid = Inventory.lookup Inventory._installation_uuid in
+  let rec process_event () =
+    debug "waiting for xen event at (%s)" __LOC__;
+    let port = pending handle in
+    if port = virq_enomem_port then begin
+      info "Sending HOST_LOW_MEMORY message.";
+      (* Call the script to call xenapi to create message which indicates the host is in low memory situation *)
+      let pid = Forkhelpers.safe_close_and_exec None None None [] !Xc_resources.send_message_script ["--name"; "HOST_LOW_MEMORY"; "--priority"; "2"; "--class"; "host"; "--uuid"; host_uuid; "--body"; "Host does not have enough memory in xen heap"]  in
+      Forkhelpers.dontwaitpid pid
+    end;
+    (* We want to receive further notification, so unmask it *)
+    if to_int port <> -1 then unmask handle port;
+    process_event ()
+  in
+  process_event ()
+
 let init () =
   look_for_forkexec ();
 
@@ -3528,6 +3548,17 @@ let init () =
   Device.Backend.init();
   debug "xenstore is responding to requests";
   let () = Watcher.create_watcher_thread () in
+  let (_: Thread.t) = Thread.create (fun () ->
+      debug "starting xen event watch thread.";
+      while true do
+        try
+          watch_xen_event ()
+        with e ->
+          debug "watch_xen_event thread raised: %s" (Printexc.to_string e);
+          debug "watch_xen_event thread backtrace: %s" (Printexc.get_backtrace ());
+          Thread.delay 5.;
+      done) ()
+  in
   ()
 
 module DEBUG = struct


### PR DESCRIPTION
1. Add a new thread to watch xen event
2. Call xapi to send message when receive ENOMEM event from xen
3. Introduce a script to call xapi to send message. (This script is necessary
because xenopsd cannot call xapi-client directly due to the dependency limitation.)

Signed-off-by: Yang Qian <yang.qian@citrix.com>