### PR TITLE
CP-29936: UEFI: block migration when NVME devices are present

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1649,6 +1649,8 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
       let url = Uri.of_string vmm.vmm_url in
       (* We need to perform version exchange here *)
 
+      let module B = (val get_backend () : S) in
+      B.VM.assert_can_save vm;
       Xenops_hooks.vm_pre_migrate ~reason:Xenops_hooks.reason__migrate_source ~id;
 
       let module Remote = Xenops_interface.XenopsAPI(Idl.GenClientExnRpc(struct let rpc = Xcp_client.xml_http_rpc ~srcstr:"xenops" ~dststr:"dst_xenops" (fun () -> vmm.vmm_url) end)) in

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -85,6 +85,7 @@ module type S = sig
     val request_shutdown: Xenops_task.task_handle -> Vm.t -> shutdown_request -> float -> bool
     val wait_shutdown: Xenops_task.task_handle -> Vm.t -> shutdown_request -> float -> bool
 
+    val assert_can_save: Vm.t -> unit
     val save: Xenops_task.task_handle -> progress_cb -> Vm.t -> flag list -> data -> data option -> (Xenops_task.task_handle -> unit) -> unit
     val restore: Xenops_task.task_handle -> progress_cb -> Vm.t -> Vbd.t list -> Vif.t list -> data -> data option -> string list -> unit
 

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -67,6 +67,7 @@ module VM = struct
   let set_memory_dynamic_range _ _ _ _ = unimplemented "VM.set_memory_dynamic_range"
   let request_shutdown _ _ _ _ = unimplemented "VM.request_shutdown"
   let wait_shutdown _ _ _ _ = unimplemented "VM.wait_shutdown"
+  let assert_can_save _ = unimplemented "VM.assert_can_save"
   let save _ _ _ _ _ _ _ = unimplemented "VM.save"
   let restore _ _ _ _ _ _ _ = unimplemented "VM.restore"
   let s3suspend _ _ = unimplemented "VM.s3suspend"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2389,7 +2389,7 @@ module Backend = struct
       (* This will raise QMP_Error if it can't do it, we catch it and update xenstore. *)
       match qmp_send_cmd domid Qmp.Query_migratable with
       | Qmp.Unit ->
-        debug "query-migratable precheck passed";
+        debug "query-migratable precheck passed (domid=%d)" domid;
         Generic.safe_rm ~xs path;
       | other ->
         raise @@
@@ -2589,14 +2589,14 @@ module Backend = struct
         QMP_Event.update_cant_suspend domid xs;
         match xs.Xs.read (Dm_Common.cant_suspend_reason_path domid) with
         | msg ->
-          debug "assert_can_suspend: rejecting";
+          debug "assert_can_suspend: rejecting (domid=%d)" domid;
           raise @@
           Xenopsd_error (Device_detach_rejected("VM",
                                                 domid |> Xenops_helpers.uuid_of_domid ~xs
                                                 |> Uuidm.to_string,
                                                 msg))
         | exception e ->
-          debug "assert_can_suspend: OK";
+          debug "assert_can_suspend: OK (domid=%d)" domid;
           () (* key not present *)
 
       let suspend (task: Xenops_task.task_handle) ~xs ~qemu_domid domid =

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -286,6 +286,7 @@ sig
   val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
   val start_vnconly : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
   val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val assert_can_suspend : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> unit
   val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
   val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
   val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1747,8 +1747,8 @@ module VM = struct
         match domid_of_uuid ~xc ~xs uuid with
         | None -> failwith (Printf.sprintf "VM %s disappeared" (Uuidm.to_string uuid))
         | Some domid ->
-         Device.Dm.assert_can_suspend ~xs ~dm:(dm_of ~vm) domid
-    )
+          Device.Dm.assert_can_suspend ~xs ~dm:(dm_of ~vm) domid
+      )
 
   let save task progress_callback vm flags data vgpu_data pre_suspend_callback =
     let flags' =
@@ -1990,6 +1990,9 @@ module VM = struct
                  -1.0
              end
            in
+           let not_migratable () =
+             try assert_can_save vm; false
+             with _ -> true in
            {
              Vm.power_state = if di.Xenctrl.paused then Paused else Running;
              domids = [ di.Xenctrl.domid ];
@@ -2015,7 +2018,7 @@ module VM = struct
              nomigrate = begin match vme with
                | None   -> false
                | Some x -> x.VmExtra.persistent.VmExtra.nomigrate
-             end;
+             end || not_migratable ();
              nested_virt = begin match vme with
                | None   -> false
                | Some x -> x.VmExtra.persistent.VmExtra.nested_virt

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1990,9 +1990,6 @@ module VM = struct
                  -1.0
              end
            in
-           let not_migratable () =
-             try assert_can_save vm; false
-             with _ -> true in
            {
              Vm.power_state = if di.Xenctrl.paused then Paused else Running;
              domids = [ di.Xenctrl.domid ];
@@ -2018,7 +2015,7 @@ module VM = struct
              nomigrate = begin match vme with
                | None   -> false
                | Some x -> x.VmExtra.persistent.VmExtra.nomigrate
-             end || not_migratable ();
+             end;
              nested_virt = begin match vme with
                | None   -> false
                | Some x -> x.VmExtra.persistent.VmExtra.nested_virt

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1741,6 +1741,15 @@ module VM = struct
              raise (Xenops_interface.Xenopsd_error Ballooning_timeout_before_migration)
       ) task vm
 
+  let assert_can_save vm =
+    with_xc_and_xs (fun xc xs ->
+        let uuid = uuid_of_vm vm in
+        match domid_of_uuid ~xc ~xs uuid with
+        | None -> failwith (Printf.sprintf "VM %s disappeared" (Uuidm.to_string uuid))
+        | Some domid ->
+         Device.Dm.assert_can_suspend ~xs ~dm:(dm_of ~vm) domid
+    )
+
   let save task progress_callback vm flags data vgpu_data pre_suspend_callback =
     let flags' =
       List.map


### PR DESCRIPTION
NVME devices are not yet migratable by QEMU, and we can't recover from VM.save errors from QEMU currently (we don't support fast resume).
Instead there is a new QMP command that we can use to check whether QEMU considers the domain migratable (based on its devices), if they are not we should forced migration and suspen in xenopsd
(the migration would be rejected or crash if we attempted to do it).

Introduce a new assert_can_save API, and update the nomigrate flag whenever we receive events from the VM (e.g. because it unplugged its NVME device switching to PV drivers and becomes migratable).

I'd like to have a discussion whether updating the nomigrate flag is the right thing to do here, or if we should instead add another method in xcp-idl xenops_interface to query the migratable state.

The nice thing about the approach in this PR is that allowed operations got updated properly, and is_mobile says false.
The downside is that this adds extra overhead to each VM.stat call, and the error message isn't very helpful (`The VM is configured in a way that prevents it from being mobile.`), although if you attempt to force the migration you get a more specific one:
```
The VM rejected the attempt to detach the device.
type: VM
ref: 7c77faf0-ff77-711a-8b0c-d7d43f0d2d7e
msg: {"error":{"class":"GenericError","desc":"State blocked by non-migratable device '0000:00:07.0/nvme'","data":{}},"id":"qmp-000041-77"}
```