### PR TITLE
CP-31321: Support extra_args for vGPU configuration

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1874,11 +1874,14 @@ module Dm_Common = struct
       List.map (fun x ->
           match x.implementation with
           | Nvidia _conf ->
-             Printf.sprintf "--device=%s,%s,%s,%s"
-               (Xenops_interface.Pci.string_of_address x.physical_pci_address)
-               _conf.type_id
-               (get_pci_string _conf.virtual_pci_address)
-               _conf.uuid
+            Printf.sprintf "--device=%s"
+              ([(Xenops_interface.Pci.string_of_address x.physical_pci_address);
+                _conf.type_id;
+                (get_pci_string _conf.virtual_pci_address);
+                _conf.uuid;
+                _conf.extra_args]
+               |> List.filter (fun str -> str <> "")
+               |> String.concat ",")
           | _ -> "")
         (List.sort virtual_pci_address_compare vgpus) in
     let suspend_file = sprintf demu_save_path domid in


### PR DESCRIPTION
Signed-off-by: Lin Liu <lin.liu@citrix.com>

As titled, add support for extra_args for vgpu.

Customer can set extra args for the vgpu by command 
```xe vgpu-param-set uuid=xxxx extra_args="key1=v1,key2=v2"```
This is very similer to the previous verion of 
``` xe vm-param-set uuid=xxx platform:vgpu_extra_args="key1=v1,key2=v2"```