### PR TITLE
CA-320361: use device-id if it exists

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2192,7 +2192,10 @@ module Dm_Common = struct
               ; "subvendor_id=0x5853"
               ; sprintf"subsystem_id=0x%04x" device_id ]
             | None -> []
-          else []
+          else match info.xen_platform with
+            | Some (device_id, _) ->
+              [ sprintf "device-id=0x%04x" device_id ]
+            | None -> []
       ])
     ]
 


### PR DESCRIPTION
For compatibility with old tools and Naples.
device-id is still 2 in the template (and in xenstore) for UEFI,
but not in qemu, which confuses things.

The template can be updated to remove the device-id in the future,
however it cannot be done yet because the old tools fail with device-id
1.