### PR TITLE
XSI-254 don't create empty /domain/N/device/vif [backport]

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -243,11 +243,22 @@ let make ~xc ~xs vm_info uuid =
 				) dirs in
 
 			let device_dirs = ["device"; "device/vbd"; "device/vif"] in
+			let device_dirs' =
+				let xsi_254 =
+					try
+						List.assoc "netscaler" vm_info.platformdata = "XSI-254"
+					with Not_found -> false in
+				if xsi_254 then [] else device_dirs
+			in
 
-			(* create read/write nodes for the guest to use *)
+				(* create read/write nodes for the guest to use. XSI-254:
+				 * disable creation of empty device entries in the domain
+				 * hierarchy upon request. Always create them in the xenops
+				 * hierarchy
+				 *)
 			mksubdirs
 				dom_path
-				(device_dirs @ [
+					(device_dirs' @ [
 					"feature";
 					"error";
 					"drivers";


### PR DESCRIPTION
Creation of a domain includes creating its XenStore hierarchy. This
includes empty device entries for VIFs and VBDs as they are required for
Windows - see commit e894ebfd4cbe039adccf8ba78f4912ed373cc95d.

This commit introduces a check to not create them to work around
a bug in a VM that would trip over these empty directories. Since
Windows guests depend on the empty entries, this should almost never be
used. Empty directories are not created when the platform contains this
key:value: netscaler:XSI-254.

Backport of edd538a604ecc8752d659a6cf16ba9056160cbc5. Changes only in
whitespace because the 0.17-lcm branch uses tabs at the beginning of the line.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>