### PR TITLE
CP-31431: Add quarantine/dequarantine for PCI devices

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -30,6 +30,7 @@ let hotplug_timeout = ref 300.
 let qemu_dm_ready_timeout = ref 300.
 let vgpu_ready_timeout = ref 30.
 let use_upstream_qemu = ref false
+let pci_quarantine = ref true
 
 let watch_queue_length = ref 1000
 
@@ -64,6 +65,7 @@ let options = [
   "action-after-qemu-crash", Arg.String (fun x -> action_after_qemu_crash := if x="" then None else Some x), (fun () -> match !action_after_qemu_crash with None->"" | Some x->x), "Action to take for VMs if QEMU crashes or dies unexpectedly: pause, poweroff. Otherwise, no action (default).";
   "feature-flags-path", Arg.Set_string feature_flags_path, (fun () -> !feature_flags_path), "Directory of experimental feature flags";
   "pvinpvh-xen-cmdline", Arg.Set_string pvinpvh_xen_cmdline, (fun () -> !pvinpvh_xen_cmdline), "Command line for the inner-xen for PV-in-PVH guests";
+  "pci-quarantine", Arg.Bool (fun b -> pci_quarantine := b), (fun () -> string_of_bool !pci_quarantine), "True if IOMMU contexts of PCI devices are needed to be placed in quarantine";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -203,7 +203,7 @@ sig
 
   exception Cannot_use_pci_with_no_pciback of t list
 
-  val add : xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
+  val add : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
   val release : address list -> Xenctrl.domid -> unit
   val reset : xs:Xenstore.Xs.xsh -> address -> unit
   val bind : address list -> supported_driver -> unit
@@ -282,13 +282,13 @@ sig
     -> int  (** domid *)
     -> qemu_args
 
-  val start : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
-  val start_vnconly : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
-  val restore : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val start : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val start_vnconly : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
+  val restore : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dm:Profile.t -> ?timeout:float -> info -> Xenctrl.domid -> unit
   val suspend : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
   val resume : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
   val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> dm:Profile.t -> Xenctrl.domid -> unit
-  val restore_vgpu : Xenops_task.task_handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> unit
+  val restore_vgpu : Xenops_task.task_handle -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> Xenctrl.domid  -> Xenops_interface.Vgpu.t -> int -> unit
 
   val after_suspend_image: xs:Xenstore.Xs.xsh -> dm:Profile.t -> qemu_domid:int -> int -> unit
 end

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -23,6 +23,10 @@ external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_doma
 
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
+exception Unix_error of Unix.error * string
+
+let _ = Callback.register_exception "Xenctrlext.Unix_error" (Unix_error(Unix.E2BIG, ""))
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -40,3 +44,9 @@ external domain_get_runstate_info : handle -> int -> runstateinfo = "stub_xenctr
 external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
+
+external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -23,6 +23,8 @@ external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_doma
 
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
+exception Unix_error of Unix.error * string
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -40,3 +42,9 @@ external domain_get_runstate_info : handle -> int -> runstateinfo = "stub_xenctr
 external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
+
+external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1589,20 +1589,20 @@ module VM = struct
             Opt.iter
               (fun stubdom_domid ->
                  Stubdom.build task ~xc ~xs ~dm:qemu_dm ~store_domid ~console_domid info xenguest di.Xenctrl.domid stubdom_domid;
-                 Device.Dm.start_vnconly task ~xs ~dm:qemu_dm info stubdom_domid
+                 Device.Dm.start_vnconly task ~xc ~xs ~dm:qemu_dm info stubdom_domid
               ) (get_stubdom ~xs di.Xenctrl.domid);
           | Vm.HVM { Vm.qemu_stubdom = false } ->
             (if saved_state then Device.Dm.restore else Device.Dm.start)
-              task ~xs ~dm:qemu_dm info di.Xenctrl.domid;
+              task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid;
             Device.Serial.update_xenstore ~xs di.Xenctrl.domid
           | Vm.PV _ ->
             Device.Vfb.add ~xc ~xs di.Xenctrl.domid;
             Device.Vkbd.add ~xc ~xs di.Xenctrl.domid;
-            Device.Dm.start_vnconly task ~xs ~dm:qemu_dm info di.Xenctrl.domid
+            Device.Dm.start_vnconly task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid
           | Vm.PVinPVH _ ->
             Device.Vfb.add ~xc ~xs di.Xenctrl.domid;
             Device.Vkbd.add ~xc ~xs di.Xenctrl.domid;
-            Device.Dm.start_vnconly task ~xs ~dm:qemu_dm info di.Xenctrl.domid
+            Device.Dm.start_vnconly task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid
         ) (create_device_model_config vm vmextra vbds vifs vgpus vusbs);
       match vm.Vm.ty with
       | Vm.PV { vncterm = true; vncterm_ip = ip }
@@ -2203,7 +2203,7 @@ module PCI = struct
          end;
 
          Device.PCI.bind [ pci.address ] Device.PCI.Pciback;
-         Device.PCI.add xs [ pci.address ] frontend_domid
+         Device.PCI.add xc xs [ pci.address ] frontend_domid
       ) vm
 
   let unplug task vm pci =
@@ -2229,7 +2229,7 @@ module VGPU = struct
 
   let start task vm vgpu saved_state =
     on_frontend
-      (fun _ xs frontend_domid _ ->
+      (fun xc xs frontend_domid _ ->
          let vmextra = DB.read_exn vm in
          let vcpus = match vmextra.VmExtra.persistent with
            | { VmExtra.build_info = None } ->
@@ -2238,7 +2238,7 @@ module VGPU = struct
            | { VmExtra.build_info = Some build_info } ->
              build_info.Domain.vcpus
          in
-         Device.Dm.restore_vgpu task ~xs frontend_domid vgpu vcpus
+         Device.Dm.restore_vgpu task ~xc ~xs frontend_domid vgpu vcpus
       ) vm
 
   let get_state vm vgpu =


### PR DESCRIPTION
This commit makes changes for CA-297891, in which a special domain is
used in Xen to quarantine the PCI devices for pass-through. The
quarantine means a separate I/O address space for DMA of PCI device. Two
cases are considered in this commit:

1. when a PCI device is going to be passed-through to a guest domain, it
will be placed into quarantine firstly (done by toolstack). Later on,
when it is deassigned from the guest domain, it will be placed (done by
Xen) to quarantine domain, rather than the dom0.

2. when a PCI device, which had been passed-through to a guest domain and
now it is in quarantine, is going to be managed by host driver running on
dom0 to emulate virtual devices (not PCI pass-through), it should be
moved out from quarantine and assigned back to dom0. I.E. NVIDIA vGPUs
and Intel vGPUs.

Signed-off-by: Ming Lu <ming.lu@citrix.com>
Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>