### PR TITLE
CA-304519 wait for QMP socket by connecting to it

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2696,9 +2696,9 @@ module Backend = struct
                  with e ->
                    debug "QMP event socket for domid %d not yet ready: %s"
                      domid (Printexc.to_string e);
-                   Unix.sleepf 0.1
+                   Thread.delay 0.1
                else
-                 Unix.sleepf 0.05;
+                 Thread.delay 0.05;
              done;)
           (fun () -> Unix.close socket);
         if not !finished then


### PR DESCRIPTION
It is not obvious for xenopsd when the QMP socket is ready. So far we
only wait for the path to appear but this does not mean it is ready
and trying to connect to it can still fail. Now we are also trying to
establish a connection before returning. If connecting fails, we wait
and try again until the timeout is reached.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>