### PR TITLE
CA-320189: miss "-vgpu" argument for multiple vGPUs

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -706,6 +706,7 @@ let xenguest_args_hvm ~domid ~store_port ~store_domid ~console_port ~console_dom
   ]
   @ (vgpus |> function
     | [Xenops_interface.Vgpu.{implementation = Nvidia _}] -> ["-vgpu"]
+    | Xenops_interface.Vgpu.{implementation = Nvidia _} :: _ -> ["-vgpu"]
     | _ -> []
   )
   @ xenguest_args_base ~domid ~store_port ~store_domid ~console_port ~console_domid ~memory


### PR DESCRIPTION
xenguest "-vgpu" argument is added for single vGPU, it should also be
added for multiple vGPUs case. This fixs system hang with 4 vGPUs.

Signed-off-by: Talons Lee <xin.li@citrix.com>