### PR TITLE
CA-302981, CP-30032: Do not try to stop/destroy varstored chroot in BIOS mode, and sandbox varstore-rm

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -63,6 +63,7 @@ let () = Printf.ksprintf Jbuild_plugin.V1.send {|
     xcp.xen
     xcp.storage
     xcp.updates
+    xcp.varstore.privileged
     sexplib
     ppx_sexp_conv.runtime-lib
     uutf

--- a/lib/xenops_sandbox.ml
+++ b/lib/xenops_sandbox.ml
@@ -117,7 +117,7 @@ module Varstore_guard = struct
     let chroot = varstored_chroot ~domid in
     Chroot.create chroot;
     Chroot.prepare chroot path;
-    Chroot.absolute_path_outside (varstored_chroot ~domid) path
+    Chroot.absolute_path_outside chroot path
 
   let read ~domid path =
     let chroot = varstored_chroot ~domid in
@@ -126,9 +126,9 @@ module Varstore_guard = struct
   let stop dbg ~domid =
       let chroot = varstored_chroot ~domid in
       if Sys.file_exists chroot.root then
-        let gid = (varstored_chroot ~domid).Chroot.gid in
+        let gid = chroot.Chroot.gid in
         let absolute_socket_path = Chroot.absolute_path_outside chroot socket_path in
         Xenops_utils.best_effort "Stop listening on deprivileged socket" (fun () ->
             Varstore_privileged_client.Client.destroy dbg gid absolute_socket_path);
-        Chroot.destroy @@ varstored_chroot ~domid
+        Chroot.destroy chroot
 end

--- a/lib/xenops_sandbox.ml
+++ b/lib/xenops_sandbox.ml
@@ -1,0 +1,135 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make(struct let name = "xenops_sandbox" end)
+module Chroot : sig
+  type t = {
+    root: string;
+    uid: int;
+    gid: int;
+  }
+  module Path : sig
+    type t
+    val of_string : relative:string -> t
+  end
+  (** [absolute_path_outside chroot path] returns the absolute path outside the chroot *)
+  val absolute_path_outside : t -> Path.t -> string
+
+  (** [chroot_path_inside path] returns the path when inside the chroot *)
+  val chroot_path_inside : Path.t -> string
+
+  (** [prepare chroot path] ensures that [path] is owned by the chrooted daemon and rw- *)
+  val prepare : t -> Path.t -> unit
+
+  (** [of_domid daemon domid] describes a chroot for specified daemon and domain *)
+  val of_domid : daemon:string -> domid:int -> t
+
+  (** [create chroot] Creates the specified chroot with appropriate permissions *)
+  val create : t -> unit
+
+  (** [destroy chroot] Deletes the chroot *)
+  val destroy: t -> unit
+end = struct
+  type t = {
+    root: string;
+    uid: int;
+    gid: int;
+  }
+
+  module Path = struct
+    type t = string
+    let of_string ~relative =
+      if not (Filename.is_implicit relative) then
+        invalid_arg (Printf.sprintf "Expected implicit filename, but got '%s' (at %s)" relative __LOC__);
+      relative
+  end
+
+  let absolute_path_outside chroot path =
+    Filename.concat chroot.root path
+
+  let chroot_path_inside path = Filename.concat "/" path
+
+  let prepare chroot path =
+    let fullpath = absolute_path_outside chroot path in
+    Xenops_utils.Unixext.with_file fullpath [Unix.O_CREAT; Unix.O_EXCL] 0o600 (fun fd ->
+        Unix.fchown fd chroot.uid chroot.gid)
+
+  let qemu_base_uid () = (Unix.getpwnam "qemu_base").Unix.pw_uid
+  let qemu_base_gid () = (Unix.getpwnam "qemu_base").Unix.pw_gid
+
+  let of_domid ~daemon ~domid =
+    let root = Printf.sprintf "/var/run/xen/%s-root-%d" daemon domid in
+    (* per VM uid/gid as for QEMU *)
+    let uid = qemu_base_uid () + domid in
+    let gid = qemu_base_gid () + domid in
+    { root; uid; gid }
+
+  let create chroot =
+    try
+      Xenops_utils.Unixext.mkdir_rec chroot.root 0o755;
+      (* we want parent dir to be 0o755 and this dir 0o750 *)
+      Unix.chmod chroot.root 0o750;
+      (* the chrooted daemon will have r-x permissions *)
+      Unix.chown chroot.root 0 chroot.gid;
+      D.debug "Created chroot %s" chroot.root
+    with e ->
+      Backtrace.is_important e;
+      D.warn "Failed to create chroot at %s for UID %d: %s" chroot.root chroot.uid
+        (Printexc.to_string e);
+      raise e
+
+  let destroy chroot =
+    Xenops_utils.best_effort (Printf.sprintf "removing chroot %s" chroot.root)
+      (fun () -> Xenops_utils.FileFS.rmtree chroot.root)
+end
+
+module Varstore_guard = struct
+  let varstored_chroot ~domid = Chroot.of_domid ~daemon:"varstored" ~domid
+  let socket_path = Chroot.Path.of_string ~relative:"xapi-depriv-socket"
+
+  (** [start dbg ~vm_uuid ~domid ~paths] prepares a chroot for [domid],
+   * and asks varstore-guard to create a socket restricted to [vm_uuid].
+   * Also creates empty files specified in [paths] owned by [domid] user.*)
+  let start dbg ~vm_uuid ~domid ~paths =
+    let chroot = varstored_chroot ~domid in
+    Chroot.create chroot;
+    let absolute_socket_path = Chroot.absolute_path_outside chroot socket_path in
+    let vm_uuidm = match Uuidm.of_string vm_uuid with Some uuid -> uuid | None ->
+     failwith (Printf.sprintf "Invalid VM uuid %s" vm_uuid) in
+    List.iter (Chroot.prepare chroot) paths;
+    Varstore_privileged_client.Client.create dbg vm_uuidm chroot.gid absolute_socket_path;
+    chroot, Chroot.chroot_path_inside socket_path
+
+  (** [prepare ~domid path] creates an empty [path] file owned by [domid] inside the chroot for [domid]
+ * and returns the absolute path to it outside the chroot *)
+  let prepare ~domid path =
+    let chroot = varstored_chroot ~domid in
+    Chroot.create chroot;
+    Chroot.prepare chroot path;
+    Chroot.absolute_path_outside (varstored_chroot ~domid) path
+
+  let stop dbg ~domid ~paths =
+      let chroot = varstored_chroot ~domid in
+      if Sys.file_exists chroot.root then
+        let read_file relative =
+          relative |> Chroot.absolute_path_outside chroot |> Xenops_utils.Unixext.string_of_file in
+        let gid = (varstored_chroot ~domid).Chroot.gid in
+        let absolute_socket_path = Chroot.absolute_path_outside chroot socket_path in
+        let files = paths |> List.map read_file in
+        Xenops_utils.best_effort "Stop listening on deprivileged socket" (fun () ->
+            Varstore_privileged_client.Client.destroy dbg gid absolute_socket_path);
+        Chroot.destroy @@ varstored_chroot ~domid;
+        files
+      else []
+end

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -770,3 +770,10 @@ let chunks size lst =
         else [op]::xs::xss
     ) [] lst
   |> List.map (fun xs -> List.rev xs) |> List.rev
+
+let best_effort txt f =
+  try
+    f ()
+  with e ->
+    info "%s: ignoring exception %s" txt (Printexc.to_string e)
+

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1966,8 +1966,7 @@ module Dm_Common = struct
     let stop_varstored () =
       Varstored.stop ~xs domid;
       let dbg = Printf.sprintf "stop domid %d" domid in
-      let (_:string list) = Xenops_sandbox.Varstore_guard.stop dbg ~domid ~paths:[] in
-      ()
+      Xenops_sandbox.Varstore_guard.stop dbg ~domid
     in
     stop_vgpu ();
     stop_varstored ();
@@ -3107,8 +3106,7 @@ module Dm = struct
   let suspend_varstored (task: Xenops_task.task_handle) ~xs domid =
     debug "Called Dm.suspend_varstored (domid=%d)" domid;
     Varstored.stop ~xs domid;
-    let dbg = Xenops_task.get_dbg task in
-    Xenops_sandbox.Varstore_guard.stop dbg ~domid ~paths:[efivars_save_path] |> List.hd
+    Xenops_sandbox.Varstore_guard.read ~domid efivars_save_path
 
   let restore_varstored (task: Xenops_task.task_handle) ~xs ~efivars domid =
     debug "Called Dm.restore_varstored (domid=%d)" domid;

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -331,12 +331,8 @@ let destroy ~xs domid kind devid =
     with Unixext.Process_still_alive ->
       debug "%d: failed to respond to SIGTERM, sending SIGKILL" pid;
       Unixext.kill_and_wait ~signal:Sys.sigkill pid
-  let best_effort txt f =
-    try
-      f ()
-    with e ->
-      info "%s: ignoring exception %s" txt (Printexc.to_string e)
 
+  let best_effort = Xenops_utils.best_effort
 end
 
 (****************************************************************************************)
@@ -1637,88 +1633,6 @@ end
 
 let can_surprise_remove ~xs (x: device) = Generic.can_surprise_remove ~xs x
 
-module Chroot : sig
-  type t = {
-    root: string;
-    uid: int;
-    gid: int;
-  }
-  module Path : sig
-    type t
-    val of_string : relative:string -> t
-  end
-  (** [absolute_path_outside chroot path] returns the absolute path outside the chroot *)
-  val absolute_path_outside : t -> Path.t -> string
-
-  (** [chroot_path_inside path] returns the path when inside the chroot *)
-  val chroot_path_inside : Path.t -> string
-
-  (** [prepare chroot path] ensures that [path] is owned by the chrooted daemon and rw- *)
-  val prepare : t -> Path.t -> unit
-
-  (** [of_domid daemon domid] describes a chroot for specified daemon and domain *)
-  val of_domid : daemon:string -> domid:int -> t
-
-  (** [create chroot] Creates the specified chroot with appropriate permissions *)
-  val create : t -> unit
-
-  (** [destroy chroot] Deletes the chroot *)
-  val destroy: t -> unit
-end = struct
-  type t = {
-    root: string;
-    uid: int;
-    gid: int;
-  }
-
-  module Path = struct
-    type t = string
-    let of_string ~relative =
-      if not (Filename.is_implicit relative) then
-        invalid_arg (Printf.sprintf "Expected implicit filename, but got '%s' (at %s)" relative __LOC__);
-      relative
-  end
-
-  let absolute_path_outside chroot path =
-    Filename.concat chroot.root path
-
-  let chroot_path_inside path = Filename.concat "/" path
-
-  let prepare chroot path =
-    let fullpath = absolute_path_outside chroot path in
-    Unixext.with_file fullpath [Unix.O_CREAT; Unix.O_EXCL] 0o600 (fun fd ->
-        Unix.fchown fd chroot.uid chroot.gid)
-
-  let qemu_base_uid () = (Unix.getpwnam "qemu_base").Unix.pw_uid
-  let qemu_base_gid () = (Unix.getpwnam "qemu_base").Unix.pw_gid
-
-  let of_domid ~daemon ~domid =
-    let root = Printf.sprintf "%s/%s-root-%d" Device_common.var_run_xen_path daemon domid in
-    (* per VM uid/gid as for QEMU *)
-    let uid = qemu_base_uid () + domid in
-    let gid = qemu_base_gid () + domid in
-    { root; uid; gid }
-
-  let create chroot =
-    try
-      Xenops_utils.Unixext.mkdir_rec chroot.root 0o755;
-      (* we want parent dir to be 0o755 and this dir 0o750 *)
-      Unix.chmod chroot.root 0o750;
-      (* the chrooted daemon will have r-x permissions *)
-      Unix.chown chroot.root 0 chroot.gid;
-      debug "Created chroot %s" chroot.root
-    with e ->
-      Backtrace.is_important e;
-      D.warn "Failed to create chroot at %s for UID %d: %s" chroot.root chroot.uid
-        (Printexc.to_string e);
-      raise e
-
-  let destroy chroot =
-    if Sys.file_exists chroot.root then
-      Generic.best_effort (Printf.sprintf "removing chroot %s" chroot.root)
-        (fun () -> Xenops_utils.FileFS.rmtree chroot.root)
-end
-
 (** Dm_Common contains the private Dm functions that are common between the qemu profile backends. *)
 module Dm_Common = struct
 
@@ -1775,9 +1689,8 @@ module Dm_Common = struct
 
   let vnc_socket_path = (sprintf "%s/vnc-%d") Device_common.var_run_xen_path
 
-  let varstored_chroot ~domid = Chroot.of_domid ~daemon:"varstored" ~domid
-  let efivars_resume_path = Chroot.Path.of_string ~relative:"efi-vars-resume.dat"
-  let efivars_save_path = Chroot.Path.of_string ~relative:"efi-vars-save.dat"
+  let efivars_resume_path = Xenops_sandbox.Chroot.Path.of_string ~relative:"efi-vars-resume.dat"
+  let efivars_save_path = Xenops_sandbox.Chroot.Path.of_string ~relative:"efi-vars-save.dat"
 
   let get_vnc_port ~xs domid ~f =
     match Qemu.is_running ~xs domid with
@@ -2052,14 +1965,9 @@ module Dm_Common = struct
     let stop_vgpu () = Vgpu.stop ~xs domid in
     let stop_varstored () =
       Varstored.stop ~xs domid;
-      let chroot = varstored_chroot ~domid in
-      if Sys.file_exists chroot.Chroot.root then begin
-        let gid = chroot.Chroot.gid in
-        let dbg = Printf.sprintf "stop_varstored for domid %d" domid in
-        Generic.best_effort "Stop listening on deprivileged socket" (fun () ->
-            Varstore_privileged_client.Client.destroy dbg gid);
-        Chroot.destroy @@ varstored_chroot ~domid;
-      end
+      let dbg = Printf.sprintf "stop domid %d" domid in
+      let (_:string list) = Xenops_sandbox.Varstore_guard.stop dbg ~domid ~paths:[] in
+      ()
     in
     stop_vgpu ();
     stop_varstored ();
@@ -3027,16 +2935,8 @@ module Dm = struct
     let (>>=) = bind in
     let argf fmt = ksprintf (fun s -> [ "--arg"; s]) fmt in
     let on cond value = if cond then value else return () in
-    let chroot = varstored_chroot ~domid in
-    Chroot.create chroot;
-    let socket_path = Chroot.Path.of_string ~relative:"xapi-depriv-socket" in
-    let absolute_socket_path = Chroot.absolute_path_outside chroot socket_path in
-    let vm_uuidm = match Uuidm.of_string vm_uuid with Some uuid -> uuid | None ->
-     failwith (Printf.sprintf "Invalid VM uuid %s" vm_uuid) in
-    Varstore_privileged_client.Client.create (Xenops_task.get_dbg task) vm_uuidm chroot.gid absolute_socket_path;
-(*    Unix.chmod absolute_socket_path 0o660;
-      Unix.chown absolute_socket_path 0 chroot.gid; *)
-    Chroot.prepare chroot efivars_save_path;
+    let chroot, socket_path =
+      Xenops_sandbox.Varstore_guard.start (Xenops_task.get_dbg task) ~vm_uuid ~domid ~paths:[ efivars_save_path] in
     let args =
       Add.many [ "--domain"; string_of_int domid
                ; "--chroot"; chroot.root
@@ -3044,15 +2944,15 @@ module Dm = struct
                ; "--uid"; string_of_int chroot.uid
                ; "--gid"; string_of_int chroot.gid
                ; "--backend"; backend
-               ; "--arg"; Printf.sprintf "socket:%s" (Chroot.chroot_path_inside socket_path)
+               ; "--arg"; Printf.sprintf "socket:%s" socket_path
                ] >>= fun () ->
       (Varstored.pidfile_path domid |> function None -> return () | Some x ->
            Add.many [ "--pidfile"; x ]) >>= fun () ->
       Add.many @@ argf "uuid:%s" vm_uuid >>= fun () ->
       on reset_on_boot @@ Add.arg "--nonpersistent" >>= fun () ->
       on restore @@ Add.arg "--resume" >>= fun () ->
-      on restore @@ Add.many @@ argf "resume:%s" (Chroot.chroot_path_inside efivars_resume_path) >>= fun () ->
-      Add.many @@ argf "save:%s" (Chroot.chroot_path_inside efivars_save_path)
+      on restore @@ Add.many @@ argf "resume:%s" (Xenops_sandbox.Chroot.chroot_path_inside efivars_resume_path) >>= fun () ->
+      Add.many @@ argf "save:%s" (Xenops_sandbox.Chroot.chroot_path_inside efivars_save_path)
     in
     let args = Fe_argv.run args |> snd |> Fe_argv.argv in
     let pid = start_daemon ~path ~args ~name ~domid ~fds:[] () in
@@ -3207,12 +3107,12 @@ module Dm = struct
   let suspend_varstored (task: Xenops_task.task_handle) ~xs domid =
     debug "Called Dm.suspend_varstored (domid=%d)" domid;
     Varstored.stop ~xs domid;
-    Unixext.string_of_file @@ Chroot.absolute_path_outside (varstored_chroot ~domid) efivars_save_path
+    let dbg = Xenops_task.get_dbg task in
+    Xenops_sandbox.Varstore_guard.stop dbg ~domid ~paths:[efivars_save_path] |> List.hd
 
   let restore_varstored (task: Xenops_task.task_handle) ~xs ~efivars domid =
     debug "Called Dm.restore_varstored (domid=%d)" domid;
-    Chroot.create (varstored_chroot ~domid);
-    let path = Chroot.absolute_path_outside (varstored_chroot ~domid) efivars_resume_path in
+    let path = Xenops_sandbox.Varstore_guard.prepare ~domid efivars_resume_path in
     debug "Writing EFI variables to %s (domid=%d)" path domid;
     Unixext.write_string_to_file path efivars;
     debug "Wrote EFI variables to %s (domid=%d)" path domid


### PR DESCRIPTION
This would cause some confusing log messages at best, or even fail in the worst case (if varstored-guard is not running). So just avoid doing it if we are not using UEFI mode.