### PR TITLE
CP-29100: Remove PCI Device and expose IO port for communication with varstored.

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2753,8 +2753,6 @@ module Dm = struct
     let on cond value = if cond then value else return () in
     let args =
       Add.many [ "--domain"; string_of_int domid
-               ; "--device"; string_of_int 15
-               ; "--function"; string_of_int 0
                ; "--backend"; backend ] >>= fun () ->
       (Varstored.pidfile_path domid |> function None -> return () | Some x ->
          Add.many [ "--pidfile"; x ]) >>= fun () ->


### PR DESCRIPTION
Changes to arguments passed to varstored.