### PR TITLE
CA 309427

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -113,8 +113,9 @@ def prepare_exec():
     restrict_fsize()
 
     flags = CLONE_NEWNS | CLONE_NEWIPC
-    # hvm_serial may require network access so don't unshare the network.
-    if not hvm_serial:
+    # serial redirection for debug may be using the network so don't
+    # unshare in this case
+    if not network_serial:
         flags |= CLONE_NEWNET
     unshare(flags)
 
@@ -158,9 +159,6 @@ def main(argv):
 
     qemu_args.extend(argv[2:])
 
-    global hvm_serial
-    hvm_serial = xenstore_read("/local/domain/%d/platform/hvm_serial" % domid)
-
     n = 0
 
     vga_type = 'cirrus-vga'
@@ -174,6 +172,9 @@ def main(argv):
     serial_c = ''
     tmp_serial_c = ''
     depriv = True
+
+    global network_serial
+    network_serial = False
 
     while n < len(qemu_args):
         p = qemu_args[n]
@@ -191,6 +192,17 @@ def main(argv):
         if p == "-priv":
             del qemu_args[n]
             depriv = False
+            continue
+
+        if p == "-serial":
+            params = qemu_args[n + 1].split(',')
+            # There are other network options apart from 'tcp' but,
+            # in practice, tcp is always used for serial debug
+            if params[0].startswith('tcp'):
+                print "serial: '%s'" % qemu_args[n + 1]
+                network_serial = True
+
+            n += 1
             continue
 
         if p == "-trad-compat":

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1732,11 +1732,8 @@ module Dm_Common = struct
           "-vgt_high_gm_sz"; Int64.to_string gvt_g.high_gm_sz;
           "-vgt_fence_sz"; Int64.to_string gvt_g.fence_sz;
         ]
-        and config_file_opt = match gvt_g.monitor_config_file with
-          | Some path -> ["-vgt_monitor_config_file"; path]
-          | None -> []
         and priv_opt = ["-priv"] in
-        List.flatten [base_opts; config_file_opt; priv_opt]
+        List.flatten [base_opts; priv_opt]
       | Vgpu [{implementation = MxGPU mxgpu}] -> []
       | Vgpu _ -> failwith "Unsupported vGPU configuration"
       | Std_vga -> ["-std-vga"]


### PR DESCRIPTION
…erial

The 'hvm_serial' option can be set on either the 'platform' or
'other-config' keys. Only the former causes something to be written into
xenstore.
Also, what we're trying to do is avoid the network unshare in the case that
a serial device is re-directed to the network. Hence the wrapper should
be parsing any '-serial' argument looking for a network re-direct. In
practice the only one we care about is 'tcp' so it's sufficient to look for
that prefix. If other types of re-direction become commonplace in future
then the test can be extended.

Signed-off-by: Paul Durrant <paul.durrant@citrix.com>