### PR TITLE
CA-309685 fix fd leak in QMP connection handling

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2344,9 +2344,9 @@ module Backend = struct
       try
         Lookup.channel_of domid >>| fun () ->
         let c = Qmp_protocol.connect (monitor_path domid) in
+        Lookup.add c domid;
         Qmp_protocol.negotiate c;
         Qmp_protocol.write c (Command (None, Cont));
-        Lookup.add c domid;
         Monitor.add m (Qmp_protocol.to_fd c);
         debug "Added QMP Event fd for domain %d" domid
       with e ->


### PR DESCRIPTION
In the case of QMP negotiation failure, remove() is called but it does
not know the connection that it needs to close. This commit makes sure
remove() does know it by adding the connection to the lookup table
before calling Qmp_protocol.negotiate() (which might fail and trigger
the cleanup case).

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>