### PR TITLE
Always add "console=xen" prefix to PV-shim cmdline

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -45,7 +45,7 @@ let vif_ready_for_igmp_query_timeout = ref 120
 
 let feature_flags_path = ref "/etc/xenserver/features.d"
 
-let pvinpvh_xen_cmdline = ref "pv-shim"
+let pvinpvh_xen_cmdline = ref "pv-shim console=xen"
 
 let numa_placement = ref false
 


### PR DESCRIPTION
We need to always have PV-shim output in our system logs to assist
analysis of potential failures in the field. This still leaves
an option to override console settings using "pvinpvh-xen-cmdline"
since only the last value will take effect.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>