### PR TITLE
Improvements to a class of migration failures

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1917,9 +1917,9 @@ and trigger_cleanup_after_failure op t =
   | VM_receive_memory (id, final_id, _, _) ->
       immediate_operation dbg id (VM_check_state id) ;
       immediate_operation dbg final_id (VM_check_state final_id)
-  | VM_migrate vmm ->
-      immediate_operation dbg vmm.vmm_id (VM_check_state vmm.vmm_id) ;
-      immediate_operation dbg vmm.vmm_id (VM_check_state vmm.vmm_id)
+  | VM_migrate {vmm_id; vmm_tmp_src_id} ->
+      immediate_operation dbg vmm_id (VM_check_state vmm_id) ;
+      immediate_operation dbg vmm_tmp_src_id (VM_check_state vmm_tmp_src_id)
   | VBD_hotplug id | VBD_hotunplug (id, _) ->
       immediate_operation dbg (fst id) (VBD_check_state id)
   | VIF_hotplug id | VIF_hotunplug (id, _) ->


### PR DESCRIPTION
Suppose we are migrating a VM from src -> dest. If dest's xenopsd fails
after having copied the memory across, the src xenopsd will hang until
you restart the toolstack. After restarting, you are left unable to perform
power operations on the VM using the xen api.

This PR improves the situation by:
 - causing such a migration to fail promptly rather than hanging
 - after toolstack restarts, you can turn the VM off with a force shutdown; 
   thereafter, you can shutdown / reboot / start as usual

This PR _doesn't_ get the metadata completely right unfortunately. The toolstacks
don't correctly reflect the VM's `resident_on` metadata after the failed migration.
The correct value is assumed after restarting toolstacks, but subsequently force shutting
down the VM causes the pool to think that the VM is resident on the src host from then on.
This issue _should_ be resolvable by getting the src xenopsd to remove the temporary
VM after the destination sends an error handshake (though I believe this isn't as
straightforward as it sounds).