### PR TITLE
CA-298525 make QMP interaction more robust

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2238,7 +2238,9 @@ module Backend = struct
             debug "Added QMP Event fd for domain %d" domid
           with e ->
             debug_exn (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket" domid) e;
-            remove domid
+            remove domid;
+            raise @@ Ioemu_failed
+              (sprintf "domid %d" domid, "QMP failure at "^__LOC__)
 
         let qmp_event_handle domid qmp_event =
           (* This function will be extended to handle qmp events *)


### PR DESCRIPTION
Xenopsd monitors the QMP connection to QEMU in a thread and executes QMP
commands in it. In case the QMP connection closes (for any reason) it
simply removes the corresponding domid but does not escalate this. This
commit makes Monitor.add more robust by making it raising an exception
if communication fails. This is only effective when Monitor.add is
called from outside the thread from init_daemon - as it happens in
CA-298525. Any exceptions inside the thread is logged but ignored
otherwise.

Trying to start a VM when the issue occurs leads now to the following
error:

  An emulator required to run this VM failed to start
  vm: e0267811-4386-7fb4-ad1b-6dc8dd685b1e (Windows 8.1)
  name: domid 10
  msg: QMP failure at File "xc/device.ml", line 2247, characters 59-66

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>