### PR TITLE
CA-332952: Always pass no-smep and no-smap cmdline arguments to PV shim

### DIFF
--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -45,7 +45,7 @@ let vif_ready_for_igmp_query_timeout = ref 120
 
 let feature_flags_path = ref "/etc/xenserver/features.d"
 
-let pvinpvh_xen_cmdline = ref "pv-shim console=xen"
+let pvinpvh_xen_cmdline = ref "console=xen"
 
 let numa_placement = ref false
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1514,7 +1514,8 @@ module VM = struct
     } in
     debug "static_max_mib=%Ld" static_max_mib;
     let pvinpvh_xen_cmdline =
-      let base =
+      let base = "pv-shim no-smep no-smap" in
+      let opt =
         try List.assoc "pvinpvh-xen-cmdline" vm.Vm.platformdata
         with Not_found -> !Xenopsd.pvinpvh_xen_cmdline
       in
@@ -1529,7 +1530,7 @@ module VM = struct
         in
         Printf.sprintf "shim_mem=%LdM" shim_mib
       in
-      String.concat " " [base; shim_mem]
+      String.concat " " [base; opt; shim_mem]
     in
     (* We should prevent leaking files in our filesystem *)
     let kernel_to_cleanup = ref None in


### PR DESCRIPTION
Those do not necessary need to be enabled in PV shim and tend to affect
performance significantly in some cases. SMEP in particular locks up
PV shim domains with 32 vCPUs on AMD machines due to the nature of CR4
register change emulation in L0 Xen.

While doing this, split PV shim cmdline default to base and opt chunks
to avoid losing necessary arguments on override.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>