### PR TITLE
CA-342935: Disengage guest balloon driver and reset PV features on so…

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1791,6 +1791,11 @@ let soft_reset ~xc ~xs domid =
   xs.Xs.write (dom_path ^ "/store/port") (string_of_int store_port) ;
   xs.Xs.write (dom_path ^ "/console/port") (string_of_int console_port) ;
   Xenctrlext.domain_update_channels xc domid store_port console_port ;
+  (* reset PV features and disengage balloon driver *)
+  List.iter (fun p -> log_exn_rm ~xs (dom_path ^ "/control/feature-" ^ p))
+    ["suspend"; "poweroff"; "reboot"; "vcpu-hotplug"; "balloon"] ;
+  log_exn_rm ~xs (dom_path ^ "/memory/target") ;
+  xs.Xs.write (dom_path ^ "/data/updated") "1";
   unpause ~xc domid
 
 let vcpu_affinity_set ~xc domid vcpu cpumap =


### PR DESCRIPTION
…ft reset

Keeping balloon target set confuses those kdump kernels with balloon memory
hotplug compiled in since the target value does not correspond to the memory
reserved and available for the crash kernel. That usually results in balloon
driver trying to hotplug the difference quickly going out of reservation.
Toolstack doesn't know how much memory is reserved for the crash kernel by
the guest and, therefore, is unable to set the target properly.

If the target is not set in xenstore then balloon driver will not be enabled
in kdump kernel and the issue is avoided. Additionally, reset the rest of
PV features that the first kernel already declared - those will be
re-declared by kdump kernel accordingly.

Signed-off-by: Igor Druzhinin <igor.druzhinin@citrix.com>