### PR TITLE
Cleanups around Stdext: Stop using Opt and Stdext directly

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -14,13 +14,12 @@
 
 let project_url = "http://github.com/xapi-project/xenops-cli"
 
-open Common
 open Cmdliner
 
 (* Help sections common to all commands *)
 
 let _common_options = "COMMON OPTIONS"
-let help = [ 
+let help = [
   `S _common_options;
   `P "These options are common to all commands.";
   `S "MORE HELP";
@@ -29,16 +28,16 @@ let help = [
 ]
 
 (* Options common to all commands *)
-let common_options_t = 
-  let docs = _common_options in 
-  let debug = 
+let common_options_t =
+  let docs = _common_options in
+  let debug =
     let doc = "Give only debug output." in
     Arg.(value & flag & info ["debug"] ~docs ~doc) in
   let verb =
     let doc = "Give verbose output." in
-    let verbose = true, Arg.info ["v"; "verbose"] ~docs ~doc in 
-    Arg.(last & vflag_all [false] [verbose]) in 
-  let socket = 
+    let verbose = true, Arg.info ["v"; "verbose"] ~docs ~doc in
+    Arg.(last & vflag_all [false] [verbose]) in
+  let socket =
     let doc = Printf.sprintf "Specify path to the server Unix domain socket." in
     Arg.(value & opt file !Xenops_interface.default_path & info ["socket"] ~docs ~doc) in
   let queue =
@@ -79,7 +78,7 @@ let add_cmd =
     `S "DESCRIPTION";
     `P "Registers a new VM with the xenopsd service.";
   ] @ help in
-  let filename = 
+  let filename =
     let doc = Printf.sprintf "Path to the VM metadata to be registered." in
     Arg.(value & pos 0 (some file) None & info [] ~doc) in
   Term.(ret(pure Xn.add $ common_options_t $ filename)),
@@ -334,7 +333,7 @@ let cd_eject_cmd =
     let doc = "VBD id" in
     Arg.(value & pos 0 (some string) None & info [] ~doc) in
   Term.(ret (pure Xn.cd_eject $ common_options_t $ vbd)),
-  Term.info "cd-eject" ~sdocs:_common_options ~doc ~man  
+  Term.info "cd-eject" ~sdocs:_common_options ~doc ~man
 
 let stat_vm_cmd =
   let doc = "Query the runtime status of a running VM." in
@@ -348,8 +347,8 @@ let stat_vm_cmd =
   Term.(ret (pure Xn.stat_vm $ common_options_t $ vm)),
   Term.info "vm-stat" ~sdocs:_common_options ~doc ~man
 
-let default_cmd = 
-  let doc = "interact with the XCP xenopsd VM management service" in 
+let default_cmd =
+  let doc = "interact with the XCP xenopsd VM management service" in
   let man = help in
   Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_options_t)),
   Term.info "xenops-cli" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
@@ -361,6 +360,6 @@ let cmds = [list_cmd; create_cmd; add_cmd; remove_cmd; start_cmd; shutdown_cmd; 
 
 let _ =
   Xcp_client.use_switch := false;
-  match Term.eval_choice default_cmd cmds with 
+  match Term.eval_choice default_cmd cmds with
   | `Error _ -> exit 1
   | _ -> exit 0

--- a/cli/xn.ml
+++ b/cli/xn.ml
@@ -173,7 +173,6 @@ let parse_pci vm_id (x, idx) = match Re.Str.split_delim (Re.Str.regexp "[,]") x 
       ) options in
     let bool_opt k opts =
       if List.mem_assoc k opts then Some (List.assoc k opts = "1") else None in
-    let open Pci in
     let open Xn_cfg_types in
     let msitranslate = bool_opt _msitranslate options in
     let power_mgmt = bool_opt _power_mgmt options in
@@ -193,18 +192,6 @@ let parse_pci vm_id (x, idx) = match Re.Str.split_delim (Re.Str.regexp "[,]") x 
   | _ ->
     Printf.fprintf stderr "Failed to parse PCI '%s'. It should be '[DDDD:]BB:VV.F[,option1[,option2]]'." x;
     exit 2
-
-let print_disk vbd =
-  let device_number = snd vbd.Vbd.id in
-  let mode = match vbd.Vbd.mode with
-    | Vbd.ReadOnly -> "r"
-    | Vbd.ReadWrite -> "w" in
-  let ty = match vbd.Vbd.ty with
-    | Vbd.CDROM -> ":cdrom"
-    | Vbd.Floppy -> ":floppy"
-    | Vbd.Disk -> "" in
-  let source = print_source vbd.Vbd.backend in
-  Printf.sprintf "%s,%s%s,%s" source device_number ty mode
 
 type disk_info = {
   id: string;

--- a/dbgring/dbgring.ml
+++ b/dbgring/dbgring.ml
@@ -25,7 +25,7 @@ let open_ring0 () =
 
 let open_ringU domid mfn =
   let xc = Xenctrl.interface_open () in
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () -> Xenctrl.map_foreign_range xc domid (Xenmmap.getpagesize()) mfn)
     (fun () -> Xenctrl.interface_close xc)
 

--- a/dbgring/dune
+++ b/dbgring/dune
@@ -2,7 +2,19 @@
  (name dbgring)
  (public_name dbgring)
  (package xapi-xenopsd-xc)
- (libraries xapi-xenopsd xenctrl xenstore xenstore.unix
- xenstore_transport xenstore_transport.unix threads stdext xapi-idl.xen
- rpclib.core uutf xapi-idl rpclib.json)
+ (libraries
+   xapi-xenopsd
+   xenctrl
+   xenstore
+   xenstore.unix
+   xenstore_transport
+   xenstore_transport.unix
+   threads
+   xapi-idl.xen
+   rpclib.core
+   uutf
+   xapi-idl
+   rpclib.json
+   xapi-stdext-pervasives
+ )
 )

--- a/doc/walk-throughs/VM.start.md
+++ b/doc/walk-throughs/VM.start.md
@@ -467,7 +467,7 @@ is reassuringly simple:
 ```
 		if di.Xenctrl.total_memory_pages = 0n then raise (Domain_not_built);
 		Domain.unpause ~xc di.Xenctrl.domid;
-		Opt.iter
+		Option.iter
 			(fun stubdom_domid ->
 				Domain.unpause ~xc stubdom_domid
 			) (get_stubdom ~xs di.Xenctrl.domid)

--- a/lib/bootloader.ml
+++ b/lib/bootloader.ml
@@ -55,7 +55,7 @@ type t = {
 }
 
 (** Helper function to generate a bootloader commandline *)
-let command bootloader q pv_bootloader_args image vm_uuid = 
+let command bootloader q pv_bootloader_args image vm_uuid =
   (* Let's not do anything fancy while parsing the pv_bootloader_args string:
      no escaping of spaces or quotes for now *)
   let pv_bootloader_args = if pv_bootloader_args = "" then [] else Astring.String.cuts ~sep:" " pv_bootloader_args in
@@ -78,7 +78,7 @@ let command bootloader q pv_bootloader_args image vm_uuid =
       vm;
       pv_bootloader_args;
       image;
-    ] in    
+    ] in
     path_of_bootloader Eliloader, List.concat args
   | None -> raise (Unknown_bootloader bootloader)
 

--- a/lib/bootloader.ml
+++ b/lib/bootloader.ml
@@ -157,7 +157,7 @@ let sanity_check_path p = match p with
   | p when Filename.is_relative p ->
     raise (Bad_error ("Bootloader returned a relative path for kernel or ramdisk: "^p))
   | p ->
-    let canonical_path = Stdext.Unixext.resolve_dot_and_dotdot p in
+    let canonical_path = Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot p in
     match Filename.dirname canonical_path with
     | "/var/run/xen/pygrub" (* From pygrub, including when called by eliloader *)
     | "/var/run/xend/boot" (* From eliloader *)

--- a/lib/cancellable_subprocess.ml
+++ b/lib/cancellable_subprocess.ml
@@ -19,7 +19,7 @@ open D
 
 open Forkhelpers
 
-let finally = Stdext.Pervasiveext.finally
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let run (task: Xenops_task.task_handle) ?env ?stdin fds ?(syslog_stdout=NoSyslogging) cmd args =
   let stdinandpipes = Option.map (fun str ->

--- a/lib/cancellable_subprocess.ml
+++ b/lib/cancellable_subprocess.ml
@@ -22,7 +22,7 @@ open Forkhelpers
 let finally = Stdext.Pervasiveext.finally
 
 let run (task: Xenops_task.task_handle) ?env ?stdin fds ?(syslog_stdout=NoSyslogging) cmd args =
-  let stdinandpipes = Opt.map (fun str ->
+  let stdinandpipes = Option.map (fun str ->
       let (x,y) = Unix.pipe () in
       (str,x,y)) stdin in
   (* Used so that cancel -> kills subprocess -> Unix.WSIGNALED -> raise cancelled *)
@@ -30,7 +30,7 @@ let run (task: Xenops_task.task_handle) ?env ?stdin fds ?(syslog_stdout=NoSyslog
   finally (fun () ->
       match with_logfile_fd "execute_command_get_out" (fun out_fd ->
           with_logfile_fd "execute_command_get_err" (fun err_fd ->
-              let t = safe_close_and_exec ?env (Opt.map (fun (_,fd,_) -> fd) stdinandpipes) (Some out_fd) (Some err_fd) fds ~syslog_stdout cmd args in
+              let t = safe_close_and_exec ?env (Option.map (fun (_,fd,_) -> fd) stdinandpipes) (Some out_fd) (Some err_fd) fds ~syslog_stdout cmd args in
               let done_waitpid = ref false in
               finally
                 (fun () ->
@@ -42,7 +42,7 @@ let run (task: Xenops_task.task_handle) ?env ?stdin fds ?(syslog_stdout=NoSyslog
                         try Unix.kill pid' Sys.sigkill with _ -> ()
                      )
                      (fun () ->
-                        Opt.iter (fun (str,_,wr) -> Unixext.really_write wr str 0 (String.length str)) stdinandpipes;
+                        Option.iter (fun (str,_,wr) -> Unixext.really_write wr str 0 (String.length str)) stdinandpipes;
                         done_waitpid := true;
                         snd (Forkhelpers.waitpid t)
                      )
@@ -66,4 +66,4 @@ let run (task: Xenops_task.task_handle) ?env ?stdin fds ?(syslog_stdout=NoSyslog
       | Success(_,Failure(_,exn))
       | Failure(_, exn) ->
         raise exn)
-    (fun () -> Opt.iter (fun (_,x,y) -> Unix.close x; Unix.close y) stdinandpipes)
+    (fun () -> Option.iter (fun (_,x,y) -> Unix.close x; Unix.close y) stdinandpipes)

--- a/lib/cancellable_subprocess.ml
+++ b/lib/cancellable_subprocess.ml
@@ -48,7 +48,7 @@ let run (task: Xenops_task.task_handle) ?env ?stdin fds ?(syslog_stdout=NoSyslog
                      )
                 ) (fun () -> if not(!done_waitpid) then Forkhelpers.dontwaitpid t)
             )) with
-      | Success(out,Success(err,(status))) -> 
+      | Success(out,Success(err,(status))) ->
         begin
           match status with
           | Unix.WEXITED 0 -> (out,err)

--- a/lib/dune
+++ b/lib/dune
@@ -35,7 +35,7 @@
    fmt
    xapi-stdext-date
    xapi-stdext-pervasives
-   xapi-stdext-std
+   xapi-stdext-threads
    xapi-stdext-unix
  )
  (preprocess

--- a/lib/dune
+++ b/lib/dune
@@ -10,7 +10,34 @@
  (public_name xapi-xenopsd)
  (wrapped false)
  (flags :standard -warn-error +a-3)
- (libraries c_stubs stdext threads threads.posix uuidm xmlm cohttp uri rpclib.core forkexec fd-send-recv xapi-idl xapi-idl.xen xapi-idl.storage xapi-idl.updates xapi-idl.varstore.privileged sexplib ppx_sexp_conv.runtime-lib uutf core re re.pcre fmt)
+ (libraries
+   c_stubs
+   threads
+   threads.posix
+   uuidm
+   xmlm
+   cohttp
+   uri
+   rpclib.core
+   forkexec
+   fd-send-recv
+   xapi-idl
+   xapi-idl.xen
+   xapi-idl.storage
+   xapi-idl.updates
+   xapi-idl.varstore.privileged
+   sexplib
+   ppx_sexp_conv.runtime-lib
+   uutf
+   core
+   re
+   re.pcre
+   fmt
+   xapi-stdext-date
+   xapi-stdext-pervasives
+   xapi-stdext-std
+   xapi-stdext-unix
+ )
  (preprocess
   (pps ppx_deriving_rpc ppx_sexp_conv)
  )

--- a/lib/suspend_image.ml
+++ b/lib/suspend_image.ml
@@ -45,7 +45,7 @@ module Xenops_record = struct
   } [@@deriving sexp]
 
   let make ?vm_str ?xs_subtree () =
-    let time = Stdext.Date.(to_string (of_float (Unix.time ()))) in
+    let time = Xapi_stdext_date.Date.(to_string (of_float (Unix.time ()))) in
     let word_size = Sys.word_size in
     { word_size; time; vm_str; xs_subtree }
 
@@ -155,9 +155,9 @@ type 'a thread_status = Running | Thread_failure of exn | Success of 'a
 let with_conversion_script task name hvm fd f =
   let module D = Debug.Make(struct let name = "suspend_image_conversion" end) in
   let open D in
-  let open Stdext in
-  let open Pervasiveext in
-  let open Threadext in
+  let module Mutex = Xapi_stdext_threads.Threadext.Mutex in
+  let module Unixext = Xapi_stdext_unix.Unixext in
+  let finally = Xapi_stdext_pervasives.Pervasiveext.finally in
   check_conversion_script () >>= fun () ->
   let (pipe_r, pipe_w) = Unix.pipe () in
   let fd_uuid = Uuidm.(to_string (create `V4))

--- a/lib/tuntap.ml
+++ b/lib/tuntap.ml
@@ -4,7 +4,7 @@
 
 external _tap_open : string -> Unix.file_descr = "stub_tap_open"
 
-let finally = Stdext.Pervasiveext.finally
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let tap_open ifname =
   try

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1838,7 +1838,7 @@ and perform_exn ?subtask ?result (op: operation) (t: Xenops_task.task_handle) : 
            in
 
            (* If we have a vGPU, kick off its migration process before
-              					 * starting the main VM migration sequence. *)
+            * starting the main VM migration sequence. *)
            match VGPU_DB.ids id with
            | [] ->
              first_handshake ();

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -22,7 +22,7 @@ open D
 
 let rpc_of ty x = Rpcmarshal.marshal ty.Rpc.Types.ty x
 
-let finally = Stdext.Pervasiveext.finally
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let domain_shutdown_ack_timeout = ref 60.
 
@@ -696,7 +696,7 @@ module Worker = struct
 end
 
 module WorkerPool = struct
-  module Date = Stdext.Date
+  module Date = Xapi_stdext_date.Date
 
   (* Store references to Worker.ts here *)
   let pool = ref []

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1652,7 +1652,7 @@ and trigger_cleanup_after_failure_atom op t =
   | PCI_plug (id, _)
   | PCI_unplug id ->
     immediate_operation dbg (fst id) (PCI_check_state id)
-  | PCI_dequarantine addr -> ()
+  | PCI_dequarantine _ -> ()
 
   | VUSB_plug id
   | VUSB_unplug id ->
@@ -2174,7 +2174,7 @@ module PCI = struct
   let dequarantine _ dbg (pci_addr:Pci.address) =
     let module B = (val get_backend () : S) in
     let f () =
-      debug "PCI.dequarantine %s" B.PCI.(string_of_address pci_addr);
+      debug "PCI.dequarantine %s" (string_of_address pci_addr);
       B.PCI.dequarantine pci_addr
     in
     Debug.with_thread_associated dbg f ()

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -107,7 +107,7 @@ let utf8_recode str =
   loop d e;
   Buffer.contents b
 
-let dropnone x = List.filter_map (Opt.map (fun x -> x)) x
+let dropnone x = List.filter_map (Option.map Fun.id) x
 
 module FileFS = struct
   (** A directory tree containiign files, each of which contain strings *)
@@ -308,7 +308,7 @@ module TypedTable = functor(I: ITEM) -> struct
   let read (k: I.key) =
     let module FS = (val get_fs_backend () : FS) in
     let path = get_path k in
-    Opt.map (fun x -> match Rpcmarshal.unmarshal t.Rpc.Types.ty x with | Ok x -> x | Error (`Msg m) -> failwith (Printf.sprintf "Failed to unmarshal '%s': %s" I.namespace m)) (FS.read path)
+    Option.map (fun x -> match Rpcmarshal.unmarshal t.Rpc.Types.ty x with | Ok x -> x | Error (`Msg m) -> failwith (Printf.sprintf "Failed to unmarshal '%s': %s" I.namespace m)) (FS.read path)
 
   let read_exn (k: I.key) = match read k with
     | Some x -> x

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -13,9 +13,8 @@
  *)
 
 open Xenops_interface
-module Unixext = Stdext.Unixext
-module Opt = Stdext.Opt
-module Mutex = Stdext.Threadext.Mutex
+module Unixext = Xapi_stdext_unix.Unixext
+module Mutex = Xapi_stdext_threads.Threadext.Mutex
 
 let rpc_of ty x = Rpcmarshal.marshal ty.Rpc.Types.ty x
 

--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -106,7 +106,7 @@ let handle_received_fd this_connection =
   debug "Calling recv_fd()";
   let len, _, received_fd = Fd_send_recv.recv_fd this_connection buf 0 msg_size [] in
   debug "recv_fd ok (len = %d)" len;
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
        let req = Bytes.sub_string buf 0 len |> Jsonrpc.of_string |> Xenops_migrate.Forwarded_http_request.t_of_rpc in
        debug "Received request = [%s]\n%!" (req |> Xenops_migrate.Forwarded_http_request.rpc_of_t |> Jsonrpc.to_string);

--- a/list_domains/list_domains.ml
+++ b/list_domains/list_domains.ml
@@ -19,7 +19,7 @@ let bytes = ref false
 let pages = ref false
 let all_the_rest = ref false
 
-let xc_handle = Xenctrl.interface_open() 
+let xc_handle = Xenctrl.interface_open()
 
 let hashtbl_of_domaininfo x : (string, string) Hashtbl.t =
   let table = Hashtbl.create 10 in
@@ -53,13 +53,11 @@ let hashtbl_of_domaininfo x : (string, string) Hashtbl.t =
   let shadow_mib =
     try Some (Int64.of_int (Xenctrl.shadow_allocation_get xc_handle x.domid))
     with _ -> None in
-  let open Xapi_stdext_pervasives.Pervasiveext in
-  let open Xapi_stdext_monadic in
-  let shadow_bytes = may Memory.bytes_of_mib shadow_mib in
-  let shadow_pages = may Memory.pages_of_mib shadow_mib in
-  Hashtbl.add table "shadow bytes" (Opt.default "N/A" (may Int64.to_string shadow_bytes));
-  Hashtbl.add table "shadow pages" (Opt.default "N/A" (may Int64.to_string shadow_pages));
-  Hashtbl.add table "shadow MiB"   (Opt.default "N/A" (may Int64.to_string shadow_mib  ));
+  let shadow_bytes = Option.map Memory.bytes_of_mib shadow_mib in
+  let shadow_pages = Option.map Memory.pages_of_mib shadow_mib in
+  Hashtbl.add table "shadow bytes" (Option.value ~default:"N/A" (Option.map Int64.to_string shadow_bytes));
+  Hashtbl.add table "shadow pages" (Option.value ~default:"N/A" (Option.map Int64.to_string shadow_pages));
+  Hashtbl.add table "shadow MiB"   (Option.value ~default:"N/A" (Option.map Int64.to_string shadow_mib  ));
   table
 
 let select table keys =

--- a/suspend_image_viewer/suspend_image_viewer.ml
+++ b/suspend_image_viewer/suspend_image_viewer.ml
@@ -105,7 +105,7 @@ let print_layout headers =
 module D = Debug.Make(struct let name = "suspend-image-viewer" end)
 
 let print_image path =
-  Stdext.Unixext.with_file path [Unix.O_RDONLY] 0o400 (fun fd ->
+  Xapi_stdext_unix.Unixext.with_file path [Unix.O_RDONLY] 0o400 (fun fd ->
       print_layout (parse_layout fd)
     )
 

--- a/test/test.ml
+++ b/test/test.ml
@@ -150,7 +150,7 @@ let vm_test_remove_missing _ =
     | Xenopsd_error Does_not_exist (_,_) -> None
     | e -> Some e
   in
-  Opt.iter raise exn
+  Option.iter raise exn
 
 let example_uuid = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0"
 
@@ -268,9 +268,9 @@ let vm_assert_equal vm vm' =
     assert_equal ~msg:"video_mib" ~printer:string_of_int h.video_mib h'.video_mib;
     assert_equal ~msg:"video" ~printer:(fun x -> x |> rpc_of_video_card |> Jsonrpc.to_string) h.video h'.video;
     assert_equal ~msg:"acpi" ~printer:string_of_bool h.acpi h'.acpi;
-    assert_equal ~msg:"serial" ~printer:(Opt.default "None") h.serial h'.serial;
-    assert_equal ~msg:"keymap" ~printer:(Opt.default "None") h.keymap h'.keymap;
-    assert_equal ~msg:"vnc_ip" ~printer:(Opt.default "None") h.vnc_ip h'.vnc_ip;
+    assert_equal ~msg:"serial" ~printer:(Option.value ~default:"None") h.serial h'.serial;
+    assert_equal ~msg:"keymap" ~printer:(Option.value ~default:"None") h.keymap h'.keymap;
+    assert_equal ~msg:"vnc_ip" ~printer:(Option.value ~default:"None") h.vnc_ip h'.vnc_ip;
     assert_equal ~msg:"pci_emulations" ~printer:(String.concat ";")  h.pci_emulations h'.pci_emulations;
     assert_equal ~msg:"pci_passthrough" ~printer:string_of_bool  h.pci_passthrough h'.pci_passthrough;
     assert_equal ~msg:"boot_order" ~printer:(fun x -> x) h.boot_order h'.boot_order;
@@ -278,7 +278,7 @@ let vm_assert_equal vm vm' =
   | (PV p|PVinPVH p), (PV p' | PVinPVH p') ->
     assert_equal ~msg:"framebuffer" ~printer:string_of_bool p.framebuffer p'.framebuffer;
     assert_equal ~msg:"vncterm" ~printer:string_of_bool p.vncterm p'.vncterm;
-    assert_equal ~msg:"vncterm_ip" ~printer:(Opt.default "None") p.vncterm_ip p'.vncterm_ip;
+    assert_equal ~msg:"vncterm_ip" ~printer:(Option.value ~default:"None") p.vncterm_ip p'.vncterm_ip;
     begin match p.boot, p'.boot with
       | Direct _, Indirect _
       | Indirect _, Direct _ -> failwith "pv-boot-ness"
@@ -643,7 +643,7 @@ module VbdDeviceTests = DeviceTests(struct
       let open Vbd in
       assert_equal ~msg:"id" ~printer:(fun (a, b) -> Printf.sprintf "%s.%s" a b) vbd.id vbd'.id;
       assert_equal ~msg:"mode" ~printer:(function ReadWrite -> "RW" | ReadOnly -> "RO") vbd.mode vbd'.mode;
-      assert_equal ~msg:"backend" ~printer:(fun x -> Opt.default "None" (Opt.map (fun x -> x |> rpc_of_disk |> Jsonrpc.to_string) x)) vbd.backend vbd'.backend;
+      assert_equal ~msg:"backend" ~printer:(fun x -> Option.value ~default:"None" (Option.map (fun x -> x |> rpc_of_disk |> Jsonrpc.to_string) x)) vbd.backend vbd'.backend;
       assert_equal ~msg:"unpluggable" ~printer:string_of_bool vbd.unpluggable vbd'.unpluggable;
       assert_equal ~msg:"extra_backend_keys" ~printer:sl vbd.extra_backend_keys vbd'.extra_backend_keys;
       assert_equal ~msg:"extra_private_keys" ~printer:sl vbd.extra_private_keys vbd'.extra_private_keys

--- a/test/test.ml
+++ b/test/test.ml
@@ -29,7 +29,7 @@ let usage_and_exit () =
 
 let dbg = "test"
 
-let finally = Stdext.Pervasiveext.finally
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 let expect_exception pred f =
   let exn =

--- a/xc/cancel_utils.ml
+++ b/xc/cancel_utils.ml
@@ -105,7 +105,7 @@ let on_shutdown ~xs domid =
 
 let with_path ~xs key f =
   let path = cancel_path_of ~xs key in
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
        xs.Xs.write path "";
        f ()

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -591,7 +591,7 @@ module Vbd_Common = struct
       "params", x.params;
     ]);
 
-    Opt.iter
+    Option.iter
       (fun protocol ->
          Hashtbl.add front_tbl "protocol" (string_of_protocol protocol)
       ) x.protocol;
@@ -643,7 +643,7 @@ module Vbd_Common = struct
             debug "Temporary failure to allocte a device number; retrying";
             Thread.delay 0.1
           end else raise e (* permanent failure *)
-      done; Opt.unbox !result in
+      done; Option.get !result in
     add_wait task ~xc ~xs device
 
   let qemu_media_change ~xs device _type params =
@@ -1120,7 +1120,7 @@ module PV_Vnc = struct
 
   let start ?statefile ~xs ?ip domid =
     debug "In PV_Vnc.start";
-    let ip = Opt.default "127.0.0.1" ip in
+    let ip = Option.value ~default:"127.0.0.1" ip in
     let l = [ "-x"; sprintf "/local/domain/%d/console" domid;
               "-T"; (* listen for raw connections *)
               "-v"; ip ^ ":1";
@@ -2070,7 +2070,7 @@ module Dm_Common = struct
     in
     let videoram_opt = ["-videoram"; string_of_int info.video_mib] in
     let vnc_opts_of ip_addr_opt auto port keymap ~domid =
-      let ip_addr = Opt.default "127.0.0.1" ip_addr_opt in
+      let ip_addr = Option.value ~default:"127.0.0.1" ip_addr_opt in
       let unused_opt, vnc_arg = match domid with
         | None when auto -> ["-vncunused"], Printf.sprintf "%s:1"  ip_addr
         | None           -> [], Printf.sprintf "%s:%d" ip_addr port

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -32,7 +32,7 @@ exception Cdrom
 module D = Debug.Make(struct let name = "xenops" end)
 open D
 
-let finally = Stdext.Pervasiveext.finally
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 (** Definition of available qemu profiles, used by the qemu backend implementations *)
 module Profile = struct

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -425,7 +425,7 @@ let with_qmp_connection domid f =
       Qmp_protocol.connect (qmp_libxl_path domid)
     )
   in
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () -> f connection)
     (fun () -> exec (fun () ->
          Qmp_protocol.close connection

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -256,7 +256,7 @@ let parse_backend_link x =
   | _ -> None
 
 let readdir ~xs d = try xs.Xs.directory d with Xs_protocol.Enoent _ -> []
-let to_list ys = List.concat (List.map Opt.to_list ys)
+let to_list ys = List.concat (List.map Option.to_list ys)
 let list_kinds ~xs dir = to_list (List.map parse_kind (readdir ~xs dir))
 
 (* NB: we only read data from the frontend directory. Therefore this gives

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -599,7 +599,7 @@ let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid ~dm domid =
 
   (* Remove our reference to the /vm/<uuid> directory *)
   let vm_path = try Some (xs.Xs.read (dom_path ^ "/vm")) with _ -> None in
-  Opt.iter (fun vm_path -> log_exn_rm ~xs (vm_path ^ "/domains/" ^ (string_of_int domid))) vm_path;
+  Option.iter (fun vm_path -> log_exn_rm ~xs (vm_path ^ "/domains/" ^ (string_of_int domid))) vm_path;
 
   (* Delete /local/domain/<domid>, /xenops/domain/<domid>, /libxl/<domid>
      	 * and all the backend device paths *)

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -602,7 +602,7 @@ let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid ~dm domid =
   Option.iter (fun vm_path -> log_exn_rm ~xs (vm_path ^ "/domains/" ^ (string_of_int domid))) vm_path;
 
   (* Delete /local/domain/<domid>, /xenops/domain/<domid>, /libxl/<domid>
-     	 * and all the backend device paths *)
+   * and all the backend device paths *)
   debug "VM = %s; domid = %d; xenstore-rm %s" (Uuid.to_string uuid) domid dom_path;
   xs.Xs.rm dom_path;
   xs.Xs.rm xenops_dom_path;
@@ -615,9 +615,9 @@ let destroy (task: Xenops_task.task_handle) ~xc ~xs ~qemu_domid ~dm domid =
   ) ["/backend"; "/xenserver/backend"];
 
   (* If all devices were properly un-hotplugged, then zap the private tree in
-     	 * xenstore.  If there was some error leave the tree for debugging / async
-     	 * cleanup.  If there are any remaining domains with the same UUID, then
-     	 * zap only the hotplug tree for the destroyed domain. *)
+   * xenstore.  If there was some error leave the tree for debugging / async
+   * cleanup.  If there are any remaining domains with the same UUID, then
+   * zap only the hotplug tree for the destroyed domain. *)
   if failed_devices = [] then begin
     if List.length other_domains < 1 then
       log_exn_rm ~xs (Device_common.get_private_path_by_uuid uuid)

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -25,7 +25,7 @@ open Xenops_task
 module D = Debug.Make(struct let name = "xenops" end)
 open D
 
-let finally = Stdext.Pervasiveext.finally
+let finally = Xapi_stdext_pervasives.Pervasiveext.finally
 
 type xen_arm_arch_domainconfig = Xenctrl.xen_arm_arch_domainconfig = {
   gic_version: int;
@@ -1534,7 +1534,7 @@ type suspend_flag = Live | Debug
       debug "Writing End_of_image footer(s)";
       progress_callback 1.;
       (* Close all streams *)
-      let fds = Stdext.Listext.List.setify (main_fd :: Opt.to_list vgpu_fd) in
+      let fds = Xapi_stdext_std.Listext.List.setify (main_fd :: Option.to_list vgpu_fd) in
       fold (fun fd () -> write_header fd (End_of_image, 0L)) fds ()
     in (match res with
     | `Error e -> raise e

--- a/xc/dune
+++ b/xc/dune
@@ -4,10 +4,34 @@
  (package xapi-xenopsd-xc)
  (flags -warn-error +a-3)
 
- (libraries astring xenctrl xapi-xenopsd xenstore xenstore.unix
-  xenstore_transport.unix rpclib.core forkexec xapi-idl xapi-idl.storage xapi-idl.memory
-  xapi-idl.rrd xapi-idl.network xapi-idl.varstore.privileged xapi-rrd sexplib xapi-inventory ezxenstore profiling qmp
-  mtime.clock.os ppx_sexp_conv.runtime-lib re re.pcre)
+ (libraries
+   astring
+   xenctrl
+   xapi-xenopsd
+   xenstore
+   xenstore.unix
+   xenstore_transport.unix
+   rpclib.core
+   forkexec
+   xapi-idl
+   xapi-idl.storage
+   xapi-idl.memory
+   xapi-idl.rrd
+   xapi-idl.network
+   xapi-idl.varstore.privileged
+   xapi-rrd sexplib
+   xapi-inventory
+   ezxenstore
+   profiling qmp
+   mtime.clock.os
+   ppx_sexp_conv.runtime-lib
+   re
+   re.pcre
+   xapi-stdext-pervasives
+   xapi-stdext-std
+   xapi-stdext-threads
+   xapi-stdext-unix
+ )
 
  (preprocess
   (pps ppx_deriving_rpc ppx_sexp_conv)

--- a/xc/emu_manager.ml
+++ b/xc/emu_manager.ml
@@ -180,7 +180,7 @@ let with_connection (task: Xenops_task.task_handle) path domid (args: string lis
     info "Cancelling task %s; sending 'abort' to emu-manager pid: %d"
       (Xenops_task.id_of_handle task) pid;
     send_abort t in
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
        Xenops_task.with_cancel task cancel_cb
          (fun () ->

--- a/xc/hotplug.ml
+++ b/xc/hotplug.ml
@@ -219,7 +219,7 @@ let release (task:Xenops_task.task_handle) ~xc ~xs (x: device) =
   let extra_xenserver_path = extra_xenserver_path_of_device xs x in
   Xs.transaction xs (fun t ->
       t.Xst.rm hotplug_path;
-      Opt.iter t.Xst.rm private_data_path;
+      Option.iter t.Xst.rm private_data_path;
       t.Xst.rm extra_xenserver_path
     )
 

--- a/xc/list_domains.ml
+++ b/xc/list_domains.ml
@@ -20,9 +20,9 @@ let bytes = ref false
 let pages = ref false
 let all_the_rest = ref false
 
-let xc_handle = Xenctrl.interface_open() 
+let xc_handle = Xenctrl.interface_open()
 
-let hashtbl_of_domaininfo (x: Xenctrl.domaininfo) : (string, string) Hashtbl.t = 
+let hashtbl_of_domaininfo (x: Xenctrl.domaininfo) : (string, string) Hashtbl.t =
   let table = Hashtbl.create 10 in
 
   let pages_to_string_bytes    x = Int64.to_string (Memory.bytes_of_pages    (Int64.of_nativeint (x))) in
@@ -32,8 +32,8 @@ let hashtbl_of_domaininfo (x: Xenctrl.domaininfo) : (string, string) Hashtbl.t =
   let int = string_of_int and int64 = Int64.to_string and int32 = Int32.to_string in
   Hashtbl.add table "id" (int x.Xenctrl.domid);
   let state = let bool ch = function true -> ch | _ -> " " in
-    (bool "D" x.Xenctrl.dying) ^ (bool "S" x.Xenctrl.shutdown) ^ 
-    (bool "P" x.Xenctrl.paused) ^ (bool "B" x.Xenctrl.blocked) ^ 
+    (bool "D" x.Xenctrl.dying) ^ (bool "S" x.Xenctrl.shutdown) ^
+    (bool "P" x.Xenctrl.paused) ^ (bool "B" x.Xenctrl.blocked) ^
     (bool "R" x.Xenctrl.running) ^ (bool "H" x.Xenctrl.hvm_guest) in
   Hashtbl.add table "state" state;
   Hashtbl.add table "shutdown code" (int x.Xenctrl.shutdown_code);
@@ -60,8 +60,8 @@ let hashtbl_of_domaininfo (x: Xenctrl.domaininfo) : (string, string) Hashtbl.t =
   Hashtbl.add table "shadow MiB"   (Option.value ~default:"N/A" (Option.map Int64.to_string shadow_mib  ));
   table
 
-let select table keys = 
-  List.map (fun key -> 
+let select table keys =
+  List.map (fun key ->
       if not(Hashtbl.mem table key) then failwith (Printf.sprintf "Failed to find key: %s" key);
       Hashtbl.find table key) keys
 

--- a/xc/list_domains.ml
+++ b/xc/list_domains.ml
@@ -53,11 +53,11 @@ let hashtbl_of_domaininfo (x: Xenctrl.domaininfo) : (string, string) Hashtbl.t =
   let shadow_mib =
     try Some (Int64.of_int (Xenctrl.shadow_allocation_get xc_handle x.Xenctrl.domid))
     with _ -> None in
-  let shadow_bytes = may Memory.bytes_of_mib shadow_mib in
-  let shadow_pages = may Memory.pages_of_mib shadow_mib in
-  Hashtbl.add table "shadow bytes" (Opt.default "N/A" (may Int64.to_string shadow_bytes));
-  Hashtbl.add table "shadow pages" (Opt.default "N/A" (may Int64.to_string shadow_pages));
-  Hashtbl.add table "shadow MiB"   (Opt.default "N/A" (may Int64.to_string shadow_mib  ));
+  let shadow_bytes = Option.map Memory.bytes_of_mib shadow_mib in
+  let shadow_pages = Option.map Memory.pages_of_mib shadow_mib in
+  Hashtbl.add table "shadow bytes" (Option.value ~default:"N/A" (Option.map Int64.to_string shadow_bytes));
+  Hashtbl.add table "shadow pages" (Option.value ~default:"N/A" (Option.map Int64.to_string shadow_pages));
+  Hashtbl.add table "shadow MiB"   (Option.value ~default:"N/A" (Option.map Int64.to_string shadow_mib  ));
   table
 
 let select table keys = 

--- a/xc/stats.ml
+++ b/xc/stats.ml
@@ -91,7 +91,7 @@ let sample (name: string) (x: float) : unit =
 (** Helper function to time a specific thing *)
 let time_this (name: string) f =
   let start_time = Unix.gettimeofday () in
-  Stdext.Pervasiveext.finally f
+  Xapi_stdext_pervasives.Pervasiveext.finally f
     (fun () ->
        try
          let end_time = Unix.gettimeofday () in

--- a/xc/xenguestHelper.ml
+++ b/xc/xenguestHelper.ml
@@ -85,7 +85,7 @@ let with_connection (task: Xenops_task.task_handle) path domid (args: string lis
     cancelled := true;
     info "Cancelling task %s by killing xenguest subprocess pid: %d" (Xenops_task.id_of_handle task) pid;
     try Unix.kill pid Sys.sigkill with _ -> () in
-  Stdext.Pervasiveext.finally
+  Xapi_stdext_pervasives.Pervasiveext.finally
     (fun () ->
        Xenops_task.with_cancel task cancel_cb
          (fun () ->

--- a/xc/xenops_helpers.ml
+++ b/xc/xenops_helpers.ml
@@ -22,7 +22,7 @@ let with_xc_and_xs f =
   Xenctrl.with_intf (fun xc -> with_xs (fun xs -> f xc xs))
 
 let with_xc_and_xs_final f cf =
-  with_xc_and_xs (fun xc xs -> Stdext.Pervasiveext.finally (fun () -> f xc xs) cf)
+  with_xc_and_xs (fun xc xs -> Xapi_stdext_pervasives.Pervasiveext.finally (fun () -> f xc xs) cf)
 
 exception Domain_not_found
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -767,11 +767,11 @@ module HOST = struct
          (* Set X86_FEATURE_IBS in e1c for HVM guests *)
          features_hvm.(3) <- Int64.logor features_hvm.(3) 0x400L;
 
-	 let features_hvm_host = Array.copy features_hvm in
-	 let features_pv_host = Array.copy features_pv in
+         let features_hvm_host = Array.copy features_hvm in
+         let features_pv_host = Array.copy features_pv in
 
-	 upgrade_for_migration ~xc features_hvm;
-	 upgrade_for_migration ~xc features_pv;
+         upgrade_for_migration ~xc features_hvm;
+         upgrade_for_migration ~xc features_pv;
 
          let v = version xc in
          let xen_version_string = Printf.sprintf "%d.%d%s" v.major v.minor v.extra in
@@ -1256,7 +1256,7 @@ module VM = struct
          safe_rm xs (Printf.sprintf "/vm/%s" vm.Vm.id);
       );
     (* Best-effort attempt to remove metadata - if VM has been powered off
-       * then it will have already been deleted by VM.destroy *)
+     * then it will have already been deleted by VM.destroy *)
     try DB.remove vm.Vm.id
     with Xenopsd_error (Does_not_exist("extra", _)) -> ()
 

--- a/xc/xenops_xc_main.ml
+++ b/xc/xenops_xc_main.ml
@@ -42,7 +42,7 @@ let check_domain0_uuid () =
   forget_client ()
 
 let make_var_run_xen () =
-  Stdext.Unixext.mkdir_rec Device_common.var_run_xen_path 0o0755
+  Xapi_stdext_unix.Unixext.mkdir_rec Device_common.var_run_xen_path 0o0755
 
 (* Start the program with the xen backend *)
 let _ =


### PR DESCRIPTION
Because Stdext is not used directly, Monadic and Opt modules are not imported at all and Std is not imported for xapi-xenopsd.

The latest commit builds xenopsd cleanly in a xenserver mock chroot.