### PR TITLE
CA-314511: Set "type" key for HVM domains that is expected by xl

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -304,6 +304,7 @@ def main(argv):
         qemu_args += ["-runas", "%d.%d" % (uid, gid)]
 
     xenstore_write("/libxl/%d/dm-version" % domid, "qemu_xen")
+    xenstore_write("/libxl/%d/type" % domid, "HVM")
 
     print "Exec: %s %s" % (qemu_dm, " ".join(qemu_args))
 


### PR DESCRIPTION
Most of xl utilities while quering for domain type are trying to
distinguish between HVM and PVH by reading /libxl/<domid>/type key.
It now mostly works because the default behavior is to assume the
domain is HVM and show a warning.

Set the key explicitly to "HVM" to avoid the warning and confusion.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>