### PR TITLE
CP-28375: Implement soft reset handler for guest kdump support

### DIFF
--- a/c_stubs/xenctrlext_stubs.c
+++ b/c_stubs/xenctrlext_stubs.c
@@ -243,6 +243,31 @@ CAMLprim value stub_xenctrlext_domid_quarantine(value unit)
     CAMLreturn(Val_int(DOMID_IO));
 }
 
+CAMLprim value stub_xenctrlext_domain_soft_reset(value xch, value domid)
+{
+    CAMLparam2(xch, domid);
+    caml_enter_blocking_section();
+    int retval = xc_domain_soft_reset(_H(xch), _D(domid));
+    caml_leave_blocking_section();
+    if (retval)
+        failwith_xc(_H(xch));
+    CAMLreturn(Val_unit);
+}
+
+CAMLprim value stub_xenctrlext_domain_update_channels(value xch, value domid,
+        value store_port, value console_port)
+{
+    CAMLparam4(xch, domid, store_port, console_port);
+    caml_enter_blocking_section();
+    int retval = xc_set_hvm_param(_H(xch), _D(domid), HVM_PARAM_STORE_EVTCHN, Int_val(store_port));
+    if (!retval)
+        retval = xc_set_hvm_param(_H(xch), _D(domid), HVM_PARAM_CONSOLE_EVTCHN, Int_val(console_port));
+    caml_leave_blocking_section();
+    if (retval)
+        failwith_xc(_H(xch));
+    CAMLreturn(Val_unit);
+}
+
 /* based on xenctrl_stubs.c */
 static int get_cpumap_len(value xch, value cpumap)
 {

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -2367,6 +2367,8 @@ and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
           | Some Needs_suspend ->
               warn "VM %s has unexpectedly suspended" id ;
               [Vm.Shutdown]
+          | Some Needs_softreset ->
+              B.VM.soft_reset t vm ; []
           | None ->
               debug "VM %s is not requesting any attention" id ;
               []

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -21,6 +21,7 @@ type domain_action_request =
   | Needs_reboot
   | Needs_suspend
   | Needs_crashdump
+  | Needs_softreset
 [@@deriving rpcty]
 
 type device_action_request = Needs_unplug | Needs_set_qos
@@ -156,6 +157,8 @@ module type S = sig
     val s3suspend : Xenops_task.task_handle -> Vm.t -> unit
 
     val s3resume : Xenops_task.task_handle -> Vm.t -> unit
+
+    val soft_reset : Xenops_task.task_handle -> Vm.t -> unit
 
     val get_state : Vm.t -> Vm.state
 

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -556,6 +556,8 @@ module VM = struct
 
   let s3resume _ _vm = ()
 
+  let soft_reset _ _vm = ()
+
   let get_state vm = Mutex.execute m (get_state_nolock vm)
 
   let request_rdp _vm _enabled = ()

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -99,6 +99,8 @@ module VM = struct
 
   let s3resume _ _ = unimplemented "VM.s3resume"
 
+  let soft_reset _ _ = unimplemented "VM.soft_reset"
+
   let get_state _ = Xenops_utils.halted_vm
 
   let request_rdp _ _ = unimplemented "VM.request_rdp"

--- a/xc/domain.mli
+++ b/xc/domain.mli
@@ -281,6 +281,9 @@ val send_s3resume : xc:Xenctrl.handle -> domid -> unit
 val vcpu_affinity_set : xc:Xenctrl.handle -> domid -> int -> bool array -> unit
 (** Set cpu affinity of some vcpus of a domain using an boolean array *)
 
+val soft_reset : xc:Xenctrl.handle -> xs:Xenstore.Xs.xsh -> domid -> unit
+(** Perform soft reset of a domain *)
+
 val vcpu_affinity_get : xc:Xenctrl.handle -> domid -> int -> bool array
 (** Get Cpu affinity of some vcpus of a domain *)
 

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -64,6 +64,12 @@ external deassign_device : handle -> domid -> int -> unit
 
 external domid_quarantine : unit -> int = "stub_xenctrlext_domid_quarantine"
 
+external domain_soft_reset : handle -> domid -> unit
+  = "stub_xenctrlext_domain_soft_reset"
+
+external domain_update_channels : handle -> domid -> int -> int -> unit
+  = "stub_xenctrlext_domain_update_channels"
+
 external vcpu_setaffinity_soft : handle -> domid -> int -> bool array -> unit
   = "stub_xenctrlext_vcpu_setaffinity_soft"
 

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -60,6 +60,12 @@ external deassign_device : handle -> domid -> int -> unit
 
 external domid_quarantine : unit -> int = "stub_xenctrlext_domid_quarantine"
 
+external domain_soft_reset : handle -> domid -> unit
+  = "stub_xenctrlext_domain_soft_reset"
+
+external domain_update_channels : handle -> domid -> int -> int -> unit
+  = "stub_xenctrlext_domain_update_channels"
+
 type meminfo = {memfree: int64; memsize: int64}
 
 type numainfo = {memory: meminfo array; distances: int array array}

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2503,6 +2503,10 @@ module VM = struct
     on_domain (fun xc xs task vm di ->
         Domain.send_s3resume ~xc di.Xenctrl.domid)
 
+  let soft_reset =
+    on_domain (fun xc xs task vm di ->
+        Domain.soft_reset ~xc ~xs di.Xenctrl.domid)
+
   let get_state vm =
     let uuid = uuid_of_vm vm in
     let vme = vm.Vm.id |> DB.read in
@@ -2839,6 +2843,8 @@ module VM = struct
                     Needs_crashdump
                 | 4 ->
                     Needs_reboot
+                | 5 ->
+                    Needs_softreset
                 | _ ->
                     Needs_poweroff
                 ) (* unexpected *)


### PR DESCRIPTION
Shutdown code 5 means that a domain has kdump kernel loaded and is ready
for a jump to it. This is possible if either the domain is crashed
and we need to load a crash kernel or kexec has been called as part of
e.g. a fast reboot. Code 5 needs to be handled by calling a special
operation called "soft reset" for the domain. This will ensure the domain
is ready for the next enlightned Linux kernel to go through its boot
sequence. The side effect of this operation means xenstore and console
event channels are closed for guest domain and need to be recreated.
The rest of the domain state stays untouched meaning kdump boot process
will follow the same path as bugcheck kernel of Windows guests.

For now only support 1 soft reset per domain lifecycle which corresponds to
crash dump usecase. To support indefinite kexec reboots more garbage
collection needs to be implemented.

Additinally, enable new platform feature - xs_reset_watches. That will
tell the guest it can issue a xenstored command to reset watches for
itself on kexec reboot.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>