### PR TITLE
fixup! REQ-627 CP-31787 disable shared EPT for nvidia SRIOV

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1085,7 +1085,7 @@ let rec atomics_of_operation = function
       | [] -> []
       | vgpus -> [VGPU_start (vgpus, true)]
     in
-    let vgpus = VGPU_DB.list id |> List.map fst in
+    let vgpus = VGPU_DB.vgpus id in
     let no_sharept = List.exists is_no_sharept vgpus in
 
     [ [


### PR DESCRIPTION
<del>This might have been lost during the last rebase.</del> We had a similar fix before: https://github.com/xapi-project/xenopsd/pull/666/files

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>