### PR TITLE
CP-31060: Support multiple vGPUs in resuming.

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -143,7 +143,7 @@ module type S = sig
     val get_device_action_request: Vm.id -> Vif.t -> device_action_request option
   end
   module VGPU : sig
-    val start: Xenops_task.task_handle -> Vm.id -> Vgpu.t -> bool -> unit
+    val start: Xenops_task.task_handle -> Vm.id -> Vgpu.t list -> bool -> unit
     val set_active: Xenops_task.task_handle -> Vm.id -> Vgpu.t -> bool -> unit
     val get_state: Vm.id -> Vgpu.t -> Vgpu.state
   end

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2987,12 +2987,8 @@ module Dm = struct
       let state_path = Printf.sprintf "/local/domain/%d/vgpu/state" domid in
       let cancel = Cancel_utils.Vgpu domid in
       if not (Vgpu.is_running ~xs domid) then begin
-        (* The below line does nothing if the device is already bound to the
-           			 * nvidia driver. We rely on xapi to refrain from attempting to run
-           			 * a vGPU on a device which is passed through to a guest. *)
-        debug "start_vgpu: got VGPU with physical pci address %s"
-          (Xenops_interface.Pci.string_of_address pci);
-        PCI.bind [pci] PCI.Nvidia;
+        let pcis = List.map (fun x -> x.physical_pci_address) vgpus in
+          PCI.bind pcis PCI.Nvidia;
         let module Q = (val Backend.of_profile profile) in
         let device = Q.Vgpu.device ~index:0 in
         let args = vgpu_args_of_nvidia domid vcpus vgpu pci restore device in
@@ -3116,9 +3112,9 @@ module Dm = struct
   let restore (task: Xenops_task.task_handle) ~xs ~dm ?timeout info domid =
     __start task ~xs ~dm ?timeout Restore info domid
 
-  let restore_vgpu (task: Xenops_task.task_handle) ~xs domid vgpu vcpus profile =
+  let restore_vgpu (task: Xenops_task.task_handle) ~xs domid vgpus vcpus profile =
     debug "Called Dm.restore_vgpu";
-    start_vgpu ~xs task ~restore:true domid [vgpu] vcpus profile
+    start_vgpu ~xs task ~restore:true domid vgpus vcpus profile
 
   let suspend_varstored (task: Xenops_task.task_handle) ~xs domid =
     debug "Called Dm.suspend_varstored (domid=%d)" domid;

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -287,7 +287,7 @@ sig
   val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
   val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
   val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
-  val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> Profile.t  -> unit
+  val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t list -> int -> Profile.t  -> unit
   val suspend_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid -> string
   val restore_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> efivars:string -> Xenctrl.domid -> unit
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2334,7 +2334,7 @@ module VGPU = struct
 
   let id_of vgpu = snd vgpu.id
 
-  let start task vm vgpu saved_state =
+  let start task vm vgpus saved_state =
     on_frontend
       (fun _ xs frontend_domid _ ->
          let vmextra = DB.read_exn vm in
@@ -2348,7 +2348,7 @@ module VGPU = struct
          let profile = match vmextra.VmExtra.persistent.profile with
            | None -> Device.Profile.Qemu_upstream_compat
            | Some p -> p in
-         Device.Dm.restore_vgpu task ~xs frontend_domid vgpu vcpus profile
+         Device.Dm.restore_vgpu task ~xs frontend_domid vgpus vcpus profile
       ) vm
 
   let active_path vm vgpu = Printf.sprintf "/vm/%s/devices/vgpu/%s" vm (snd vgpu.Vgpu.id)


### PR DESCRIPTION
Change the type of VGPU_start atomic to support multiple vGPUs in resuming.

Signed-off-by: Michael Z <michael.zhao@citrix.com>