### PR TITLE
CP-31431: Add quarantine/dequarantine for PCI devices

### DIFF
--- a/c_stubs/xenctrlext_stubs.c
+++ b/c_stubs/xenctrlext_stubs.c
@@ -27,27 +27,44 @@
 #include <caml/fail.h>
 #include <caml/signals.h>
 #include <caml/callback.h>
+#include <caml/unixsupport.h>
 
 #define _H(__h) ((xc_interface *)(__h))
 #define _D(__d) ((uint32_t)Int_val(__d))
 
 /* From xenctrl_stubs */
+#define ERROR_STRLEN 1024
+
+static void raise_unix_errno_msg(int err_code, const char *err_msg)
+{
+        CAMLparam0();
+        value args[] = { unix_error_of_code(err_code), caml_copy_string(err_msg) };
+
+        caml_raise_with_args(*caml_named_value("Xenctrlext.Unix_error"),
+                             sizeof(args)/sizeof(args[0]), args);
+        CAMLnoreturn;
+}
+
 static void failwith_xc(xc_interface *xch)
 {
         static char error_str[XC_MAX_ERROR_MSG_LEN + 6];
+        int real_errno = -1;
         if (xch) {
                 const xc_error *error = xc_get_last_error(xch);
-                if (error->code == XC_ERROR_NONE)
+                if (error->code == XC_ERROR_NONE) {
+                        real_errno = errno;
                         snprintf(error_str, sizeof(error_str), "%d: %s", errno, strerror(errno));
-                else
+                } else {
+                        real_errno = error->code;
                         snprintf(error_str, sizeof(error_str), "%d: %s: %s",
                                  error->code,
                                  xc_error_code_to_desc(error->code),
                                  error->message);
+                }
         } else {
                 snprintf(error_str, sizeof(error_str), "Unable to open XC interface");
         }
-        caml_raise_with_string(*caml_named_value("xc.error"), error_str);
+        raise_unix_errno_msg(real_errno, error_str);
 }
 
 CAMLprim value stub_xenctrlext_get_runstate_info(value xch, value domid)
@@ -207,6 +224,23 @@ CAMLprim value stub_xenctrlext_assign_device(value xch, value domid,
     if (retval)
         failwith_xc(_H(xch));
     CAMLreturn(Val_unit);
+}
+
+CAMLprim value stub_xenctrlext_deassign_device(value xch, value domid, value machine_sbdf)
+{
+    CAMLparam3(xch, domid, machine_sbdf);
+    caml_enter_blocking_section();
+    int retval = xc_deassign_device(_H(xch), _D(domid), Int_val(machine_sbdf));
+    caml_leave_blocking_section();
+    if (retval)
+        failwith_xc(_H(xch));
+    CAMLreturn(Val_unit);
+}
+
+CAMLprim value stub_xenctrlext_domid_quarantine(value unit)
+{
+    CAMLparam1(unit);
+    CAMLreturn(Val_int(DOMID_IO));
 }
 
 /* based on xenctrl_stubs.c */

--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -32,6 +32,7 @@ let qemu_dm_ready_timeout = ref 300.
 let vgpu_ready_timeout = ref 30.
 let varstored_ready_timeout = ref 30.
 let use_upstream_qemu = ref false
+let pci_quarantine = ref true
 
 let watch_queue_length = ref 1000
 
@@ -75,6 +76,7 @@ let options = [
   "pvinpvh-xen-cmdline", Arg.Set_string pvinpvh_xen_cmdline, (fun () -> !pvinpvh_xen_cmdline), "Command line for the inner-xen for PV-in-PVH guests";
   "numa-placement", Arg.Bool (fun x -> numa_placement := x), (fun () -> string_of_bool !numa_placement), "NUMA-aware placement of VMs";
   "numa-placement-strict", Arg.Bool (fun x -> numa_placement_strict := x), (fun () -> string_of_bool !numa_placement), "Fail if NUMA-aware placement is not possible";
+  "pci-quarantine", Arg.Bool (fun b -> pci_quarantine := b), (fun () -> string_of_bool !pci_quarantine), "True if IOMMU contexts of PCI devices are needed to be placed in quarantine";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -286,13 +286,13 @@ sig
     -> int  (** domid *)
     -> qemu_args
 
-  val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
-  val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val start : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val restore : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
   val assert_can_suspend : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> unit
   val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
   val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
   val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
-  val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t list -> int -> Profile.t  -> unit
+  val restore_vgpu : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t list -> int -> Profile.t  -> unit
   val suspend_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid -> vm_uuid:string -> string
   val restore_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> efivars:string -> Xenctrl.domid -> unit
 

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -21,6 +21,10 @@ external domain_set_timer_mode: handle -> domid -> int -> unit = "stub_xenctrlex
 external domain_send_s3resume: handle -> domid -> unit = "stub_xenctrlext_domain_send_s3resume"
 external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_domain_get_acpi_s_state"
 
+exception Unix_error of Unix.error * string
+
+let _ = Callback.register_exception "Xenctrlext.Unix_error" (Unix_error(Unix.E2BIG, ""))
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -42,6 +46,10 @@ external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_
 external physdev_map_pirq : handle -> domid -> int -> int = "stub_xenctrlext_physdev_map_pirq"
 
 external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"
 
 external vcpu_setaffinity_soft: handle -> domid -> int -> bool array -> unit = "stub_xenctrlext_vcpu_setaffinity_soft"
 

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -21,6 +21,8 @@ external domain_set_timer_mode: handle -> domid -> int -> unit = "stub_xenctrlex
 external domain_send_s3resume: handle -> domid -> unit = "stub_xenctrlext_domain_send_s3resume"
 external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_domain_get_acpi_s_state"
 
+exception Unix_error of Unix.error * string
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -42,6 +44,10 @@ external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_
 external physdev_map_pirq : handle -> domid -> int -> int = "stub_xenctrlext_physdev_map_pirq"
 
 external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"
 
 type meminfo = {
   memfree: int64;

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1641,7 +1641,7 @@ module VM = struct
               warn "QEMU stub domains are no longer implemented;\
                 QEMU will be started in the control domain";
             (if saved_state then Device.Dm.restore else Device.Dm.start)
-              task ~xs ~dm:qemu_dm info di.Xenctrl.domid;
+              task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid;
             Device.Serial.update_xenstore ~xs di.Xenctrl.domid
           | Vm.PV _ | Vm.PVinPVH _ -> assert false
         ) (create_device_model_config vm vmextra vbds vifs vgpus vusbs);
@@ -2357,7 +2357,7 @@ module VGPU = struct
 
   let start task vm vgpus saved_state =
     on_frontend
-      (fun _ xs frontend_domid _ ->
+      (fun xc xs frontend_domid _ ->
          let vmextra = DB.read_exn vm in
          let vcpus = match vmextra.VmExtra.persistent with
            | { VmExtra.build_info = None } ->
@@ -2369,7 +2369,7 @@ module VGPU = struct
          let profile = match vmextra.VmExtra.persistent.profile with
            | None -> Device.Profile.Qemu_upstream_compat
            | Some p -> p in
-         Device.Dm.restore_vgpu task ~xs frontend_domid vgpus vcpus profile
+         Device.Dm.restore_vgpu task ~xc ~xs frontend_domid vgpus vcpus profile
       ) vm
 
   let active_path vm vgpu = Printf.sprintf "/vm/%s/devices/vgpu/%s" vm (snd vgpu.Vgpu.id)


### PR DESCRIPTION
This commit makes changes for CA-297891, in which a special domain is
used in Xen to quarantine the PCI devices for pass-through. The
quarantine means a separate I/O address space for DMA of PCI device. Two
cases are considered in this commit:

1. when a PCI device is going to be passed-through to a guest domain, it
will be placed into quarantine firstly (done by toolstack). Later on,
when it is deassigned from the guest domain, it will be placed (done by
Xen) to quarantine domain, rather than the dom0.

2. when a PCI device, which had been passed-through to a guest domain and
now it is in quarantine, is going to be managed by host driver running on
dom0 to emulate virtual devices (not PCI pass-through), it should be
moved out from quarantine and assigned back to dom0. I.E. NVIDIA vGPUs
and Intel vGPUs.