### PR TITLE
CA-322655: only replace reboots with shutdown when throttling a VM th…

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1907,7 +1907,9 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
           (* A VM which crashes too quickly should be shutdown *)
           if run_time < 120. then begin
             warn "VM %s crashed too quickly after start (%.2f seconds); shutting down" id run_time;
-            [ Vm.Shutdown ]
+            vm.Vm.on_crash |> List.map (function
+                | Vm.Start -> Vm.Shutdown
+                | other -> other)
           end else vm.Vm.on_crash
         | Some Needs_suspend ->
           warn "VM %s has unexpectedly suspended" id;


### PR DESCRIPTION
…at crashes too often

If a VM crashes too often we do not want to endlessly restart it, and
have to give up at some point.
However if the VM is set to actions-after-crash=preserve or
coredump-and-destroy then we should be fine executing those actions,
since those are the ones needed to actually debug why a VM is crashing.

Here are all the crash behaviours from xapi:
```
    let on_crash_behaviour = function
      | `preserve -> [ Vm.Pause ]
      | `coredump_and_restart -> [ Vm.Coredump; Vm.Start ]
      | `coredump_and_destroy -> [ Vm.Coredump; Vm.Shutdown ]
      | `restart
      | `rename_restart -> [ Vm.Start ]
      | `destroy -> [ Vm.Shutdown ] in
```

So just replace Vm.Start with Vm.Shutdown to throttle but keep all other
actions intact.

I haven't actually tested this yet