### PR TITLE
maintenance: point xapi-xenopsd-cli.opam to correct repo

### DIFF
--- a/xapi-xenopsd-cli.opam
+++ b/xapi-xenopsd-cli.opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
-homepage: "https://github.com/xapi-project/xenops-cli"
-bug-reports: "https://github.com/xapi-project/xenops-cli/issues"
-dev-repo: "git+https://github.com/xapi-project/xenops-cli.git"
+homepage: "https://github.com/xapi-project/xenopsd"
+bug-reports: "https://github.com/xapi-project/xenopsd/issues"
+dev-repo: "git+https://github.com/xapi-project/xenopsd.git"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -25,5 +25,5 @@ description: """
 A simple command-line tool for interacting with xenopsd
 """
 url {
-  src: "https://github.com/xapi-project/xenops-cli/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/master.tar.gz"
 }


### PR DESCRIPTION
See that xapi-xenopsd-cli.opam was added in https://github.com/xapi-project/xenopsd/pull/692/files, but the url still pointed to xenops-cli.git

xenops-cli was moved to xenopsd as xapi-xenopsd-cli,
but this opam file was not updated.
