### PR TITLE
CA-305090: do not fail on older versions of qemu

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2436,7 +2436,11 @@ module Backend = struct
                                           "Unexpected result for QMP command: %s"
                                           Qmp.(other |> as_msg |> string_of_message))))
       | exception QMP_Error (_, msg) ->
-        xs.Xs.write path msg
+        match Astring.String.find_sub ~sub:"CommandNotFound" msg with
+        | None -> xs.Xs.write path msg
+        | Some _ ->
+          debug "query-migratable ignoring precheck, qemu too old (domid=%d)" domid;
+          Generic.safe_rm ~xs path
 
     let qmp_event_handle domid qmp_event =
       (* This function will be extended to handle qmp events *)


### PR DESCRIPTION
To allow merging qemu and toolstack components independently,
we should be backwards compatible with older versions of qemu
that do not support this command.

The 'query-migratable' command is useful for detecting problems that
would prevent migration early (e.g. NVME device attached),
but is not relevant for BIOS boot mode.