### PR TITLE
CA-320215: use xl pci attach for PV guests

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1268,7 +1268,7 @@ module PCI = struct
 
   let add ~xc ~xs ~hvm pcidevs domid =
     try
-      if !Xenopsd.use_old_pci_add then
+      if !Xenopsd.use_old_pci_add or (not hvm) then
         add_xl (List.map (fun (a,_) -> a) pcidevs) domid
       else
         List.iter (_pci_add ~xc ~xs ~hvm domid) pcidevs;


### PR DESCRIPTION
The new code in xenopsd only supports HVM guests.
It is unclear whether anyone would still be using PCI passthrough to PV guests, we haven't explicitly documented that it is not supported, so add it back and fall back to the old code for it.