### PR TITLE
maintenance: do not apply patch for building

### DIFF
--- a/xapi-xenopsd.opam
+++ b/xapi-xenopsd.opam
@@ -5,7 +5,6 @@ authors: "xen-api@lists.xen.org"
 homepage: "https://github.com/xapi-project/xenopsd"
 dev-repo: "git+https://github.com/xapi-project/xenopsd.git"
 bug-reports: "https://github.com/xapi-project/xenopsd/issues"
-patches: ["xenopsd-evtchn-revert-CP29693.patch"]
 build: [
   ["./configure"]
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
They are no longer available anywhere and it breaks the build:
https://github.com/xapi-project/xs-opam/pull/352

Example of broken build: https://travis-ci.com/psafont/xen-api/jobs/187564273#L1781