### PR TITLE
xenopsd: silence failed to read PID messages

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1019,8 +1019,7 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
         (* backward compatibility during update installation: only has xenstore pid *)
         let pid = xs.Xs.read (pid_path domid) in
         Some (int_of_string pid)
-    with e ->
-      debug "Failed to read PID for %s (domid=%d): %s" D.name domid (Printexc.to_string e);
+    with _ ->
       None
 
   let is_running ~xs domid =


### PR DESCRIPTION
These got introduced with the varstored changes, but this message gets
logged way too often, and distracts from finding real errors.
