### PR TITLE
CA-322498: Ensure that QEMU receives the max-memory value used for do…

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1403,8 +1403,14 @@ module VM = struct
           | Vgpu, vgpus -> Device.Dm.Vgpu vgpus
           | _ -> raise (Xenopsd_error (Internal_error "Invalid graphics mode"))
         in
+        let memory =
+          (* This is the same as is passed to xenguest at build time, with -mem_max_mib *)
+          (* build_info.memory_max is set to static_max_kib in build_domain_exn *)
+          let static_max_mib = Memory.mib_of_kib_used build_info.Domain.memory_max in
+          Memory.kib_of_mib (Memory.HVM.build_max_mib static_max_mib video_mib)
+        in
         let open Device.Dm in {
-          memory = build_info.Domain.memory_max;
+          memory;
           boot = boot_order;
           firmware = firmware;
           serial = Some serial;


### PR DESCRIPTION
…main build

QEMU currently gets build_info.Domain.memory_max, which is equal to static-max.
However, the value that is given to xenguest as `-mem_max_mib` to build the
domain is equal to static-max minus video memory. So QEMU is getting passed too
large a number, which can lead to it crashing due to DMA requests for memory
locations that the guest does not actually own.

This patch ensures that QEMU is given the same memory size as xenguest. Note
that there was no problem on qemu-trad, even though it received the same memory
parameter: qemu-trad did not actually use it. We also don't have to worry about
live-migration across versions, where the destination's QEMU is given a lower
memory size, owing to the way this parameter is used within QEMU (according to
the QEMU experts).

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>