### PR TITLE
Backport of CA-327906 - don't fail migration if a xenstore directory is missing

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1821,6 +1821,8 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
           Handshake.send s Handshake.Success;
           debug "VM.receive_memory: Synchronisation point 4";
         with e ->
+          Backtrace.is_important e;
+          Debug.log_backtrace e (Backtrace.get e);
           debug "Caught %s: cleaning up VM state" (Printexc.to_string e);
           perform_atomics (atomics_of_operation (VM_shutdown (id, None)) @ [
               VM_remove id

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1627,44 +1627,6 @@ module Vusb = struct
 
 end
 
-module Serial : sig
-  val update_xenstore: xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-end = struct
-  let tty_prefix     = "pty:"
-  let tty_path domid = Printf.sprintf "/local/domain/%d/serial/0/tty" domid
-  let strip n str    = String.sub str n (String.length str - n)
-
-  let is_serial0 device =
-    device.Qmp.label = "serial0"
-    && Astring.String.is_prefix tty_prefix device.Qmp.filename
-
-  let find_serial0 domid =
-    match qmp_send_cmd domid Qmp.Query_chardev with
-    | Qmp.(Char_devices devices) ->
-        List.find_opt is_serial0 devices
-    | other ->
-        warn "Unexpected QMP result for domid %d query-chardev" domid;
-        None
-
-  (** query qemu for the serial console and write it to xenstore. Only
-   *  write path for a real console, not a file or socket path.
-   *  CA-318579
-   *)
-  let update_xenstore ~xs domid =
-    if not @@ Qemu.is_running ~xs domid then begin
-      let msg = sprintf "Qemu not running for domain %d (%s)" domid __LOC__ in
-      raise (Internal_error msg)
-    end;
-    match find_serial0 domid with
-    | Some device ->
-        let path = strip (String.length tty_prefix) device.Qmp.filename in
-        xs.Xs.write (tty_path domid) path
-    | None        -> debug "no serial device for domain %d found" domid
-    | exception e ->
-        debug "Can't probe serial0 device for domid %d: %s"
-          domid (Printexc.to_string e)
-end
-
 let can_surprise_remove ~xs (x: device) = Generic.can_surprise_remove ~xs x
 
 (** Dm_Common contains the private Dm functions that are common between the qemu profile backends. *)

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -297,10 +297,6 @@ module Backend: sig
   val init : unit -> unit
 end
 
-module Serial : sig
-  val update_xenstore: xs:Xenstore.Xs.xsh -> Xenctrl.domid -> unit
-end
-
 module Vusb :
 sig
   val vusb_plug : xs:Xenstore.Xs.xsh -> privileged:bool -> domid:Xenctrl.domid -> id:string -> hostbus:string -> hostport: string -> version: string-> unit

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1517,9 +1517,15 @@ let move_xstree ~xs domid olduuid newuuid =
     { contents;
       subtrees = List.map (fun f -> (f, get_tree t (path @ [f]))) subtrees } in
 
+  let exists t path =
+    try let (_:string) = t.Xs.read (String.concat "/" path) in true
+    with Xs_protocol.Enoent _ -> false
+  in
+
   let mv_tree path =
     let open Xenstore in
     Xs.transaction xs (fun t ->
+        if exists t path then
         let tree = get_tree t path in
         let rec fixup write path (name,node) =
           let fixed_name = Re.replace_string regexp ~by:newuuid name in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1593,8 +1593,7 @@ module VM = struct
               ) (get_stubdom ~xs di.Xenctrl.domid);
           | Vm.HVM { Vm.qemu_stubdom = false } ->
             (if saved_state then Device.Dm.restore else Device.Dm.start)
-              task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid;
-            Device.Serial.update_xenstore ~xs di.Xenctrl.domid
+              task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid
           | Vm.PV _ ->
             Device.Vfb.add ~xc ~xs di.Xenctrl.domid;
             Device.Vkbd.add ~xc ~xs di.Xenctrl.domid;


### PR DESCRIPTION
* Backport for CA-327906 "don't fail migration if a xenstore directory is missing" from 
8c3756b9.

* Revert of "CA-318579 write serial device to xenstore for HVM". This was reverted because it was never released and requires support in OCaml QMP which makes it difficult to build.
