### PR TITLE
CA-322749: Make toolstack work with old Nvidia host drivers

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -46,8 +46,6 @@ let feature_flags_path = ref "/etc/xenserver/features.d"
 
 let pvinpvh_xen_cmdline = ref "pv-shim"
 
-let nvidia_compat_lookup_file = ref "/var/run/nonpersistent/xapi/nvidia_compat_lookup"
-
 let options = [
   "queue", Arg.Set_string Xenops_interface.queue_name, (fun () -> !Xenops_interface.queue_name), "Listen on a specific queue";
   "sockets-path", Arg.Set_string sockets_path, (fun () -> !sockets_path), "Directory to create listening sockets";
@@ -70,7 +68,6 @@ let options = [
   "action-after-qemu-crash", Arg.String (fun x -> action_after_qemu_crash := if x="" then None else Some x), (fun () -> match !action_after_qemu_crash with None->"" | Some x->x), "Action to take for VMs if QEMU crashes or dies unexpectedly: pause, poweroff. Otherwise, no action (default).";
   "feature-flags-path", Arg.Set_string feature_flags_path, (fun () -> !feature_flags_path), "Directory of experimental feature flags";
   "pvinpvh-xen-cmdline", Arg.Set_string pvinpvh_xen_cmdline, (fun () -> !pvinpvh_xen_cmdline), "Command line for the inner-xen for PV-in-PVH guests";
-  "nvidia-compat-lookup-file", Arg.Set_string nvidia_compat_lookup_file, (fun () -> !nvidia_compat_lookup_file), "Path to the file with NVidia vGPU compat data written by xapi";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1983,22 +1983,6 @@ module Dm_Common = struct
     ; fd_map = []
     }
 
-  let nvidia_compat_lookup config_file =
-    let rec find = function
-      | [] -> raise Not_found
-      | conf :: others ->
-        match String.split_on_char ' ' conf with
-        | [cf; type_id] when cf = config_file -> type_id
-        | _ -> find others
-    in
-    try
-      Unixext.string_of_file !Xenopsd.nvidia_compat_lookup_file
-      |> String.split_on_char '\n'
-      |> find
-    with e ->
-      error "nvidia_compat_lookup for %s failed with %s" config_file (Printexc.to_string e);
-      raise (Xenopsd_error (Internal_error (Printf.sprintf "NVidia vGPU compat metadata lookup failed (%s)" __LOC__)))
-
   let vgpu_args_of_nvidia domid vcpus vgpus restore =
     let open Xenops_interface.Vgpu in
     let virtual_pci_address_compare vgpu1 vgpu2 =


### PR DESCRIPTION
Delete nvidia_compat_lookup_file as now demu keep backward compatibility

Signed-off-by: Lin Liu <lin.liu@citrix.com>