### PR TITLE
REQ-627 CA-333495 Introduce PCI.dequarantine

### DIFF
--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -110,6 +110,7 @@ module type S = sig
     val plug: Xenops_task.task_handle -> Vm.id -> Pci.t -> bool -> unit
     val unplug: Xenops_task.task_handle -> Vm.id -> Pci.t -> unit
     val get_device_action_request: Vm.id -> Pci.t -> device_action_request option
+    val dequarantine: Pci.address -> unit
   end
   module VBD : sig
     val set_active: Xenops_task.task_handle -> Vm.id -> Vbd.t -> bool -> unit

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -425,6 +425,7 @@ module PCI = struct
   let get_state vm pci = Mutex.execute m (pci_state vm pci)
 
   let get_device_action_request _vm _pci = None
+  let dequarantine _ = ()
 end
 
 module VGPU = struct

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -90,6 +90,7 @@ module VM = struct
 end
 module PCI = struct
   let get_state _ _ = unplugged_pci
+  let dequarantine _ = ()
   let plug _ _ _ = unimplemented "PCI.plug"
   let unplug _ _ _ = unimplemented "PCI.unplug"
   let get_device_action_request _ _ = None

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -3337,8 +3337,7 @@ module Dm = struct
       let cancel = Cancel_utils.Vgpu domid in
       if not (Vgpu.is_running ~xs domid) then begin
         let pcis = List.map (fun x -> x.physical_pci_address) vgpus in
-        List.iter (fun x -> ignore(PCI.dequarantine xc x)) pcis;
-          PCI.bind pcis PCI.Nvidia;
+        PCI.bind pcis PCI.Nvidia;
         let module Q = (val Backend.of_profile profile) in
         let args = vgpu_args_of_nvidia domid vcpus vgpus restore in
         let vgpu_pid = Vgpu.start_daemon ~path:!Xc_resources.vgpu ~args
@@ -3366,7 +3365,6 @@ module Dm = struct
         raise (Ioemu_failed ("vgpu", Printf.sprintf "Daemon vgpu returned error: %s" error_code))
       end
     | [{physical_pci_address = pci; implementation = GVT_g vgpu}] ->
-      ignore(PCI.dequarantine xc pci);
       PCI.bind [pci] PCI.I915
     | [{physical_pci_address = pci; implementation = MxGPU vgpu}] ->
       Mutex.execute gimtool_m (fun () ->

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -210,6 +210,8 @@ sig
   val reset : xs:Xenstore.Xs.xsh -> address -> unit
   val bind : address list -> supported_driver -> unit
   val list : xs:Xenstore.Xs.xsh -> Xenctrl.domid -> (int * address) list
+
+  val dequarantine : Xenctrl.handle ->  Xenops_interface.Pci.address -> bool
 end
 
 module Vfs :

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2365,6 +2365,16 @@ module PCI = struct
      * in Domain.destroy. *)
     ()
 
+  let dequarantine (pci:Pci.address) =
+    let fail msg = raise (Xenopsd_error (Internal_error msg)) in
+    let addr = Pci.string_of_address pci in
+    with_xc_and_xs @@ fun xc _xs ->
+      match Device.PCI.dequarantine xc pci with
+      | true ->
+          debug "PCI %s dequarantine - success" addr
+      | false ->
+          error "PCI %s dequarantine - failed" addr;
+          fail @@ Printf.sprintf "PCI %s dequarantine failed" addr
 end
 
 let set_active_device path active =


### PR DESCRIPTION
The commits in this PR introduce:

* an API call to de-quarantine a PCI device
* a PCI_dequarantine operation used during VM start

The API call is required because Xapi needs to configure drivers of PCI devices (just like xenopsd) and for this a PCI device must be de-quarantined. 

This PR depends on corresponding changes in xcp-idl: https://github.com/xapi-project/xcp-idl/pull/302 which has been reverted but needs to be active for this PR to work. Travis is broken because of the cross-repo dependencies.
