### PR TITLE
CP-29827: drop some trad-compat options

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -147,13 +147,14 @@ def main(argv):
     # prepare the correct set of ACPI tables in hvmloader
     xenstore_write("/local/domain/%d/platform/device-model" % domid, "qemu_xen")
 
-    trad_compat = 'true'
+    trad_compat = '-trad-compat' in argv
     igdpt = ''
+    machine = 'pc-0.10' if trad_compat else 'pc-i440fx-2.10'
 
     qemu_args.extend(['-machine',
-                      'pc-0.10,accel=xen,max-ram-below-4g=%lu,'
+                      '%s,accel=xen,max-ram-below-4g=%lu,'
                       'allow-unassigned=true,trad_compat=%s%s'
-                      % (mmio_start, trad_compat, igdpt)])
+                      % (machine, mmio_start, trad_compat, igdpt)])
 
     qemu_args.extend(argv[2:])
 
@@ -164,8 +165,10 @@ def main(argv):
 
     vga_type = 'cirrus-vga'
     vgamem_mb = 4
-    vga_extra_props = ["rombar=1,romfile=",
-                       "subvendor_id=0x5853,subsystem_id=0x0001,addr=2"]
+    vga_extra_props = ["addr=2"]
+    if trad_compat:
+        vga_extra_props += ["rombar=1,romfile=",
+                            "subvendor_id=0x5853,subsystem_id=0x0001"]
     upgraded_save_image = None
     serial_c = ''
     tmp_serial_c = ''
@@ -189,6 +192,10 @@ def main(argv):
             depriv = False
             continue
 
+        if p == "-trad-compat":
+            del qemu_args[n]
+            continue
+
         if p == "-acpi":
             del qemu_args[n]
             continue
@@ -201,7 +208,8 @@ def main(argv):
 
         if p == "-std-vga":
             vga_type = 'VGA'
-            vga_extra_props += ['qemu-extended-regs=false']
+            if trad_compat:
+                vga_extra_props += ['qemu-extended-regs=false']
             del qemu_args[n]
             continue
 
@@ -212,7 +220,8 @@ def main(argv):
 
         if p == "-xengt":
             vga_type = 'VGA'
-            vga_extra_props += ['qemu-extended-regs=false']
+            if trad_compat:
+                vga_extra_props += ['qemu-extended-regs=false']
             n += 1
             continue
 

--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -166,8 +166,9 @@ def main(argv):
     vga_type = 'cirrus-vga'
     vgamem_mb = 4
     vga_extra_props = ["addr=2"]
+    vga_extra_props += ["romfile="]
     if trad_compat:
-        vga_extra_props += ["rombar=1,romfile=",
+        vga_extra_props += ["rombar=1",
                             "subvendor_id=0x5853,subsystem_id=0x0001"]
     upgraded_save_image = None
     serial_c = ''

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2810,8 +2810,12 @@ module Backend = struct
           let ifname          = sprintf "tap%d.%d" domid devid in
           let uuid, _  as tap = tap_open ifname in
           let args =
-            [ "-device"; sprintf "%s,netdev=tapnet%d,mac=%s,addr=%x%s" nic_type devid mac (Config.NIC.addr ~devid ~index)
-                (String.concat "," ("" :: Config.NIC.extra_flags))
+            [ "-device"; String.concat "," (
+                  [ nic_type
+                  ; sprintf "netdev=tapnet%d" devid
+                  ; sprintf "mac=%s" mac
+                  ; sprintf "addr=%x" (Config.NIC.addr ~devid ~index) ]
+                  @ Config.NIC.extra_flags)
             ; "-netdev"; sprintf "tap,id=tapnet%d,fd=%s" devid uuid
             ] in
           (index+1, tap::fds, args@argv) in

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -290,7 +290,7 @@ sig
   val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
   val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
   val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
-  val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> unit
+  val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> Profile.t  -> unit
   val suspend_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid -> string
   val restore_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> efivars:string -> Xenctrl.domid -> unit
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2267,7 +2267,10 @@ module VGPU = struct
            | { VmExtra.build_info = Some build_info } ->
              build_info.Domain.vcpus
          in
-         Device.Dm.restore_vgpu task ~xs frontend_domid vgpu vcpus
+         let profile = match vmextra.VmExtra.persistent.profile with
+           | None -> Device.Profile.Qemu_upstream_compat
+           | Some p -> p in
+         Device.Dm.restore_vgpu task ~xs frontend_domid vgpu vcpus profile
       ) vm
 
   let get_state vm vgpu =


### PR DESCRIPTION
In UEFI boot mode we get a chance to start fresh with a new version of
QEMU device-model, so move all the code that is needed for backwards compatibility
into the qemu-upstream-compat profile.

Testing on Ring3 BST indicates the new device models work fairly well, the most risky change here is changing the machine type.