### PR TITLE
XSI-555

### DIFF
--- a/lib/suspend_image.ml
+++ b/lib/suspend_image.ml
@@ -35,9 +35,9 @@ module Xenops_record = struct
   type t = {
       time: string
     ; word_size: int
-    ; (* All additional fields below should use the sexp_option extension *)
-      vm_str: string sexp_option
-    ; xs_subtree: (string * string) list sexp_option
+    ; (* All additional fields below should use the [@sexp.option] extension *)
+      vm_str: string option [@sexp.option]
+    ; xs_subtree: (string * string) list option [@sexp.option]
   }
   [@@deriving sexp]
 


### PR DESCRIPTION
Do a VM power-state check before executing VM_reboot, VM_start or VM_resume. Do this in `perform`, right before executing the operation, which should be exactly the right time. These checks replace similar power-state checks in xapi, which are done before queueing the operation. This is too early, because xenopsd may be busy responding to in-guest requests to shutdown or reboot.

The checks are done outside the exception handler that surrounds `perform`, because we want to just raise an error to the client that requested the operation (i.e. xapi) without entering `trigger_cleanup_after_failure` (the VM is good, but the request is bad).