### PR TITLE
CA-233384: move qemu save/restore to tmpfs in /var/run

### DIFF
--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -342,8 +342,8 @@ let protocol_of_string = function
   | s            -> raise (Unknown_device_protocol s)
 
 
-let qemu_save_path : (_, _, _) format = "/var/lib/xen/qemu-save.%d"
-let qemu_restore_path : (_, _, _) format = "/var/lib/xen/qemu-resume.%d"
+let qemu_save_path : (_, _, _) format = "/var/run/xen/qemu-save.%d"
+let qemu_restore_path : (_, _, _) format = "/var/run/xen/qemu-resume.%d"
 
 let demu_save_path : (_, _, _) format = "/var/lib/xen/demu-save.%d"
 let demu_restore_path : (_, _, _) format = "/var/lib/xen/demu-resume.%d"


### PR DESCRIPTION
This does not move the chroot path, because this might contain core dumps
that could be large.
It also does not move the demu save path, since GPU data can be very large.

The qemu restore record is limited to 1MiB in xenopsd.

A stress test and Ring3 BST has passed.