### PR TITLE
CA-335964: store the original vm uuid when starting migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: c
-sudo: required
-service: docker
+os: linux
+dist: xenial
+services:
+  - docker
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
 script:
   - wget https://raw.githubusercontent.com/xapi-project/xs-opam/master/tools/xs-opam-ci.env
@@ -11,6 +13,6 @@ env:
   global:
     - PACKAGE="xapi-xenopsd"
     - PINS="xapi-xenopsd:. xapi-xenopsd-xc:. xapi-xenopsd-simulator:."
-  matrix:
+  jobs:
     - PACKAGE="xapi-xenopsd-xc"
     - PACKAGE="xapi-xenopsd-simulator"

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -35,6 +35,11 @@ type shutdown_request =
   | Suspend
 [@@deriving rpcty]
 
+type rename_when =
+  | Pre_migration
+  | Post_migration
+[@@deriving rpcty]
+
 let rpc_of : type x. x Rpc.Types.def -> x -> Rpc.t = fun def x -> Rpcmarshal.marshal def.Rpc.Types.ty x
 
 let string_of_shutdown_request x = x |> rpc_of shutdown_request |> Jsonrpc.to_string
@@ -68,7 +73,7 @@ module type S = sig
   module VM : sig
     val add: Vm.t -> unit
     val remove: Vm.t -> unit
-    val rename: Vm.id -> Vm.id -> unit
+    val rename: Vm.id -> Vm.id -> rename_when ->  unit
     val create: Xenops_task.task_handle -> int64 option -> Vm.t -> Vm.id option -> bool (* no_sharept*) -> unit
     val build: ?restore_fd:Unix.file_descr -> Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list-> string list -> bool ->  unit (* XXX cancel *)
     val create_device_model: Xenops_task.task_handle -> Vm.t -> Vbd.t list -> Vif.t list -> Vgpu.t list -> Vusb.t list -> bool -> unit

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -56,7 +56,7 @@ end
 module VM = struct
   let add _ = ()
 
-  let rename _ _ = ()
+  let rename _ _ _ = ()
   let remove _ = ()
   let create _ _ _ _ = unimplemented "VM.create"
   let build ?restore_fd:_ _ _ _ _ _ = unimplemented "VM.build"

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1241,6 +1241,8 @@ module VM = struct
 
       ( match when' with
         | Pre_migration ->
+          (* Write the key to the destination, if it's written on the origin
+             subtree the value will get overwritten by [Domain.move_xstree] *)
           let origin_uuid_path = Printf.sprintf "/vm/%s/origin-uuid" new_name in
           debug "xenstore-write %s <- %s" origin_uuid_path old_name;
           xs.Xs.write origin_uuid_path old_name


### PR DESCRIPTION
This allows other daemons to hide the temporary uuid from their clients
by reading the value from xenstore.

Since rename is both used on the origin and destination of the
migration and both need different operations on xenstore, a parameter
was added to differentiate between the stages.

- [x] `origin-uuid` is never cleaned up, does it need to cleaned up on the origin host? No, the value is not transferred to the newly created vm.
- [ ] None of the changes in xenstore are "cleaned up" after a failure, are these needed?