### PR TITLE
CP-32099 pass -nomigrate to xenguest

### DIFF
--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -109,6 +109,7 @@ type build_info = {
   kernel: string;       (* in hvm case, point to hvmloader *)
   vcpus: int;           (* vcpus max *)
   priv: builder_spec_info;
+  nomigrate: bool       (* flag passed to xenguest *)
 }
 val typ_of_build_info: build_info Rpc.Types.typ
 val build_info: build_info Rpc.Types.def


### PR DESCRIPTION
Previously xenguest would calculate itself whether a domain was
migratable or not. However, it no longer has enough information to do
this so the toolstack should do it instead.o

The -nomigrate flag is passed to xenguest based on the expression below:
when it is explicitly set in the platform data or when any PCI device
(which is not an NVIDIA SR-IOV GPU) is passed trough.

    let nomigrate vm =
      let platformdata = vm.Xenops_interface.Vm.platformdata in
        Platform.is_true ~key:"nomigrate" ~platformdata ~default:false
        || Platform.is_true ~key:"nested-virt" ~platformdata ~default:false
        || Platform.is_true ~key:"exp-nested-hvm" ~platformdata ~default:false
        || extras <> [] (* contains PCI pass-trough devices *)

Operation VM_start triggers VM_create and VM_build, which calls
xenguest. Its argument list ist built based on build_info value. This
commit extends this type to capture the nomigrate flag.

The code needs to deal with a legacy case: resuming a VM that was
suspended on a very old release. We assume here that no PCI pass-through
could have existed at that time and use nomigrate=false.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>