### PR TITLE
CA-307829: XSI-216 add active state to VGPU

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -143,6 +143,7 @@ module type S = sig
   end
   module VGPU : sig
     val start: Xenops_task.task_handle -> Vm.id -> Vgpu.t -> bool -> unit
+    val set_active: Xenops_task.task_handle -> Vm.id -> Vgpu.t -> bool -> unit
     val get_state: Vm.id -> Vgpu.t -> Vgpu.state
   end
   module VUSB :sig

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -115,6 +115,7 @@ module VIF = struct
 end
 module VGPU = struct
   let start _ _ _ _ = unimplemented "VGPU.start"
+  let set_active _ _ _ _ = ()
   let get_state _ _ = unplugged_vgpu
 end
 module VUSB = struct

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -699,6 +699,7 @@ let unplugged_vif = {
 }
 
 let unplugged_vgpu = {
+  Vgpu.active = false;
   Vgpu.plugged = false;
   Vgpu.emulator_pid = None;
 }

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2239,6 +2239,14 @@ module PCI = struct
 
 end
 
+let set_active_device path active =
+  with_xs
+    (fun xs ->
+       if active
+       then xs.Xs.write path "1"
+       else safe_rm xs path;
+    )
+
 module VGPU = struct
   open Vgpu
 
@@ -2261,6 +2269,19 @@ module VGPU = struct
          Device.Dm.restore_vgpu task ~xs frontend_domid vgpu vcpus profile
       ) vm
 
+  let active_path vm vgpu = Printf.sprintf "/vm/%s/devices/vgpu/%s" vm (snd vgpu.Vgpu.id)
+
+  let set_active task vm vgpu active =
+    try
+      set_active_device (active_path vm vgpu) active
+    with e ->
+      debug "set_active %s.%s <- %b failed: %s" (fst vgpu.Vgpu.id) (snd vgpu.Vgpu.id) active (Printexc.to_string e)
+
+  let get_active vm vgpu =
+    try
+      with_xs (fun xs -> xs.Xs.read (active_path vm vgpu)) = "1"
+    with _ -> false
+
   let get_state vm vgpu =
     on_frontend
       (fun _ xs frontend_domid _ ->
@@ -2272,8 +2293,8 @@ module VGPU = struct
            | Nvidia _ -> Device.Vgpu.pid ~xs frontend_domid
          in
          match emulator_pid with
-         | Some pid -> {plugged = true; emulator_pid}
-         | None -> {plugged = false; emulator_pid})
+         | Some pid -> {Vgpu.active = true; plugged = true; emulator_pid}
+         | None -> {Vgpu.active = get_active vm vgpu; plugged = false; emulator_pid})
       vm
 end
 
@@ -2335,14 +2356,6 @@ module VUSB = struct
       debug "VM = %s; VUSB = %s; Ignoring missing device" vm (id_of vusb)
 
 end
-
-let set_active_device path active =
-  with_xs
-    (fun xs ->
-       if active
-       then xs.Xs.write path "1"
-       else safe_rm xs path;
-    )
 
 module VBD = struct
   open Vbd


### PR DESCRIPTION
Background:
    When the vgpu is added to the guest and there was a window of 5–6
seconds during the guest internal reboot, at this time the VGPU was
"unplugged". If xapi triggers a VM refresh(eg. sencond reboot API call)
for this VM during this window, then update_vgpu in xapi_xenops.ml will
remove VGPU DB in xenopsd which then the internal reboot failed.

We add "active" state for vgpu to fix this issue.

Ring3 BST: 99435  
Job 2389511 failed due to xenrt issue. 

VGPU functional: 99436 
Also due to xenrt issue which many jobs failed. 
99493 is running.

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>