### PR TITLE
CA-322786 improve ionice handling

### DIFF
--- a/lib/ionice.ml
+++ b/lib/ionice.ml
@@ -37,13 +37,10 @@ let of_class_param_exn cls param =
     | "0" -> Highest
     | x -> Other (int_of_string x) in
   match cls with
-  | "idle"
-  | "3" -> Idle
-  | "realtime"
-  | "1" -> RealTime param
-  | "best-effort"
-  | "2" -> BestEffort param
-  | _ -> raise Not_found (* caught below *)
+  | "idle"        | "3" -> Idle
+  | "realtime"    | "1" -> RealTime param
+  | "best-effort" | "2" -> BestEffort param
+  | _                   -> raise Not_found (* caught below *)
 
 exception Parse_failed of string
 
@@ -51,8 +48,10 @@ let parse_result_exn s : qos_scheduler option =
   try
     match Stdext.Xstringext.String.(split_f isspace s) with
     | [ cls_colon; "prio"; param ] ->
-      let cls = String.sub cls_colon 0 (String.length cls_colon - 1) in
-      Some (of_class_param_exn cls param)
+      ( match String.sub cls_colon 0 (String.length cls_colon - 1) with
+      | "unknown" | "none" -> None
+      | cls                -> Some (of_class_param_exn cls param)
+      )
     | _ ->
       raise (Parse_failed s)
   with _ ->

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2762,8 +2762,6 @@ module VBD = struct
       (fun xc xs ->
          try
            let (device: Device_common.device) = device_by_id xc xs vm (device_kind_of ~xs vbd) (id_of vbd) in
-           let qos_target = get_qos xc xs vm vbd device in
-
            let backend_present =
              if Device.Vbd.media_is_ejected ~xs device
              then None
@@ -2775,7 +2773,7 @@ module VBD = struct
              Vbd.active = true;
              plugged = true;
              backend_present;
-             qos_target = qos_target
+             qos_target = get_qos xc xs vm vbd device
            }
          with
          | (Xenopsd_error (Does_not_exist(_, _)))


### PR DESCRIPTION
    1. Fix parsing output from ionice(1) by recognising scheduling classes
       "none" and "unknown". There is no clear description in the ionice
       manual page what these mean but they are emitted by ionice
       nonetheless. This commit commit accepts these but returns None.
    
    2. Don't call ionice when the result isn't used.
