### PR TITLE
CA-318579 write serial device to xenstore for HVM

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1640,6 +1640,44 @@ module Vusb = struct
 
 end
 
+module Serial : sig
+  val update_xenstore: xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+end = struct
+  let tty_prefix     = "pty:"
+  let tty_path domid = Printf.sprintf "/local/domain/%d/serial/0/tty" domid
+  let strip n str    = String.sub str n (String.length str - n)
+
+  let is_serial0 device =
+    device.Qmp.label = "serial0"
+    && Astring.String.is_prefix tty_prefix device.Qmp.filename
+
+  let find_serial0 domid =
+    match qmp_send_cmd domid Qmp.Query_chardev with
+    | Qmp.(Char_devices devices) ->
+        List.find_opt is_serial0 devices
+    | other ->
+        warn "Unexpected QMP result for domid %d query-chardev" domid;
+        None
+
+  (** query qemu for the serial console and write it to xenstore. Only
+   *  write path for a real console, not a file or socket path.
+   *  CA-318579
+   *)
+  let update_xenstore ~xs domid =
+    if not @@ Qemu.is_running ~xs domid then begin
+      let msg = sprintf "Qemu not running for domain %d (%s)" domid __LOC__ in
+      raise (Xenopsd_error (Internal_error msg))
+    end;
+    match find_serial0 domid with
+    | Some device ->
+        let path = strip (String.length tty_prefix) device.Qmp.filename in
+        xs.Xs.write (tty_path domid) path
+    | None        -> debug "no serial device for domain %d found" domid
+    | exception e ->
+        debug "Can't probe serial0 device for domid %d: %s"
+          domid (Printexc.to_string e)
+end
+
 let can_surprise_remove ~xs (x: device) = Generic.can_surprise_remove ~xs x
 
 (** Dm_Common contains the private Dm functions that are common between the qemu profile backends. *)

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -298,6 +298,10 @@ module Backend: sig
   val init : unit -> unit
 end
 
+module Serial : sig
+  val update_xenstore: xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
+end
+
 module Vusb :
 sig
   val vusb_plug : xs:Xenstore.Xs.xsh -> privileged:bool -> domid:Xenctrl.domid -> id:string -> hostbus:string -> hostport: string -> version: string-> unit

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1643,7 +1643,8 @@ module VM = struct
             debug "Ignoring request for PV VNC in stubdom (would require qemu-trad)"
           | Vm.HVM { Vm.qemu_stubdom = false } ->
             (if saved_state then Device.Dm.restore else Device.Dm.start)
-              task ~xs ~dm:qemu_dm info di.Xenctrl.domid
+              task ~xs ~dm:qemu_dm info di.Xenctrl.domid;
+            Device.Serial.update_xenstore ~xs di.Xenctrl.domid
           | Vm.PV _ | Vm.PVinPVH _ -> assert false
         ) (create_device_model_config vm vmextra vbds vifs vgpus vusbs);
       match vm.Vm.ty with


### PR DESCRIPTION
From XSI-353, since the upgrade to QEMU upstream the ability to access
the serial console of an HVM guest using xl console or xenconsole has
been broken.

This commit adds code to query QEMU for the path of the serial device
and writing it to xenstore:

  /local/domain/<domid>/serial/0/tty <ptypath>

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>