### PR TITLE
REQ-627 CP-31787 disable shared EPT for nvidia SRIOV

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -69,7 +69,7 @@ module type S = sig
     val add: Vm.t -> unit
     val remove: Vm.t -> unit
     val rename: Vm.id -> Vm.id -> unit
-    val create: Xenops_task.task_handle -> int64 option -> Vm.t -> Vm.id option -> unit
+    val create: Xenops_task.task_handle -> int64 option -> Vm.t -> Vm.id option -> bool (* sriov*) -> unit
     val build: ?restore_fd:Unix.file_descr -> Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list-> string list -> bool ->  unit (* XXX cancel *)
     val create_device_model: Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list -> bool -> unit
     val destroy_device_model: Xenops_task.task_handle -> Vm.t -> unit

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -374,7 +374,7 @@ module VM = struct
 
   let add _vm = ()
   let remove _vm = ()
-  let create _ memory_limit vm _ = Mutex.execute m (create_nolock memory_limit vm)
+  let create _ memory_limit vm _ _ = Mutex.execute m (create_nolock memory_limit vm)
   let destroy _ vm = Mutex.execute m (destroy_nolock vm)
   let pause _ vm = Mutex.execute m (do_pause_unpause_nolock vm true)
   let unpause _ vm = Mutex.execute m (do_pause_unpause_nolock vm false)

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -114,7 +114,16 @@ val typ_of_build_info: build_info Rpc.Types.typ
 val build_info: build_info Rpc.Types.def
 
 (** Create a fresh (empty) domain with a specific UUID, returning the domain ID *)
-val make: xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> create_info -> int -> arch_domainconfig -> Uuidm.t -> string option -> domid
+val make:
+  xc:Xenctrl.handle
+  -> xs:Xenstore.Xs.xsh
+  -> create_info
+  -> int
+  -> arch_domainconfig
+  -> Uuidm.t
+  -> string option
+  -> bool (* sriov *)
+  -> domid
 
 (** 'types' of shutdown request *)
 type shutdown_reason = PowerOff | Reboot | Suspend | Crash | Halt | S3Suspend | Unknown of int

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1056,7 +1056,7 @@ module VM = struct
       in
       device_id, revision
 
-  let create_exn (task: Xenops_task.task_handle) memory_upper_bound vm final_id =
+  let create_exn task memory_upper_bound vm final_id sriov =
     let k = vm.Vm.id in
     with_xc_and_xs (fun xc xs ->
         (* Ensure the DB contains something for this VM - this is to avoid a race with the *)
@@ -1142,7 +1142,8 @@ module VM = struct
                   (domain_config, persistent)
               in
               let create_info = generate_create_info ~xc ~xs vm persistent in
-              let domid = Domain.make ~xc ~xs create_info vm.vcpu_max domain_config (uuid_of_vm vm) final_id in
+              let domid = Domain.make ~xc ~xs create_info vm.vcpu_max
+                            domain_config (uuid_of_vm vm) final_id sriov in
               Mem.transfer_reservation_to_domain dbg domid reservation_id;
               let initial_target =
                 let target_plus_overhead_bytes = bytes_of_kib target_plus_overhead_kib in


### PR DESCRIPTION
On domain create, domains that will use nvidia sriov must disable EPT.
The call to xc_domaincreate needs two additional flags for nvidia sr-iov
VMs: XEN_DOMCTL_IOMMU_has_IOMMU and XEN_DOMCTL_IOMMU_no_sharedpt

The call to xc_domaincreate is triggered by the VM_create atomic
operation. This commit:

* adds a flag to VM_create to indicate SRIOV mode
* introduces is_sriov() to check that a VGPU uses SRIOV
* based on the VM's environment, passes the flag accordingly

Overall this is a bit problematic because SRIOV is a device property and
xenopsd's architecture assumes that VMs and devices are constructed
independently. Now we need to inspect VGPUs before creating a VM.

Test code creates VMs without a context where this is possible. In that
case, VM.create assumes SRIOV=false.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>