### PR TITLE
CA-314170: fix vbd unplug for qdisk backends

### DIFF
--- a/scripts/xen-backend.rules.in
+++ b/scripts/xen-backend.rules.in
@@ -1,5 +1,5 @@
 SUBSYSTEM=="xen-backend", KERNEL=="tap*", RUN+="@LIBEXEC@/tap $env{ACTION}"
-SUBSYSTEM=="xen-backend", KERNEL=="vbd*|qdisk", RUN+="@LIBEXEC@/block $env{ACTION}"
+SUBSYSTEM=="xen-backend", KERNEL=="vbd*|qdisk*", RUN+="@LIBEXEC@/block $env{ACTION}"
 
 SUBSYSTEM=="xen-backend", KERNEL=="vif*", RUN+="@LIBEXEC@/vif $env{ACTION} type_if=vif"
 SUBSYSTEM=="net",         KERNEL=="tap*", RUN+="@LIBEXEC@/vif $env{ACTION} type_if=tap"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -212,16 +212,7 @@ module Generic = struct
         )
       )
 
-  let unplug_watch ~xs (x: device) =
-    let path = Hotplug.path_written_by_hotplug_scripts x in
-    let qdisk = Astring.String.is_infix ~affix:"backend/qdisk/" path in
-    if not qdisk then begin
-      Watch.key_to_disappear path
-    end else begin
-      debug "unplug_watch: not waiting for qdisk %s; returning dummy watch" path;
-      Watch.{ evaluate = fun xs -> try xs.Xs.rm path with _ -> debug "dummy unplug_watch for qdisk: %s already removed" path }
-    end
-
+  let unplug_watch ~xs (x: device) = Hotplug.path_written_by_hotplug_scripts x |> Watch.key_to_disappear
   let error_watch ~xs (x: device) = Watch.value_to_appear (error_path_of_device ~xs x)
   let frontend_closed ~xs (x: device) = Watch.map (fun () -> "") (Watch.value_to_become (frontend_rw_path_of_device ~xs x ^ "/state") (Xenbus_utils.string_of Xenbus_utils.Closed))
   let backend_closed ~xs (x: device) = Watch.value_to_become (backend_path_of_device ~xs x ^ "/state") (Xenbus_utils.string_of Xenbus_utils.Closed)

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -219,7 +219,7 @@ module Generic = struct
 
   let is_qdisk x = Hotplug.path_written_by_hotplug_scripts x |> Astring.String.is_infix ~affix:"backend/qdisk/"
 
-  let on_backend_closed_unplug ~xs x=
+  let on_backend_closed_unplug ~xs x =
     debug "Device.on_backend_closed_unplug for %s" (string_of_device x);
     (* qemu-dp does not delete the hotplug status key *)
     backend_closed ~xs x
@@ -280,6 +280,8 @@ module Generic = struct
     safe_rm xs (frontend_ro_path_of_device ~xs x)
 
   let hard_shutdown_complete ~xs (x: device) =
+    if is_qdisk x then
+      safe_rm ~xs (Hotplug.path_written_by_hotplug_scripts x);
     if !Xenopsd.run_hotplug_scripts
     then backend_closed ~xs x
     else unplug_watch ~xs x

--- a/xc/hotplug.ml
+++ b/xc/hotplug.ml
@@ -136,18 +136,12 @@ let wait_for_plug (task: Xenops_task.task_handle) ~xs (x: device) =
 let wait_for_unplug (task: Xenops_task.task_handle) ~xs (x: device) =
   debug "Hotplug.wait_for_unplug: %s" (string_of_device x);
   try
-    let path = path_written_by_hotplug_scripts x in
-    let qdisk = Astring.String.is_infix ~affix:"backend/qdisk/" path in
-    if not qdisk then begin
-      Stats.time_this "udev backend remove event"
-        (fun () ->
-           let (_: bool) = cancellable_watch (Device x) [ Watch.map (fun _ -> ()) (Watch.key_to_disappear path) ] [] task ~xs ~timeout:!Xenopsd.hotplug_timeout () in
-           ()
-        )
-    end else begin
-      debug "Hotplug.wait_for_unplug: removing qdisk path %s instead of waiting" path;
-      xs.Xs.rm path
-    end;
+    Stats.time_this "udev backend remove event" 
+      (fun () ->
+         let path = path_written_by_hotplug_scripts x in
+         let (_: bool) = cancellable_watch (Device x) [ Watch.map (fun _ -> ()) (Watch.key_to_disappear path) ] [] task ~xs ~timeout:!Xenopsd.hotplug_timeout () in
+         ()
+      );
     debug "Synchronised ok with hotplug script: %s" (string_of_device x)
   with Watch.Timeout _ ->
     raise (Device_timeout x)


### PR DESCRIPTION
xenopsd was unplugging the VBD too soon for qemu-dp backends (SMAPIv3/GFS2), while the guest was still using it, even if the guest set the error field in xenopsd saying 'Device in use'.
On a clean shutdown of a device we can only unplug it once both the frontend and backend have reached state Closed (6), otherwise the PV ring can become corrupt because the frontend/backend will be confused about the device's state (xenopsd deletes the xenstore key, so the state would be unknown).

See commit messages for more details. This passed the original test that found CA-314170 (it now claims 'Device in use' and refuses to unplug), which revealed a bug in the testcase, and it also passes the fixed testcase. The GFS2 functional suite also passed.

The problem with my previous pull request was that it didn't handle hard shutdown correctly.