### PR TITLE
CA-325848: PVinPVH: set video_mib to 0

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1541,7 +1541,7 @@ module VM = struct
                            | None -> []
                           );
                 shadow_multiplier = 1.;
-                video_mib = 4;
+                video_mib = 0;
               } in
             ((make_build_info !Resources.pvinpvh_xen builder_spec_info), "")
           | PVinPVH { boot = Indirect { devices = [] } } ->
@@ -1562,7 +1562,7 @@ module VM = struct
                                 | None -> []
                                );
                      shadow_multiplier = 1.;
-                     video_mib = 4;
+                     video_mib = 0;
                    } in
                  ((make_build_info !Resources.pvinpvh_xen builder_spec_info), "")
               ) in


### PR DESCRIPTION
Video memory in not needed in PVH mode because there is no qemu
to emulate VGA. Having video_mib also gets in the way of calculating
PVinPVH memory: build_max_mib ends up less than static_max_mib
plus shim_mib (see memory/memory.ml in xcp-idl).

Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>