### PR TITLE
CA-303253: XenMotion breaks VIF connectivity when using DVSC

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -70,7 +70,7 @@ module type S = sig
     val add: Vm.t -> unit
     val remove: Vm.t -> unit
     val rename: Vm.id -> Vm.id -> unit
-    val create: Xenops_task.task_handle -> int64 option -> Vm.t -> unit
+    val create: Xenops_task.task_handle -> int64 option -> Vm.t -> Vm.id option -> unit
     val build: ?restore_fd:Unix.file_descr -> Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list-> string list -> bool ->  unit (* XXX cancel *)
     val create_device_model: Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list -> bool -> unit
     val destroy_device_model: Xenops_task.task_handle -> Vm.t -> unit

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -376,7 +376,7 @@ module VM = struct
 
   let add _vm = ()
   let remove _vm = ()
-  let create _ memory_limit vm = Mutex.execute m (create_nolock memory_limit vm)
+  let create _ memory_limit vm _ = Mutex.execute m (create_nolock memory_limit vm)
   let destroy _ vm = Mutex.execute m (destroy_nolock vm)
   let pause _ vm = Mutex.execute m (do_pause_unpause_nolock vm true)
   let unpause _ vm = Mutex.execute m (do_pause_unpause_nolock vm false)

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -53,7 +53,7 @@ module VM = struct
 
   let rename _ _ = ()
   let remove _ = ()
-  let create _ _ _ = unimplemented "VM.create"
+  let create _ _ _ _ = unimplemented "VM.create"
   let build ?restore_fd:_ _ _ _ _ _ = unimplemented "VM.build"
   let create_device_model _ _ _ _ _ = unimplemented "VM.create_device_model"
   let destroy_device_model _ _ = unimplemented "VM.destroy_device_model"

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -113,7 +113,7 @@ val typ_of_build_info: build_info Rpc.Types.typ
 val build_info: build_info Rpc.Types.def
 
 (** Create a fresh (empty) domain with a specific UUID, returning the domain ID *)
-val make: xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> create_info -> int -> arch_domainconfig -> Uuidm.t -> domid
+val make: xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> create_info -> int -> arch_domainconfig -> Uuidm.t -> string option -> domid
 
 (** 'types' of shutdown request *)
 type shutdown_reason = PowerOff | Reboot | Suspend | Crash | Halt | S3Suspend | Unknown of int

--- a/xc/stubdom.ml
+++ b/xc/stubdom.ml
@@ -41,7 +41,7 @@ let create ~xc ~xs domid =
     Domain.bios_strings = [];
     Domain.has_vendor_device = false;
   } in
-  let stubdom_domid = Domain.make ~xc ~xs info 1 Domain.(X86 { emulation_flags = [] }) stubdom_uuid in
+  let stubdom_domid = Domain.make ~xc ~xs info 1 Domain.(X86 { emulation_flags = [] }) stubdom_uuid None in
   debug "jjd27: created stubdom with domid %d" stubdom_domid;
 
   Domain.set_machine_address_size ~xc stubdom_domid (Some 32);


### PR DESCRIPTION
The step of VM rename in migration will break the network connection of the target VM in DVSC scenario. This Pull request aims to fix that.