### PR TITLE
CA-323893: Catch exceptions in Device.PV_Vnc.is_cmdline_valid

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1056,9 +1056,8 @@ module PV_Vnc = struct
         |> Unixext.string_of_file
         |> Stdext.Xstringext.String.split '\000'
       in
-      if (List.mem !Xc_resources.vncterm cmdline) && (List.mem (vnc_console_path domid) cmdline)
-      then true
-      else false
+      (List.mem !Xc_resources.vncterm cmdline) &&
+      (List.mem (vnc_console_path domid) cmdline)
     with _ -> false
 
   let is_vncterm_running ~xs domid =

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1050,14 +1050,16 @@ module PV_Vnc = struct
   (* Look up the commandline args for the vncterm pid; *)
   (* Check that they include the vncterm binary path and the xenstore console path for the supplied domid. *)
   let is_cmdline_valid domid pid =
-    let cmdline =
-      Printf.sprintf "/proc/%d/cmdline" pid
-      |> Unixext.string_of_file
-      |> Stdext.Xstringext.String.split '\000'
-    in
-    if (List.mem !Xc_resources.vncterm cmdline) && (List.mem (vnc_console_path domid) cmdline)
-    then true
-    else false
+    try
+      let cmdline =
+        Printf.sprintf "/proc/%d/cmdline" pid
+        |> Unixext.string_of_file
+        |> Stdext.Xstringext.String.split '\000'
+      in
+      if (List.mem !Xc_resources.vncterm cmdline) && (List.mem (vnc_console_path domid) cmdline)
+      then true
+      else false
+    with _ -> false
 
   let is_vncterm_running ~xs domid =
     match pid ~xs domid with


### PR DESCRIPTION
In rare cases, an exception raised from this function during a VM reboot can
cause a call to `VM.stat` to fail. If this happens, then xapi may conclude that
the VM is halted, while it is actually rebooting. This is a problem, because
the VM will be marked as halted rather than running after the reboot.

There is a mechanism in xenopsd that always marks a VM as running, in replies
to `VM.stat`, while it is being rebooted, even when the VM is actually down at
the time. In this case it did not, due to the exception, and xapi concluded "VM
state missing" and reset the power-state.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>