### PR TITLE
CA-309841: allow using PV drivers for CDROMs again

### DIFF
--- a/scripts/block
+++ b/scripts/block
@@ -21,19 +21,12 @@ add)
         params=$(readlink -f $params || echo $params)
         frontend="/local/domain/${DOMID}/device/${TYPE}/${DEVID}"
         syslog "${XENBUS_PATH}: add params=\"${params}\""
-        # We don't have PV drivers for CDROM devices, so we prevent blkback
-        # from opening the physical-device
-        xenstore-exists "${PRIVATE}/no-physical-device"
-        if [ $? -ne 0 ]; then
-          physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
-          syslog "${XENBUS_PATH}: physical-device=${physical_device}"
-          xenstore-exists "${XENBUS_PATH}/physical-device"
-          if [ $? -eq 1 ]; then
-			syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
-            xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
-          fi
-        else
-          syslog "${XENBUS_PATH}: not writing physical-device because no-physical-device is present"
+        physical_device=$(/usr/bin/stat --format="%t:%T" "${params}")
+        syslog "${XENBUS_PATH}: physical-device=${physical_device}"
+        xenstore-exists "${XENBUS_PATH}/physical-device"
+        if [ $? -eq 1 ]; then
+                syslog "${XENBUS_PATH}: writing physical-device=${physical_device}"
+                xenstore-write "${XENBUS_PATH}/physical-device" "${physical_device}"
         fi
         xenstore-write "${HOTPLUG}/hotplug" "online"
         xenstore-write "${HOTPLUG_STATUS}" "connected"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -576,11 +576,6 @@ module Vbd_Common = struct
       "mode", string_of_mode x.mode;
       "params", x.params;
     ]);
-    (* We don't have PV drivers for HVM guests for CDROMs. We prevent
-       blkback from successfully opening the device since this can
-       prevent qemu CD eject (and subsequent vdi_deactivate) *)
-    let no_phys_device =
-      if hvm && (x.dev_type = CDROM) then ["no-physical-device", ""] else [] in
 
     Opt.iter
       (fun protocol ->
@@ -589,9 +584,8 @@ module Vbd_Common = struct
 
     let back = Hashtbl.fold (fun k v acc -> (k, v) :: acc) back_tbl [] in
     let front = Hashtbl.fold (fun k v acc -> (k, v) :: acc) front_tbl [] in
-    let priv = no_phys_device @ x.extra_private_keys in
 
-    Generic.add_device ~xs device back front priv [];
+    Generic.add_device ~xs device back front x.extra_private_keys [];
     device
 
   let add_wait (task: Xenops_task.task_handle) ~xc ~xs device =


### PR DESCRIPTION
https://github.com/xapi-project/blktap/commit/a7832564b4d7e540d2d5a85e2556f571b7f9d89b has fixed the bug in blktap that required reverting this change, so we can now put this change back in.
This is required for UEFI booted guests to be able to use PV drivers in the firmware, which is required if you want to have multiple USB boot devices (as required by SVVP tests).

We were not able to reproduce the original failure in XenRT after the blktap fix.