### PR TITLE
CP-32111: Make shim_mem configurable

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1485,7 +1485,14 @@ module VM = struct
         with Not_found -> !Xenopsd.pvinpvh_xen_cmdline
       in
       let shim_mem =
-        let shim_mib = PVinPVH_memory_model_data.shim_mib static_max_mib in
+        let shim_mib =
+          match List.assoc_opt "shim_mib" vm.Vm.platformdata with
+          | None -> PVinPVH_memory_model_data.shim_mib static_max_mib
+          | Some n -> (
+            try Int64.of_string n with _ ->
+              warn "ignoring shim_mib=%s" n ;
+              PVinPVH_memory_model_data.shim_mib static_max_mib )
+        in
         Printf.sprintf "shim_mem=%LdM" shim_mib
       in
       String.concat " " [base; shim_mem]


### PR DESCRIPTION
Currently shim_mem argument of pv-shim is being calculated automatically
by PVinPVH_memory_model_data.shim_mib. Since (1) the formula used there
can go out-of-date with the Xen version of pv-shim and (2) to allow
a user a fine-grained control of amount of pv-shim memory, introduce
a new shim_mib (Int64) parameter in vm.Vm.platformdata.

Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>