### PR TITLE
Fix reservation left when exception occur in with_reservation

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -534,7 +534,12 @@ module Mem = struct
       wants to keep the memory, then call [transfer_reservation_to_domain]. *)
   let with_reservation dbg min max f =
     let amount, id = Opt.default (min, ("none", min)) (reserve_memory_range dbg min max) in
-    f amount id
+    try
+      f amount id
+    with e ->
+      delete_reservation dbg id;
+      raise e
+
 
   (** Transfer this 'reservation' to the given domain id *)
   let transfer_reservation_to_domain_exn dbg domid (reservation_id, amount) =


### PR DESCRIPTION
if exception occured in function with_reservation, the reservation request send to squeezed before
will leaves all the lifetime of the host, and other vm will not allocate because squeezed will record
it as reserved.