### PR TITLE
CP-31431: Add quarantine/dequarantine for PCI devices

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -38,6 +38,7 @@ let default_vbd_backend_kind = ref "vbd"
 let ca_140252_workaround = ref false
 
 let additional_ballooning_timeout = ref 120.
+let pci_quarantine = ref true
 
 let options = [
     "queue", Arg.Set_string Xenops_interface.queue_name, (fun () -> !Xenops_interface.queue_name), "Listen on a specific queue";
@@ -55,6 +56,7 @@ let options = [
     "default-vbd-backend-kind", Arg.Set_string default_vbd_backend_kind, (fun () -> !default_vbd_backend_kind), "Default backend for VBDs";
     "ca-140252-workaround", Arg.Bool (fun x -> ca_140252_workaround := x), (fun () -> string_of_bool !ca_140252_workaround), "Workaround for evtchn misalignment for legacy PV tools";
     "additional-ballooning-timeout", Arg.Set_float additional_ballooning_timeout, (fun () -> string_of_float !additional_ballooning_timeout), "Time we allow the guests to do additional memory ballooning before live migration";
+   "pci-quarantine", Arg.Bool (fun b -> pci_quarantine := b), (fun () -> string_of_bool !pci_quarantine), "True if IOMMU contexts of PCI devices are needed to be placed in quarantine";
 ]
 
 let path () = Filename.concat !sockets_path "xenopsd"

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -980,10 +980,35 @@ let read_pcidir ~xs domid =
 	(* Sort into the order the devices were plugged *)
 	List.sort (fun a b -> compare (fst a) (fst b)) pairs
 
-let add ~xs pcidevs domid =
+let encode_bdf pci =
+	(pci.Xenops_interface.Pci.domain lsl 16)
+	lor ((pci.Xenops_interface.Pci.bus land 0xff) lsl 8)
+	lor ((pci.Xenops_interface.Pci.dev land 0x1f) lsl 3)
+	lor (pci.Xenops_interface.Pci.fn land 0x7)
+
+let _quarantine xc pci quarantine =
+	let pci_bdf = encode_bdf pci in
+	let domid = Xenctrlext.domid_quarantine () in
+	try
+		match quarantine with
+		| true -> Xenctrlext.assign_device xc domid pci_bdf 0; true
+		| false -> Xenctrlext.deassign_device xc domid pci_bdf; true
+	with
+	| Xenctrlext.Unix_error (Unix.ESRCH, _) -> false
+	| Xenctrlext.Unix_error (Unix.ENODEV, _) -> false
+	| e -> raise e
+
+let quarantine xc pci =
+	_quarantine xc pci true
+
+let dequarantine xc pci =
+	_quarantine xc pci false
+
+let add ~xc ~xs pcidevs domid =
 	try
 		let current = read_pcidir ~xs domid in
 		let next_idx = List.fold_left max (-1) (List.map fst current) + 1 in
+		if !Xenopsd.pci_quarantine then List.iter (fun x -> ignore(quarantine xc x)) pcidevs;
 		add_xl pcidevs domid;
 		List.iteri
 			(fun count address ->
@@ -1684,7 +1709,7 @@ let init_daemon ~task ~path ~args ~name ~domid ~xs ~ready_path ?ready_val ~timeo
 	debug "Daemon initialised: %s" (Printf.sprintf "%s-%d" name domid);
 	pid
 
-let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready_timeout) l info domid =
+let __start (task: Xenops_task.t) ~xc ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready_timeout) l info domid =
 	debug "Device.Dm.start domid=%d args: [%s]" domid (String.concat " " l);
 
 	(* start vgpu emulation if appropriate *)
@@ -1695,6 +1720,7 @@ let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready
 		(* The below line does nothing if the device is already bound to the
 		 * nvidia driver. We rely on xapi to refrain from attempting to run
 		 * a vGPU on a device which is passed through to a guest. *)
+		if !Xenopsd.pci_quarantine then ignore(PCI.dequarantine xc vgpu.physical_pci_address);
 		PCI.bind [vgpu.physical_pci_address] PCI.Nvidia;
 		let args = vgpu_args_of_nvidia domid info.vcpus vgpu in
 		let ready_path = Printf.sprintf "/local/domain/%d/vgpu-pid" domid in
@@ -1704,8 +1730,10 @@ let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready
 		Forkhelpers.dontwaitpid vgpu_pid
 	end
 	| VNC (Vgpu [{implementation = GVT_g vgpu}], _, _, _, _)
-	| SDL (Vgpu [{implementation = GVT_g vgpu}], _) ->
+	| SDL (Vgpu [{implementation = GVT_g vgpu}], _) -> begin
+		if !Xenopsd.pci_quarantine then ignore(PCI.dequarantine xc vgpu.physical_pci_address);
 		PCI.bind [vgpu.physical_pci_address] PCI.I915
+	end
 	| VNC (Vgpu _, _, _, _, _)
 	| SDL (Vgpu _, _) -> failwith "Unsupported vGPU configuration"
 	| _ -> ()
@@ -1722,16 +1750,16 @@ let __start (task: Xenops_task.t) ~xs ~dmpath ?(timeout = !Xenopsd.qemu_dm_ready
 	(* At this point we expect qemu to outlive us; we will never call waitpid *)
 	Forkhelpers.dontwaitpid qemu_pid
 
-let start (task: Xenops_task.t) ~xs ~dmpath ?timeout info domid =
+let start (task: Xenops_task.t) ~xc ~xs ~dmpath ?timeout info domid =
 	let l = cmdline_of_info info false domid in
-	__start task ~xs ~dmpath ?timeout l info domid
-let restore (task: Xenops_task.t) ~xs ~dmpath ?timeout info domid =
+	__start task ~xc ~xs ~dmpath ?timeout l info domid
+let restore (task: Xenops_task.t) ~xc ~xs ~dmpath ?timeout info domid =
 	let l = cmdline_of_info info true domid in
-	__start task ~xs ~dmpath ?timeout l info domid
+	__start task ~xc ~xs ~dmpath ?timeout l info domid
 
-let start_vnconly (task: Xenops_task.t) ~xs ~dmpath ?timeout info domid =
+let start_vnconly (task: Xenops_task.t) ~xc ~xs ~dmpath ?timeout info domid =
 	let l = vnconly_cmdline ~info domid in
-	__start task ~xs ~dmpath ?timeout l info domid
+	__start task ~xc ~xs ~dmpath ?timeout l info domid
 
 (* suspend/resume is a done by sending signals to qemu *)
 let suspend (task: Xenops_task.t) ~xs ~qemu_domid domid =

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -143,7 +143,7 @@ sig
 
 	exception Cannot_use_pci_with_no_pciback of t list
 
-	val add : xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
+	val add : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> address list -> Xenctrl.domid -> unit
 	val release : address list -> Xenctrl.domid -> unit
 	val reset : xs:Xenstore.Xs.xsh -> address -> unit
 	val bind : address list -> supported_driver -> unit
@@ -218,9 +218,9 @@ sig
 
 	val cmdline_of_info: info -> bool -> int -> string list
 
-	val start : Xenops_task.t -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
-	val start_vnconly : Xenops_task.t -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
-	val restore : Xenops_task.t -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
+	val start : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
+	val start_vnconly : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
+	val restore : Xenops_task.t -> xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> dmpath:string -> ?timeout:float -> info -> Xenctrl.domid -> unit
 	val suspend : Xenops_task.t -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val resume : Xenops_task.t -> xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit
 	val stop : xs:Xenstore.Xs.xsh -> qemu_domid:int -> Xenctrl.domid -> unit

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -23,6 +23,10 @@ external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_doma
 
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
+exception Unix_error of Unix.error * string
+
+let _ = Callback.register_exception "Xenctrlext.Unix_error" (Unix_error(Unix.E2BIG, ""))
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -40,3 +44,9 @@ external domain_get_runstate_info : handle -> int -> runstateinfo = "stub_xenctr
 external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
+
+external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -23,6 +23,8 @@ external domain_get_acpi_s_state: handle -> domid -> int = "stub_xenctrlext_doma
 
 external domain_suppress_spurious_page_faults: handle -> domid -> unit = "stub_xenctrlext_domain_suppress_spurious_page_faults"
 
+exception Unix_error of Unix.error * string
+
 type runstateinfo = {
   state : int32;
   missed_changes: int32;
@@ -40,3 +42,9 @@ external domain_get_runstate_info : handle -> int -> runstateinfo = "stub_xenctr
 external get_max_nr_cpus: handle -> int = "stub_xenctrlext_get_max_nr_cpus"
 
 external domain_set_target: handle -> domid -> domid -> unit = "stub_xenctrlext_domain_set_target"
+
+external assign_device: handle -> domid -> int -> int -> unit = "stub_xenctrlext_assign_device"
+
+external deassign_device: handle -> domid -> int -> unit = "stub_xenctrlext_deassign_device"
+
+external domid_quarantine: unit -> int = "stub_xenctrlext_domid_quarantine"

--- a/xc/xenctrlext_stubs.c
+++ b/xc/xenctrlext_stubs.c
@@ -33,22 +33,37 @@
 
 /* From xenctrl_stubs */
 #define ERROR_STRLEN 1024
+
+static void raise_unix_errno_msg(int err_code, const char *err_msg)
+{
+        CAMLparam0();
+        value args[] = { unix_error_of_code(err_code), caml_copy_string(err_msg) };
+
+        caml_raise_with_args(*caml_named_value("Xenctrlext.Unix_error"),
+                             sizeof(args)/sizeof(args[0]), args);
+        CAMLnoreturn;
+}
+
 static void failwith_xc(xc_interface *xch)
 {
         static char error_str[ERROR_STRLEN];
+        int real_errno = -1;
         if (xch) {
                 const xc_error *error = xc_get_last_error(xch);
-                if (error->code == XC_ERROR_NONE)
+                if (error->code == XC_ERROR_NONE) {
+                        real_errno = errno;
                         snprintf(error_str, ERROR_STRLEN, "%d: %s", errno, strerror(errno));
-                else
+                } else {
+                        real_errno = error->code;
                         snprintf(error_str, ERROR_STRLEN, "%d: %s: %s",
                                  error->code,
                                  xc_error_code_to_desc(error->code),
                                  error->message);
+                }
         } else {
                 snprintf(error_str, ERROR_STRLEN, "Unable to open XC interface");
         }
-        caml_raise_with_string(*caml_named_value("xc.error"), error_str);
+        raise_unix_errno_msg(real_errno, error_str);
 }
 
 CAMLprim value stub_xenctrlext_get_runstate_info(value xch, value domid)
@@ -195,6 +210,34 @@ CAMLprim value stub_xenctrlext_domain_set_target(value xch,
 	CAMLreturn(Val_unit);
 }
 
+CAMLprim value stub_xenctrlext_assign_device(value xch, value domid,
+        value machine_sbdf, value flag)
+{
+    CAMLparam4(xch, domid, machine_sbdf, flag);
+    caml_enter_blocking_section();
+    int retval = xc_assign_device(_H(xch), _D(domid), Int_val(machine_sbdf), Int_val(flag));
+    caml_leave_blocking_section();
+    if (retval)
+        failwith_xc(_H(xch));
+    CAMLreturn(Val_unit);
+}
+
+CAMLprim value stub_xenctrlext_deassign_device(value xch, value domid, value machine_sbdf)
+{
+    CAMLparam3(xch, domid, machine_sbdf);
+    caml_enter_blocking_section();
+    int retval = xc_deassign_device(_H(xch), _D(domid), Int_val(machine_sbdf));
+    caml_leave_blocking_section();
+    if (retval)
+       failwith_xc(_H(xch));
+    CAMLreturn(Val_unit);
+}
+
+CAMLprim value stub_xenctrlext_domid_quarantine(value unit)
+{
+    CAMLparam1(unit);
+    CAMLreturn(Val_int(DOMID_IO));
+}
 
 /* 
 * Local variables: 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1310,11 +1310,11 @@ module VM = struct
 							) (get_stubdom ~xs di.Xenctrl.domid);
 					| Vm.HVM { Vm.qemu_stubdom = false } ->
 						(if saved_state then Device.Dm.restore else Device.Dm.start)
-							task ~xs ~dmpath:qemu_dm info di.Xenctrl.domid
+							task ~xc ~xs ~dmpath:qemu_dm info di.Xenctrl.domid
 					| Vm.PV _ ->
 						Device.Vfb.add ~xc ~xs di.Xenctrl.domid;
 						Device.Vkbd.add ~xc ~xs di.Xenctrl.domid;
-						Device.Dm.start_vnconly task ~xs ~dmpath:qemu_dm info di.Xenctrl.domid
+						Device.Dm.start_vnconly task ~xc ~xs ~dmpath:qemu_dm info di.Xenctrl.domid
 			) (create_device_model_config vm vmextra vbds vifs vgpus);
 			match vm.Vm.ty with
 				| Vm.PV { vncterm = true; vncterm_ip = ip } -> Device.PV_Vnc.start ~xs ?ip di.Xenctrl.domid
@@ -1852,7 +1852,7 @@ module PCI = struct
 				end;
 
 				Device.PCI.bind [ pci.address ] Device.PCI.Pciback;
-				Device.PCI.add xs [ pci.address ] frontend_domid
+				Device.PCI.add xc xs [ pci.address ] frontend_domid
 			) Newest vm
 
 	let unplug task vm pci =


### PR DESCRIPTION
This commit makes changes for CA-297891, in which a special domain is
used in Xen to quarantine the PCI devices for pass-through. The
quarantine means a separate I/O address space for DMA of PCI device. Two
cases are considered in this commit:

1. when a PCI device is going to be passed-through to a guest domain, it
will be placed into quarantine firstly (done by toolstack). Later on,
when it is deassigned from the guest domain, it will be placed (done by
Xen) to quarantine domain, rather than the dom0.

2. when a PCI device, which had been passed-through to a guest domain and
now it is in quarantine, is going to be managed by host driver running on
dom0 to emulate virtual devices (not PCI pass-through), it should be
moved out from quarantine and assigned back to dom0. I.E. NVIDIA vGPUs
and Intel vGPUs.

Signed-off-by: Ming Lu <ming.lu@citrix.com>
Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>