### PR TITLE
REQ-627 CA-328215 use pci_passthrough for PV

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1027,6 +1027,7 @@ module VM = struct
     let pci_passthrough =
       match vm.ty with
       | HVM { pci_passthrough = true } -> true
+      | PV  { pci_passthrough = true } -> true
       | _ -> false in
 
     {


### PR DESCRIPTION
Xapi now passes a pci_passthrough flag for PV guests that this commit
takes into account.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>