### PR TITLE
opam: simulator does not run tests (nor ounit) anymore

### DIFF
--- a/xapi-xenopsd-simulator.opam
+++ b/xapi-xenopsd-simulator.opam
@@ -12,7 +12,6 @@ build: [
 depends: [
   "ocaml"
   "dune" {build}
-  "ounit"
   "base-unix"
   "xapi-xenopsd"
 ]


### PR DESCRIPTION
Update opam metadata to reflect the removal of the tests.

This will be followed by an update on xs-opam to pick up the change.