### PR TITLE
Use get_cpu_featureset instead of get_featureset

### DIFF
--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -737,9 +737,9 @@ module HOST = struct
          let cpu_count = p.nr_cpus in
          let socket_count = p.nr_cpus / (p.threads_per_core * p.cores_per_socket) in
 
-         let features = get_featureset xc Featureset_host in
-         let features_pv = get_featureset xc Featureset_pv in
-         let features_hvm = get_featureset xc Featureset_hvm in
+         let features = get_cpu_featureset xc Featureset_host in
+         let features_pv = get_cpu_featureset xc Featureset_pv in
+         let features_hvm = get_cpu_featureset xc Featureset_hvm in
          let features_oldstyle = oldstyle_featuremask xc in
 
          (* Compatibility with Xen 4.7 *)


### PR DESCRIPTION
The latter is an alias of the former in ocaml-xen-lowlevel-libs, and only
makes the code harder to follow.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>