### PR TITLE
maintenance: remove bisect_ppx preprocessing

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -12,6 +12,6 @@
  (flags :standard -warn-error +a-3)
  (libraries c_stubs stdext threads threads.posix uuidm xmlm cohttp uri rpclib.core forkexec fd-send-recv xapi-idl xapi-idl.xen xapi-idl.storage xapi-idl.updates xapi-idl.varstore.privileged sexplib ppx_sexp_conv.runtime-lib uutf core re re.pcre)
  (preprocess
-  (pps ppx_deriving_rpc ppx_sexp_conv bisect_ppx -conditional)
+  (pps ppx_deriving_rpc ppx_sexp_conv)
  )
 )

--- a/test/dune
+++ b/test/dune
@@ -2,7 +2,7 @@
  (name test)
  (libraries alcotest xenopsd)
  (preprocess
-  (pps ppx_deriving_rpc ppx_sexp_conv bisect_ppx -conditional)
+  (pps ppx_deriving_rpc ppx_sexp_conv)
  )
 )
 

--- a/xc/dune
+++ b/xc/dune
@@ -10,7 +10,7 @@
   mtime.clock.os ppx_sexp_conv.runtime-lib re re.pcre)
 
  (preprocess
-  (pps ppx_deriving_rpc ppx_sexp_conv bisect_ppx -conditional)
+  (pps ppx_deriving_rpc ppx_sexp_conv)
  )
 )
 


### PR DESCRIPTION
It can be added again once dune properly supports bisect_ppx.