### PR TITLE
CA-308199: fix VM migration to Xen 4.9+ on AMD machines

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -749,6 +749,9 @@ module HOST = struct
          features_pv.(3)  <- Int64.logor features_pv.(3)  0x2L;
          features_hvm.(3) <- Int64.logor features_hvm.(3) 0x2L;
 
+         (* Set X86_FEATURE_IBS in e1c for HVM guests *)
+         features_hvm.(3) <- Int64.logor features_hvm.(3) 0x400L;
+
          let v = version xc in
          let xen_version_string = Printf.sprintf "%d.%d%s" v.major v.minor v.extra in
          let xen_capabilities = version_capabilities xc in


### PR DESCRIPTION
Commit 8c07000b3b1c ("CA-254835: make Xen 4.8+ featuresets compatible
with Xen 4.7") missed one more feature bit that was removed in Xen 4.9:

https://xenbits.xen.org/gitweb/?p=xen.git;a=commitdiff;h=c783556d71084c8111ce17304992c2e85f0e0346

This prevents VM migration from 4.7 to 4.9+ versions of Xen on AMD cpus.
Fix this by using a similar workaround until new CPUID/MSR levelling
is implemented.

Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>