### PR TITLE
CA-301610: fix processing of QMP events for qemu-upstream-uefi

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -52,7 +52,7 @@ module Profile = struct
     | Qemu_trad              -> Name.qemu_trad
     | Qemu_upstream_compat   -> Name.qemu_upstream_compat
     | Qemu_upstream          -> Name.qemu_upstream
-    | Qemu_upstream_uefi     -> Name.qemu_upstream
+    | Qemu_upstream_uefi     -> Name.qemu_upstream_uefi
   let of_string  = function
     | x when x = Name.qemu_trad            -> Qemu_trad
     | x when x = Name.qemu_upstream_compat -> Qemu_upstream_compat


### PR DESCRIPTION
The diff here is rather large, but it just moves QMP_Event out of the functor to make sure that both qemu-upstream-compat and qemu-upstream-uefi are able to receive and process QMP events.
There is a global thread here, that was only spawned on the qemu-upstream-compat device-model, and start/stop only added domid to be watched from qemu-upstream-compat device-models.