### PR TITLE
CA-309685 fix fd leak in QMP connection handling

### DIFF
--- a/qemu/xenops_server_qemu.ml
+++ b/qemu/xenops_server_qemu.ml
@@ -148,9 +148,9 @@ module Qemu = struct
 				let path = Filename.concat qmp_dir uuid in
 				try
 					let c = Qmp_protocol.connect path in
-					Qmp_protocol.negotiate c;
 					Hashtbl.replace qmp_to_uuid c uuid;
 					Hashtbl.replace uuid_to_qmp uuid c;
+					Qmp_protocol.negotiate c;
 					debug "QMP %s: negotiation complete" uuid
 				with e ->
 					info "QMP %s: negotiation failed (%s): removing socket" uuid (Printexc.to_string e);


### PR DESCRIPTION
In the case of QMP negotiation failure, remove() is called but it does
not know the connection that it needs to close. This commit makes sure
remove() does know it by adding the connection to the lookup table
before calling Qmp_protocol.negotiate() (which might fail and trigger
the cleanup case).

Backport of 7ce911588d15704039168768caaddaa4beaf2533

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>