### PR TITLE
CA-306943: Revert "CA-297602: Always create a physical-device node for HVM CD-ROMs"

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -21,12 +21,19 @@ add)
         params=$(readlink -f $params || echo $params)
         frontend="/local/domain/${DOMID}/device/${TYPE}/${DEVID}"
         syslog "${XENBUS_PATH}: add params=\"${params}\""
-        physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
-        syslog "${XENBUS_PATH}: physical-device=${physical_device}"
-        xenstore-exists "${XENBUS_PATH}/physical-device"
-        if [ $? -eq 1 ]; then
-                syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
-                xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
+        # We don't have PV drivers for CDROM devices, so we prevent blkback
+        # from opening the physical-device
+        xenstore-exists "${PRIVATE}/no-physical-device"
+        if [ $? -ne 0 ]; then
+          physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
+          syslog "${XENBUS_PATH}: physical-device=${physical_device}"
+          xenstore-exists "${XENBUS_PATH}/physical-device"
+          if [ $? -eq 1 ]; then
+			syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
+            xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
+          fi
+        else
+          syslog "${XENBUS_PATH}: not writing physical-device because no-physical-device is present"
         fi
         xenstore-write "${HOTPLUG}/hotplug" "online"
         xenstore-write "${HOTPLUG_STATUS}" "connected"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -576,6 +576,11 @@ module Vbd_Common = struct
       "mode", string_of_mode x.mode;
       "params", x.params;
     ]);
+    (* We don't have PV drivers for HVM guests for CDROMs. We prevent
+       blkback from successfully opening the device since this can
+       prevent qemu CD eject (and subsequent vdi_deactivate) *)
+    let no_phys_device =
+      if hvm && (x.dev_type = CDROM) then ["no-physical-device", ""] else [] in
 
     Opt.iter
       (fun protocol ->
@@ -584,8 +589,9 @@ module Vbd_Common = struct
 
     let back = Hashtbl.fold (fun k v acc -> (k, v) :: acc) back_tbl [] in
     let front = Hashtbl.fold (fun k v acc -> (k, v) :: acc) front_tbl [] in
+    let priv = no_phys_device @ x.extra_private_keys in
 
-    Generic.add_device ~xs device back front x.extra_private_keys [];
+    Generic.add_device ~xs device back front priv [];
     device
 
   let add_wait (task: Xenops_task.task_handle) ~xc ~xs device =


### PR DESCRIPTION
Still testing, but it looks like reverting this change makes CDROM unplug run more reliably in the pool stress test.
On master we get `Watch.Timeout 300` on VBD unplug of a CDROM: the hotplug-status key does not get removed and tapdisk is throwing errors when told to remove the device. Looks like a race condition.
When reverting the change as this PR does don't see timeouts anymore.

Not sure whether there are better solutions than reverting this patch, it looks like the no-physical-device was there to workaround a kernel bug initially, and that bug is still present with blktap3 and tapdisk?
@rosslagerwall any suggestions?