### PR TITLE
REQ-627 CP-31787 disable shared EPT for nvidia SRIOV

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -104,7 +104,7 @@ type atomic =
   | VM_create_device_model of (Vm.id * bool)
   | VM_destroy_device_model of Vm.id
   | VM_destroy of Vm.id
-  | VM_create of (Vm.id * int64 option * Vm.id option)
+  | VM_create of (Vm.id * int64 option * Vm.id option * bool (*no_sharept*))
   | VM_build of (Vm.id * bool)
   | VM_shutdown_domain of (Vm.id * shutdown_request * float)
   | VM_s3suspend of Vm.id
@@ -912,6 +912,13 @@ type vgpu_fd_info = {
 let vgpu_receiver_sync : (Vm.id, vgpu_fd_info) Hashtbl.t = Hashtbl.create 10
 let vgpu_receiver_sync_m = Mutex.create ()
 
+(* The IOMMU_NO_SHAREPT flag is required for domains that use SRIOV
+ * Nvidia VGPUs. This predicate identifies the situation *)
+let is_no_sharept vgpu =
+  match vgpu.Vgpu.virtual_pci_address, vgpu.Vgpu.implementation with
+  | Some(_), Vgpu.Nvidia(_) -> true
+  | _ -> false
+
 let rec atomics_of_operation = function
   | VM_start (id, force) ->
     let vbds_rw, vbds_ro = VBD_DB.vbds id |> vbd_plug_sets in
@@ -919,9 +926,10 @@ let rec atomics_of_operation = function
     let vgpus = VGPU_DB.vgpus id in
     let pcis = PCI_DB.pcis id |> pci_plug_order in
     let vusbs = VUSB_DB.vusbs id in
+    let no_sharept = List.exists is_no_sharept vgpus in
     [ [
         VM_hook_script (id, Xenops_hooks.VM_pre_start, Xenops_hooks.reason__none);
-        VM_create (id, None, None);
+        VM_create (id, None, None, no_sharept);
         VM_build (id, force)
       ]
     ; List.map (fun vbd -> VBD_set_active (vbd.Vbd.id, true)) (vbds_rw @ vbds_ro)
@@ -1077,8 +1085,11 @@ let rec atomics_of_operation = function
       | [] -> []
       | vgpus -> [VGPU_start (vgpus, true)]
     in
+    let vgpus = VGPU_DB.list id |> List.map fst in
+    let no_sharept = List.exists is_no_sharept vgpus in
+
     [ [
-        VM_create (id, None, None);
+        VM_create (id, None, None, no_sharept);
         VM_hook_script (id, Xenops_hooks.VM_pre_resume, Xenops_hooks.reason__none);
       ]
     ; vgpu_start_operations
@@ -1414,9 +1425,9 @@ let rec perform_atomic ~progress_callback ?subtask:_ ?result (op: atomic) (t: Xe
   | VM_destroy id ->
     debug "VM.destroy %s" id;
     B.VM.destroy t (VM_DB.read_exn id)
-  | VM_create (id, memory_upper_bound, final_id) ->
+  | VM_create (id, memory_upper_bound, final_id, no_sharept) ->
     debug "VM.create %s memory_upper_bound = %s" id (Opt.default "None" (Opt.map Int64.to_string memory_upper_bound));
-    B.VM.create t memory_upper_bound (VM_DB.read_exn id) final_id
+    B.VM.create t memory_upper_bound (VM_DB.read_exn id) final_id no_sharept
   | VM_build (id,force) ->
     debug "VM.build %s" id;
     let vbds : Vbd.t list = VBD_DB.vbds id |> vbd_plug_order in
@@ -1626,7 +1637,7 @@ and trigger_cleanup_after_failure_atom op t =
   | VM_create_device_model (id, _)
   | VM_destroy_device_model id
   | VM_destroy id
-  | VM_create (id, _, _)
+  | VM_create (id, _, _, _)
   | VM_build (id, _)
   | VM_shutdown_domain (id, _, _)
   | VM_s3suspend id
@@ -1845,8 +1856,10 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
         );
 
         (try
+           let no_sharept =
+             VGPU_DB.list id |> List.map fst |> List.exists is_no_sharept in
            perform_atomics (
-             [VM_create (id, Some memory_limit, Some final_id);] @
+             [VM_create (id, Some memory_limit, Some final_id, no_sharept);] @
              (* Perform as many operations as possible on the destination domain before pausing the original domain *)
              (atomics_of_operation (VM_restore_vifs id))
            ) t;
@@ -2420,7 +2433,9 @@ module VM = struct
   let list _ dbg () =
     Debug.with_thread_associated dbg (fun () -> DB.list ()) ()
 
-  let create _ dbg id = queue_operation dbg id (Atomic(VM_create (id, None, None)))
+  let create _ dbg id =
+    let no_sharept = false in
+    queue_operation dbg id (Atomic(VM_create (id, None, None, no_sharept)))
 
   let build _ dbg id force = queue_operation dbg id (Atomic(VM_build (id, force)))
 

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -69,7 +69,7 @@ module type S = sig
     val add: Vm.t -> unit
     val remove: Vm.t -> unit
     val rename: Vm.id -> Vm.id -> unit
-    val create: Xenops_task.task_handle -> int64 option -> Vm.t -> Vm.id option -> unit
+    val create: Xenops_task.task_handle -> int64 option -> Vm.t -> Vm.id option -> bool (* no_sharept*) -> unit
     val build: ?restore_fd:Unix.file_descr -> Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list-> string list -> bool ->  unit (* XXX cancel *)
     val create_device_model: Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list -> bool -> unit
     val destroy_device_model: Xenops_task.task_handle -> Vm.t -> unit

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -374,7 +374,7 @@ module VM = struct
 
   let add _vm = ()
   let remove _vm = ()
-  let create _ memory_limit vm _ = Mutex.execute m (create_nolock memory_limit vm)
+  let create _ memory_limit vm _ _ = Mutex.execute m (create_nolock memory_limit vm)
   let destroy _ vm = Mutex.execute m (destroy_nolock vm)
   let pause _ vm = Mutex.execute m (do_pause_unpause_nolock vm true)
   let unpause _ vm = Mutex.execute m (do_pause_unpause_nolock vm false)

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -104,6 +104,7 @@ type create_info = {
   bios_strings: (string * string) list;
   has_vendor_device: bool;
   is_uefi: bool;
+  pci_passthrough: bool;
 } [@@deriving rpcty]
 
 type build_hvm_info = {
@@ -234,7 +235,7 @@ let wait_xen_free_mem ~xc ?(maximum_wait_time_seconds=64) required_memory_kib : 
   wait 0
 
 
-let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid =
+let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept =
   let flags = if vm_info.hvm then begin
       let default_flags =
         (if vm_info.hvm then [ CDF_HVM ] else []) @
@@ -260,8 +261,18 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid =
   let config = {
     ssidref = vm_info.ssidref;
     handle = Uuid.to_string uuid;
-    flags = CDF_IOMMU :: flags;
-    iommu_opts = [];
+    flags = begin match vm_info.pci_passthrough with
+      | true ->
+          debug "VM %s - using CDF_IOMMU" (Uuid.to_string uuid);
+          CDF_IOMMU :: flags
+      | false -> flags
+    end;
+    iommu_opts = begin match no_sharept with
+      | true  ->
+          debug "VM %s - using IOMMU_NO_SHAREPT" (Uuid.to_string uuid);
+          [ IOMMU_NO_SHAREPT ]
+      | false -> []
+    end;
     max_vcpus = vcpus;
     max_evtchn_port = -1;
     max_grant_frames =

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -69,6 +69,7 @@ type create_info = {
   bios_strings: (string * string) list;
   has_vendor_device: bool;
   is_uefi: bool;
+  pci_passthrough: bool;
 }
 val typ_of_create_info: create_info Rpc.Types.typ
 val create_info: create_info Rpc.Types.def
@@ -114,7 +115,16 @@ val typ_of_build_info: build_info Rpc.Types.typ
 val build_info: build_info Rpc.Types.def
 
 (** Create a fresh (empty) domain with a specific UUID, returning the domain ID *)
-val make: xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> create_info -> int -> arch_domainconfig -> Uuidm.t -> string option -> domid
+val make:
+  xc:Xenctrl.handle
+  -> xs:Xenstore.Xs.xsh
+  -> create_info
+  -> int
+  -> arch_domainconfig
+  -> Uuidm.t
+  -> string option
+  -> bool (* no_sharept *)
+  -> domid
 
 (** 'types' of shutdown request *)
 type shutdown_reason = PowerOff | Reboot | Suspend | Crash | Halt | S3Suspend | Unknown of int


### PR DESCRIPTION
On domain create, domains that will use a nvidia sriov GPU must disable
EPT.  The call to xc_domaincreate needs two additional flags for nvidia
sr-iov VMs: XEN_DOMCTL_IOMMU_has_IOMMU and XEN_DOMCTL_IOMMU_no_sharedpt

The call to xc_domaincreate is triggered by the VM_create atomic
operation. This commit:

* adds a flag to VM_create to indicate no_sharept mode
* introduces is_no_sharept() to check that a VGPU uses SRIOV
* based on the VM's environment, passes the flag accordingly

Overall this is a bit problematic because SRIOV is a device property and
xenopsd's architecture assumes that VMs and devices are constructed
independently. Now we need to inspect VGPUs before creating a VM.

Test code creates VMs without a context where this is possible. In that
case, VM.create assumes no_sharept=false.

In addition, this commit manages the CDF_IOMMU flag. It is only used
when a domain has PCI pass-trough devices. Previously it was always
used.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>