### PR TITLE
Revert "CA-299737: set cache=none for disk devices"

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2506,11 +2506,6 @@ module Backend = struct
             | Dm_Common.Disk  -> "force-lba=on"
             | Dm_Common.Cdrom -> "force-lba=off"
           in
-          let cache_of_media (media:Dm_Common.media) =
-            match media with
-            | Dm_Common.Disk  -> ["cache=none"]
-            | Dm_Common.Cdrom -> []
-          in
           List.map (fun (index, file, media) -> [
               "-drive"; String.concat "," ([
                 sprintf "file=%s" file;
@@ -2518,7 +2513,7 @@ module Backend = struct
                 sprintf "index=%d" index;
                 sprintf "media=%s" (Dm_Common.string_of_media media);
                 lba_of_media media;
-              ] @ (format_of_media media file) @ (cache_of_media media))
+              ] @ (format_of_media media file))
             ])
             info.Dm_Common.disks
           |> List.concat


### PR DESCRIPTION
Reverts xapi-project/xenopsd#582

This seems to cause an 0x80042256 error during windows install in the bvt. Revert it until we understand why