### PR TITLE
CA-314715: Pass domid argument to hooked scripts

### DIFF
--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -46,14 +46,14 @@ let reason__none = "none"
 let exitcode_log_and_continue = 1
 (* all other exit codes cause xapi to abort operation and raise XAPI_HOOK_FAILED api exception *)
 
-let list_individual_hooks ~script_name = 
+let list_individual_hooks ~script_name =
   let script_dir = hooks_dir^script_name^"/" in
-  if (try Unix.access script_dir [Unix.F_OK]; true with _ -> false) 
+  if (try Unix.access script_dir [Unix.F_OK]; true with _ -> false)
   then
     let scripts = Sys.readdir script_dir in
     Array.stable_sort compare scripts;
     scripts
-  else [| |]      
+  else [| |]
 
 let execute_hook ~script_name ~args ~reason =
   let args = args @ [ "-reason"; reason ] in

--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -74,25 +74,6 @@ let execute_vm_hook ~script_name ~id ~reason =
     )
     scripts
 
-let vm_pre_destroy ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_pre_destroy ~reason ~id
-let vm_pre_migrate ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_pre_migrate ~reason ~id
-let vm_post_migrate ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_post_migrate ~reason ~id
-let vm_pre_suspend ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_pre_suspend ~reason ~id
-let vm_pre_start ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_pre_start ~reason ~id
-let vm_pre_reboot ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_pre_reboot ~reason ~id
-let vm_pre_resume ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_pre_resume ~reason ~id
-let vm_post_resume ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_post_resume ~reason ~id
-let vm_post_destroy ~reason ~id =
-  execute_vm_hook ~script_name:scriptname__vm_post_destroy ~reason ~id
-
 type script =
   | VM_pre_destroy
   | VM_pre_migrate

--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -41,6 +41,9 @@ let reason__migrate_source = "source" (* passed to pre-migrate hook on source ho
 let reason__migrate_dest   = "destination" (* passed to post-migrate hook on destination host *)
 let reason__none = "none"
 
+(* Names of arguments *)
+let arg__vmdomid = "-vmdomid"
+
 (* Exit codes: *)
 (* success = 0 *)
 let exitcode_log_and_continue = 1

--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -55,8 +55,8 @@ let list_individual_hooks ~script_name =
     scripts
   else [| |]
 
-let execute_hook ~script_name ~args ~reason =
-  let args = args @ [ "-reason"; reason ] in
+let execute_vm_hook ~script_name ~id ~reason =
+  let args = ["-vmuuid"; id; "-reason"; reason ] in
   let scripts = list_individual_hooks ~script_name in
 
   let script_dir = hooks_dir^script_name^"/" in
@@ -73,9 +73,6 @@ let execute_hook ~script_name ~args ~reason =
            raise (Xenopsd_error (Errors.Hook_failed(script_name^"/"^script, reason, stdout, string_of_int i)))
     )
     scripts
-
-let execute_vm_hook ~id ~reason =
-  execute_hook ~args:[ "-vmuuid"; id ] ~reason
 
 let vm_pre_destroy ~reason ~id =
   execute_vm_hook ~script_name:scriptname__vm_pre_destroy ~reason ~id

--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -58,8 +58,8 @@ let list_individual_hooks ~script_name =
     scripts
   else [| |]
 
-let execute_vm_hook ~script_name ~id ~reason =
-  let args = ["-vmuuid"; id; "-reason"; reason ] in
+let execute_vm_hook ~script_name ~id ~reason ~extra_args =
+  let args = ["-vmuuid"; id; "-reason"; reason ] @ extra_args in
   let scripts = list_individual_hooks ~script_name in
 
   let script_dir = hooks_dir^script_name^"/" in

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1204,7 +1204,8 @@ let rec perform_atomic ~progress_callback ?subtask:_ ?result (op: atomic) (t: Xe
     B.VIF.set_active t (VIF_DB.vm_of id) (VIF_DB.read_exn id) b;
     VIF_DB.signal id
   | VM_hook_script(id, script, reason) ->
-    Xenops_hooks.vm ~script ~reason ~id
+    let extra_args = B.VM.get_hook_args id in
+    Xenops_hooks.vm ~script ~reason ~id ~extra_args
   | VBD_plug id ->
     debug "VBD.plug %s" (VBD_DB.string_of_id id);
     B.VBD.plug t (VBD_DB.vm_of id) (VBD_DB.read_exn id);
@@ -1662,7 +1663,8 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
 
       let module B = (val get_backend () : S) in
       B.VM.assert_can_save vm;
-      Xenops_hooks.vm ~script:Xenops_hooks.VM_pre_migrate ~reason:Xenops_hooks.reason__migrate_source ~id;
+      let extra_args = B.VM.get_hook_args id in
+      Xenops_hooks.vm ~script:Xenops_hooks.VM_pre_migrate ~reason:Xenops_hooks.reason__migrate_source ~id ~extra_args;
 
       let module Remote = Xenops_interface.XenopsAPI(Idl.Exn.GenClient(struct let rpc = Xcp_client.xml_http_rpc ~srcstr:"xenops" ~dststr:"dst_xenops" (fun () -> vmm.vmm_url) end)) in
       let regexp = Re.Pcre.regexp id in

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1687,7 +1687,7 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
       let (_: unit) = perform_atomic ~subtask:(string_of_atomic atomic) ~progress_callback:(fun _ -> ()) atomic t in
 
       (* Waiting here is not essential but adds a degree of safety
-         			 * and reducess unnecessary memory copying. *)
+       * and reducess unnecessary memory copying. *)
       (try B.VM.wait_ballooning t vm with Xenopsd_error Ballooning_timeout_before_migration -> ());
 
       (* Find out the VM's current memory_limit: this will be used to allocate memory on the receiver *)

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1662,7 +1662,7 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
 
       let module B = (val get_backend () : S) in
       B.VM.assert_can_save vm;
-      Xenops_hooks.vm_pre_migrate ~reason:Xenops_hooks.reason__migrate_source ~id;
+      Xenops_hooks.vm ~script:Xenops_hooks.VM_pre_migrate ~reason:Xenops_hooks.reason__migrate_source ~id;
 
       let module Remote = Xenops_interface.XenopsAPI(Idl.Exn.GenClient(struct let rpc = Xcp_client.xml_http_rpc ~srcstr:"xenops" ~dststr:"dst_xenops" (fun () -> vmm.vmm_url) end)) in
       let regexp = Re.Pcre.regexp id in

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -96,6 +96,7 @@ module type S = sig
     val run_script: Xenops_task.task_handle -> Vm.t -> string -> Rpc.t
     val set_domain_action_request: Vm.t -> domain_action_request option -> unit
     val get_domain_action_request: Vm.t -> domain_action_request option
+    val get_hook_args: Vm.id -> string list
 
     val generate_state_string: Vm.t -> string
     val get_internal_state: (string * string) list -> (string * Network.t) list -> Vm.t -> string

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -402,6 +402,7 @@ module VM = struct
   let run_script _ _vm _script = Rpc.Dict [("rc", Rpc.Int 0L); ("stdout", Rpc.String ""); ("stderr", Rpc.String "")]
   let set_domain_action_request _vm _request = ()
   let get_domain_action_request vm = Mutex.execute m (get_domain_action_request_nolock vm)
+  let get_hook_args (vm_uuid: Vm.id) = []
 
   let generate_state_string _vm = ""
   let get_internal_state vdi_map vif_map vm =

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -172,13 +172,13 @@ let do_set_xsdata_nolock vm xsdata () =
 let do_set_vcpus_nolock vm n () =
   let d = DB.read_exn vm.Vm.id in
   if not d.Domain.built || (d.Domain.hvm && not(d.Domain.qemu_created))
-  then raise (Xenopsd_error Domain_not_built)	
+  then raise (Xenopsd_error Domain_not_built)
   else DB.write vm.Vm.id { d with Domain.vcpus = n }
 
 let do_set_shadow_multiplier_nolock vm m () =
   let d = DB.read_exn vm.Vm.id in
   if not d.Domain.built || (d.Domain.hvm && not(d.Domain.qemu_created))
-  then raise (Xenopsd_error Domain_not_built)	
+  then raise (Xenopsd_error Domain_not_built)
   else DB.write vm.Vm.id { d with Domain.shadow_multiplier = m }
 
 let do_set_memory_dynamic_range_nolock vm min max () =
@@ -412,7 +412,7 @@ module VM = struct
   let set_internal_state vm s =
     match Rpcmarshal.unmarshal Domain.t.Rpc.Types.ty (Jsonrpc.of_string s) with
     | Ok s -> DB.write vm.Vm.id s
-    | Error (`Msg m) -> raise (Xenopsd_error (Internal_error (Printf.sprintf "Failed to unmarshal Domain.t: %s" m))) 
+    | Error (`Msg m) -> raise (Xenopsd_error (Internal_error (Printf.sprintf "Failed to unmarshal Domain.t: %s" m)))
 
   let wait_ballooning _ _ = ()
 

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -80,6 +80,7 @@ module VM = struct
   let run_script _ _ _ = unimplemented "VM.run_script"
   let set_domain_action_request _ _ = ()
   let get_domain_action_request _ = None
+  let get_hook_args _ = []
   let generate_state_string _ = ""
   let get_internal_state _ _ _ = ""
   let set_internal_state _ _ = ()

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2193,6 +2193,15 @@ module VM = struct
            end
       )
 
+  (* Some hook scripts need to know the domid to avoid confusion when migrating
+   * vms, now that the behaviour concerning uuids has changed *)
+  let get_hook_args vm_uuid =
+    with_xc_and_xs (fun xc xs ->
+      match domid_of_uuid ~xc ~xs (uuid_of_string vm_uuid) with
+      | None       -> []
+      | Some domid -> [Xenops_hooks.arg__vmdomid; string_of_int domid]
+    )
+
   let get_internal_state vdi_map vif_map vm =
     let state = DB.read_exn vm.Vm.id in
     state.VmExtra.persistent |> rpc_of VmExtra.persistent_t |> Jsonrpc.to_string


### PR DESCRIPTION
Because of the current dance of uuids during migration some scripts get confused and need the domids to properly work.