### PR TITLE
CA-330162 Ensure floppy options are passed to qemu

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -1863,8 +1863,26 @@ module Dm_Common = struct
     | VNC of disp_intf_opt * string option * bool * int * string option (* IP address, auto-allocate, port if previous false, keymap *)
     | SDL of disp_intf_opt * string (* X11 display *)
 
-  type media = Disk | Cdrom
-  let string_of_media = function Disk -> "disk" | Cdrom -> "cdrom"
+  module Media = struct
+    type t = Disk | Cdrom | Floppy
+
+    let to_string = function
+      | Disk -> "disk"
+      | Cdrom -> "cdrom"
+      | Floppy -> "floppy"
+
+    let format_of media file =
+      match media, file with
+      | Disk, _   -> ["format=raw"]
+      | Cdrom, "" -> []
+      | Cdrom, _  -> ["format=raw"]
+      | Floppy, _ -> ["format=raw"]
+
+    let lba_of = function
+      | Disk  -> "force-lba=on"
+      | Cdrom -> "force-lba=off"
+      | Floppy -> ""
+  end
 
   type info = {
     memory: int64;
@@ -1877,7 +1895,7 @@ module Dm_Common = struct
     usb: usb_opt;
     parallel: string option;
     nics: (string * string * int) list;
-    disks: (int * string * media) list;
+    disks: (int * string * Media.t) list;
     acpi: bool;
     disp: disp_opt;
     pci_emulations: string list;
@@ -2178,18 +2196,10 @@ module Dm_Common = struct
     stop_varstored ();
     stop_qemu ()
 
-  let format_of_media (media:media) file =
-    match media, file with
-    | Disk, _   -> ["format=raw"]
-    | Cdrom, "" -> []
-    | Cdrom, _  -> ["format=raw"]
-
-  let lba_of_media = function
-    | Disk  -> "force-lba=on"
-    | Cdrom -> "force-lba=off"
 
 
-  type disk_type_args = int * string * media -> string list
+
+  type disk_type_args = int * string * Media.t -> string list
 
   let ide = "ide"
   let ide_device_of ~trad_compat (index, file, media) =
@@ -2197,10 +2207,10 @@ module Dm_Common = struct
           [ sprintf "file=%s" file
           ; "if=ide"
           ; sprintf "index=%d" index
-          ; sprintf "media=%s" (string_of_media media)
+          ; sprintf "media=%s" (Media.to_string media)
           ]
-        ; if trad_compat then [lba_of_media media] else []
-        ; format_of_media media file])
+        ; if trad_compat then [Media.lba_of media] else []
+        ; Media.format_of media file])
     ]
 
   let nvme = "nvme"
@@ -2210,8 +2220,8 @@ module Dm_Common = struct
           [ sprintf "id=%s" id
           ; "if=none"
           ; sprintf "file=%s" file
-          ; sprintf "media=%s" (string_of_media media)
-          ] @ (format_of_media media file))
+          ; sprintf "media=%s" (Media.to_string media)
+          ] @ (Media.format_of media file))
     ; "-device"; String.concat ","
         ([ "nvme-ns"
          ; sprintf "drive=%s" id
@@ -3003,7 +3013,7 @@ module Backend = struct
 
         let disks_cdrom, disks_other =
           info.Dm_Common.disks
-          |> List.partition (function (_, _, Dm_Common.Cdrom) -> true | (_, _, _) -> false)
+          |> List.partition (function (_, _, Dm_Common.Media.Cdrom) -> true | (_, _, _) -> false)
         in
 
         let limit_emulated_disks disks =

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -243,7 +243,10 @@ sig
     | VNC of disp_intf_opt * string option * bool * int * string option (* IP address, auto-allocate, port if previous false, keymap *)
     | SDL of disp_intf_opt * string (* X11 display *)
 
-  type media = Disk | Cdrom
+  module Media :
+  sig
+    type t = Disk | Cdrom | Floppy
+  end
 
   type info = {
     memory: int64;
@@ -256,7 +259,7 @@ sig
     usb: usb_opt;
     parallel: string option;
     nics: (string * string * int) list;
-    disks: (int * string * media) list;
+    disks: (int * string * Media.t) list;
     acpi: bool;
     disp: disp_opt;
     pci_emulations: string list;

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1459,8 +1459,9 @@ module VM = struct
               let path = qemu_device_of_vbd_frontend bd in
               match vbd.Vbd.ty, vbd.mode with
               | Vbd.Disk, ReadOnly -> None
-              | Vbd.Disk, _        -> Some (index, path, Device.Dm.Disk)
-              | _                  -> Some (index, path, Device.Dm.Cdrom)
+              | Vbd.Disk, _        -> Some (index, path, Device.Dm.Media.Disk)
+              | Vbd.Floppy, _      -> Some (index, path, Floppy)
+              | Vbd.CDROM, _       -> Some (index, path, Cdrom)
             else None
           ) vbds in
         let usb_enabled =


### PR DESCRIPTION
Previously a floppy VBD would be treated as a
disk, which caused xenopsd to filter out that vbd
when deciding what args to execute qemu with.

Signed-off-by: lippirk <ben.anson@citrix.com>