### PR TITLE
CA-327906: don't fail migration if a xenstore directory is missing

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1866,6 +1866,8 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
           Handshake.send s Handshake.Success;
           debug "VM.receive_memory: Synchronisation point 4";
         with e ->
+          Backtrace.is_important e;
+          Debug.log_backtrace e (Backtrace.get e);
           debug "Caught %s: cleaning up VM state" (Printexc.to_string e);
           perform_atomics (atomics_of_operation (VM_shutdown (id, None)) @ [
               VM_remove id

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -285,7 +285,6 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid =
     let dom_path = xs.Xs.getdomainpath domid in
     let xenops_dom_path = xenops_path_of_domain domid in
     let vm_path = "/vm/" ^ (Uuid.to_string uuid) in
-    let vss_path = "/vss/" ^ (Uuid.to_string uuid) in
     let roperm = Xenbus_utils.roperm_for_guest domid in
     let rwperm = Xenbus_utils.rwperm_for_guest domid in
     let zeroperm = Xenbus_utils.rwperm_for_guest 0 in
@@ -317,12 +316,8 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid =
         t.Xst.write (Printf.sprintf "%s/domains/%d" vm_path domid) dom_path;
         t.Xst.write (Printf.sprintf "%s/domains/%d/create-time" vm_path domid) (Int64.to_string create_time);
 
-        t.Xst.rm vss_path;
-        t.Xst.mkdirperms vss_path rwperm;
-
         t.Xst.writev dom_path [
           "vm", vm_path;
-          "vss", vss_path;
           "name", name;
         ];
 
@@ -1560,7 +1555,6 @@ type node =
 let move_xstree ~xs domid olduuid newuuid =
   let search_paths = [[""; "local"; "domain"; string_of_int domid];
                       [""; "xapi"; olduuid];
-                      [""; "vss"; olduuid];
                       [""; "vm"; olduuid]] in
 
   let regexp = Re.Pcre.regexp olduuid in

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1573,9 +1573,15 @@ let move_xstree ~xs domid olduuid newuuid =
     { contents;
       subtrees = List.map (fun f -> (f, get_tree t (path @ [f]))) subtrees } in
 
+  let exists t path =
+    try let (_:string) = t.Xs.read (String.concat "/" path) in true
+    with Xs_protocol.Enoent _ -> false
+  in
+
   let mv_tree path =
     let open Xenstore in
     Xs.transaction xs (fun t ->
+        if exists t path then
         let tree = get_tree t path in
         let rec fixup write path (name,node) =
           let fixed_name = Re.replace_string regexp ~by:newuuid name in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1235,7 +1235,6 @@ module VM = struct
     with_xc_and_xs
       (fun xc xs ->
          safe_rm xs (Printf.sprintf "/vm/%s" vm.Vm.id);
-         safe_rm xs (Printf.sprintf "/vss/%s" vm.Vm.id);
       );
     (* Best-effort attempt to remove metadata - if VM has been powered off
        * then it will have already been deleted by VM.destroy *)


### PR DESCRIPTION
Migration of a VM without VIFs got stuck at:
```
Caught Xs_protocol.Enoent("directory"): cleaning up VM stat
```

Some more debugging showed it failed when trying to move this xenstore
entry, which was missing:
```
/xapi/8e8c58cd-eba4-cde3-e1e5-000000000001
```

The intention of this code seems to have been to ignore missing entries,
so do that by ignoring Enoent on the root of a tree.
Do not ignore Enoent on entries deep in the tree since that would
indicate a race condition elsewhere.

With these changes I was able to successfully complete a localhost migration of a VM without a VIF, which was failing previously.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>