### PR TITLE
CP-31431: Add quarantine/dequarantine for PCI devices

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -31,6 +31,7 @@ let qemu_dm_ready_timeout = ref 300.
 let vgpu_ready_timeout = ref 30.
 let varstored_ready_timeout = ref 30.
 let use_upstream_qemu = ref false
+let pci_quarantine = ref true
 
 let watch_queue_length = ref 1000
 
@@ -66,6 +67,7 @@ let options = [
   "action-after-qemu-crash", Arg.String (fun x -> action_after_qemu_crash := if x="" then None else Some x), (fun () -> match !action_after_qemu_crash with None->"" | Some x->x), "Action to take for VMs if QEMU crashes or dies unexpectedly: pause, poweroff. Otherwise, no action (default).";
   "feature-flags-path", Arg.Set_string feature_flags_path, (fun () -> !feature_flags_path), "Directory of experimental feature flags";
   "pvinpvh-xen-cmdline", Arg.Set_string pvinpvh_xen_cmdline, (fun () -> !pvinpvh_xen_cmdline), "Command line for the inner-xen for PV-in-PVH guests";
+  "pci-quarantine", Arg.Bool (fun b -> pci_quarantine := b), (fun () -> string_of_bool !pci_quarantine), "True if IOMMU contexts of PCI devices are needed to be placed in quarantine";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1131,10 +1131,35 @@ module PCI = struct
     (* Sort into the order the devices were plugged *)
     List.sort (fun a b -> compare (fst a) (fst b)) pairs
 
-  let add ~xs pcidevs domid =
+  let encode_bdf pci =
+    (pci.Xenops_interface.Pci.domain lsl 16)
+    lor ((pci.bus land 0xff) lsl 8)
+    lor ((pci.dev land 0x1f) lsl 3)
+    lor (pci.fn  land 0x7)
+
+  let _quarantine xc pci quarantine =
+    let pci_bdf = encode_bdf pci in
+    let domid = Xenctrlext.domid_quarantine () in
+    try
+      match quarantine with
+      | true -> Xenctrlext.assign_device xc domid pci_bdf 0; true
+      | false -> Xenctrlext.deassign_device xc domid pci_bdf; true
+    with
+    | Xenctrlext.Unix_error (Unix.ESRCH, _) -> false
+    | Xenctrlext.Unix_error (Unix.ENODEV, _) -> false
+    | e -> raise e
+
+  let quarantine xc pci =
+    _quarantine xc pci true
+
+  let dequarantine xc pci =
+    _quarantine xc pci false
+
+  let add ~xc ~xs pcidevs domid =
     try
       let current = read_pcidir ~xs domid in
       let next_idx = List.fold_left max (-1) (List.map fst current) + 1 in
+      if !Xenopsd.pci_quarantine then List.iter (fun x -> ignore(quarantine xc x)) pcidevs;
       add_xl pcidevs domid;
       List.iteri
         (fun count address ->
@@ -2964,7 +2989,7 @@ module Dm = struct
       ~cancel:(Cancel_utils.Varstored domid) ();
     Forkhelpers.dontwaitpid pid
 
-  let start_vgpu ~xs task ?(restore=false) domid vgpus vcpus profile =
+  let start_vgpu ~xc ~xs task ?(restore=false) domid vgpus vcpus profile =
     let open Xenops_interface.Vgpu in
     match vgpus with
     | [{physical_pci_address = pci; implementation = Nvidia vgpu}] ->
@@ -2977,6 +3002,8 @@ module Dm = struct
            			 * a vGPU on a device which is passed through to a guest. *)
         debug "start_vgpu: got VGPU with physical pci address %s"
           (Xenops_interface.Pci.string_of_address pci);
+        let pcis = List.map (fun x -> x.physical_pci_address) vgpus in
+        if !Xenopsd.pci_quarantine then List.iter (fun x -> ignore(PCI.dequarantine xc x)) pcis;
         PCI.bind [pci] PCI.Nvidia;
         let module Q = (val Backend.of_profile profile) in
         let device = Q.Vgpu.device ~index:0 in
@@ -3006,6 +3033,7 @@ module Dm = struct
         raise (Ioemu_failed ("vgpu", Printf.sprintf "Daemon vgpu returned error: %s" error_code))
       end
     | [{physical_pci_address = pci; implementation = GVT_g vgpu}] ->
+      if !Xenopsd.pci_quarantine then ignore(PCI.dequarantine xc pci);
       PCI.bind [pci] PCI.I915
     | [{physical_pci_address = pci; implementation = MxGPU vgpu}] ->
       Mutex.execute gimtool_m (fun () ->
@@ -3021,7 +3049,7 @@ module Dm = struct
   type action = Start | Restore
 
   let __start (task: Xenops_task.task_handle)
-      ~xs ~dm ?(timeout = !Xenopsd.qemu_dm_ready_timeout) action info domid =
+      ~xc ~xs ~dm ?(timeout = !Xenopsd.qemu_dm_ready_timeout) action info domid =
 
     let args = match action with
       | Start    -> qemu_args ~xs ~dm info false domid
@@ -3035,7 +3063,7 @@ module Dm = struct
     let () = match info.disp with
       | VNC (Vgpu vgpus, _, _, _, _)
       | SDL (Vgpu vgpus, _) ->
-        start_vgpu ~xs task domid vgpus info.vcpus dm
+        start_vgpu ~xc ~xs task domid vgpus info.vcpus dm
       | _ -> ()
     in
 
@@ -3095,15 +3123,15 @@ module Dm = struct
               xs.Xs.write (Qemu.pid_path_signal domid) crash_reason
         ))
 
-  let start (task: Xenops_task.task_handle) ~xs ~dm ?timeout info domid =
-    __start task ~xs ~dm ?timeout Start info domid
+  let start (task: Xenops_task.task_handle) ~xc ~xs ~dm ?timeout info domid =
+    __start task ~xc ~xs ~dm ?timeout Start info domid
 
-  let restore (task: Xenops_task.task_handle) ~xs ~dm ?timeout info domid =
-    __start task ~xs ~dm ?timeout Restore info domid
+  let restore (task: Xenops_task.task_handle) ~xc ~xs ~dm ?timeout info domid =
+    __start task ~xc ~xs ~dm ?timeout Restore info domid
 
-  let restore_vgpu (task: Xenops_task.task_handle) ~xs domid vgpu vcpus profile =
+  let restore_vgpu (task: Xenops_task.task_handle) ~xc ~xs domid vgpu vcpus profile =
     debug "Called Dm.restore_vgpu";
-    start_vgpu ~xs task ~restore:true domid [vgpu] vcpus profile
+    start_vgpu ~xc ~xs task ~restore:true domid [vgpu] vcpus profile
 
   let suspend_varstored (task: Xenops_task.task_handle) ~xs domid =
     debug "Called Dm.suspend_varstored (domid=%d)" domid;

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -200,7 +200,7 @@ sig
 
   exception Cannot_use_pci_with_no_pciback of t list
 
-  val add : xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
+  val add : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
   val release : address list -> Xenctrl.domid -> unit
   val reset : xs:Xenstore.Xs.xsh -> address -> unit
   val bind : address list -> supported_driver -> unit
@@ -281,13 +281,13 @@ sig
     -> int  (** domid *)
     -> qemu_args
 
-  val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
-  val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val start : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val restore : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
   val assert_can_suspend : xs:Xenstore.Xs.xsh -> dm:Profile.t -> Xenctrl.domid -> unit
   val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
   val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
   val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
-  val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> Profile.t  -> unit
+  val restore_vgpu : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> Profile.t  -> unit
   val suspend_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid -> string
   val restore_varstored: Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> efivars:string -> Xenctrl.domid -> unit
 

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -23,6 +23,10 @@ external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_doma
 
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
+exception Unix_error of Unix.error * string
+
+let _ = Callback.register_exception "Xenctrlext.Unix_error" (Unix_error(Unix.E2BIG, ""))
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -40,3 +44,9 @@ external domain_get_runstate_info : handle -> int -> runstateinfo = "stub_xenctr
 external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
+
+external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -23,6 +23,8 @@ external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_doma
 
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
+exception Unix_error of Unix.error * string
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -40,3 +42,9 @@ external domain_get_runstate_info : handle -> int -> runstateinfo = "stub_xenctr
 external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
+
+external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1643,7 +1643,7 @@ module VM = struct
             debug "Ignoring request for PV VNC in stubdom (would require qemu-trad)"
           | Vm.HVM { Vm.qemu_stubdom = false } ->
             (if saved_state then Device.Dm.restore else Device.Dm.start)
-              task ~xs ~dm:qemu_dm info di.Xenctrl.domid
+              task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid
           | Vm.PV _ | Vm.PVinPVH _ -> assert false
         ) (create_device_model_config vm vmextra vbds vifs vgpus vusbs);
       match vm.Vm.ty with
@@ -2302,7 +2302,7 @@ module PCI = struct
          end;
 
          Device.PCI.bind [ pci.address ] Device.PCI.Pciback;
-         Device.PCI.add xs [ pci.address ] frontend_domid
+         Device.PCI.add xc xs [ pci.address ] frontend_domid
       ) vm
 
   let unplug task vm pci =
@@ -2327,7 +2327,7 @@ module VGPU = struct
 
   let start task vm vgpu saved_state =
     on_frontend
-      (fun _ xs frontend_domid _ ->
+      (fun xc xs frontend_domid _ ->
          let vmextra = DB.read_exn vm in
          let vcpus = match vmextra.VmExtra.persistent with
            | { VmExtra.build_info = None } ->
@@ -2339,7 +2339,7 @@ module VGPU = struct
          let profile = match vmextra.VmExtra.persistent.profile with
            | None -> Device.Profile.Qemu_upstream_compat
            | Some p -> p in
-         Device.Dm.restore_vgpu task ~xs frontend_domid vgpu vcpus profile
+         Device.Dm.restore_vgpu task ~xc ~xs frontend_domid vgpu vcpus profile
       ) vm
 
   let active_path vm vgpu = Printf.sprintf "/vm/%s/devices/vgpu/%s" vm (snd vgpu.Vgpu.id)


### PR DESCRIPTION
This commit makes changes for CA-297891, in which a special domain is
used in Xen to quarantine the PCI devices for pass-through. The
quarantine means a separate I/O address space for DMA of PCI device. Two
cases are considered in this commit:

1. when a PCI device is going to be passed-through to a guest domain, it
will be placed into quarantine firstly (done by toolstack). Later on,
when it is deassigned from the guest domain, it will be placed (done by
Xen) to quarantine domain, rather than the dom0.

2. when a PCI device, which had been passed-through to a guest domain and
now it is in quarantine, is going to be managed by host driver running on
dom0 to emulate virtual devices (not PCI pass-through), it should be
moved out from quarantine and assigned back to dom0. I.E. NVIDIA vGPUs
and Intel vGPUs.

Signed-off-by: Ming Lu <ming.lu@citrix.com>
Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>