### PR TITLE
CA-335206 catch exception from Rpcmarshal.unmarshal

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1818,6 +1818,7 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
                  match Rpcmarshal.unmarshal Errors.error.Rpc.Types.ty (Jsonrpc.of_string msg) with
                  | Ok e ->    raise (Xenopsd_error e)
                  | Error _ -> raise (Xenopsd_error (Internal_error msg))
+                 | exception _ -> raise (Xenopsd_error (Internal_error msg))
              end;
              debug "VM.migrate: Synchronisation point 1";
            in


### PR DESCRIPTION
During migration we perform a handshake operation. If it fails, we try
to recover the error by trying to parse the error message as JSON.
However, the message could be something else which leads the JSON parser
to fail. We need to capture this exception in order to generate a proper
error message.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>