### PR TITLE
XSI-555

### DIFF
--- a/lib/suspend_image.ml
+++ b/lib/suspend_image.ml
@@ -35,9 +35,9 @@ module Xenops_record = struct
   type t = {
       time: string
     ; word_size: int
-    ; (* All additional fields below should use the sexp_option extension *)
-      vm_str: string sexp_option
-    ; xs_subtree: (string * string) list sexp_option
+    ; (* All additional fields below should use the [@sexp.option] extension *)
+      vm_str: string option [@sexp.option]
+    ; xs_subtree: (string * string) list option [@sexp.option]
   }
   [@@deriving sexp]
 

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -84,8 +84,11 @@ let m = Mutex.create ()
 let create_nolock _ vm () =
   debug "Domain.create vm=%s" vm.Vm.id ;
   if DB.exists vm.Vm.id then (
-    debug "VM.create_nolock %s: Already_exists" vm.Vm.id ;
-    raise (Xenopsd_error (Already_exists ("domain", vm.Vm.id)))
+    let d = DB.read_exn vm.Vm.id in
+    if not d.Domain.suspended then (
+      debug "VM.create_nolock %s: Already_exists" vm.Vm.id ;
+      raise (Xenopsd_error (Already_exists ("domain", vm.Vm.id)))
+    )
   ) else
     let open Domain in
     let domain =
@@ -124,7 +127,7 @@ let get_state_nolock vm () =
     let d = DB.read_exn vm.Vm.id in
     {
       halted_vm with
-      Vm.power_state= Running
+      Vm.power_state= if d.Domain.suspended then Suspended else Running
     ; domids= [d.Domain.domid]
     ; vcpu_target= d.Domain.vcpus
     ; last_start_time= d.Domain.last_create_time
@@ -142,7 +145,11 @@ let get_domain_action_request_nolock vm () =
 let destroy_nolock vm () =
   debug "Domain.destroy vm=%s" vm.Vm.id ;
   (* Idempotent *)
-  if DB.exists vm.Vm.id then DB.delete vm.Vm.id
+  if DB.exists vm.Vm.id then
+    let d = DB.read_exn vm.Vm.id in
+    (* Preserve the domain state if it has suspended *)
+    if not d.Domain.suspended then
+      DB.delete vm.Vm.id
 
 let build_nolock vm _vbds _vifs _vgpus _vusbs _extras () =
   debug "Domain.build vm=%s" vm.Vm.id ;
@@ -182,7 +189,7 @@ let save_nolock vm _ _data _vgpu_data () =
   DB.write vm.Vm.id {(DB.read_exn vm.Vm.id) with Domain.suspended= true}
 
 let restore_nolock vm _vbds _vifs _data _vgpu_data _extras () =
-  DB.write vm.Vm.id {(DB.read_exn vm.Vm.id) with Domain.built= true}
+  DB.write vm.Vm.id {(DB.read_exn vm.Vm.id) with Domain.built= true; suspended= false}
 
 let do_pause_unpause_nolock vm paused () =
   let d = DB.read_exn vm.Vm.id in

--- a/test/test.ml
+++ b/test/test.ml
@@ -595,7 +595,7 @@ let vm_test_halt _ =
         | _ ->
             false))
 
-let vm_test_suspend _ =
+let vm_test_suspend_resume _ =
   with_vm example_uuid (fun id ->
       Client.VM.create dbg id |> wait_for_task |> success_task ;
       Client.VM.build dbg id false |> wait_for_task |> success_task ;
@@ -605,10 +605,7 @@ let vm_test_suspend _ =
       Client.VM.unpause dbg id |> wait_for_task |> success_task ;
       Client.VM.suspend dbg id (Local "/tmp/suspend-image")
       |> wait_for_task
-      |> success_task)
-
-let vm_test_resume _ =
-  with_vm example_uuid (fun id ->
+      |> success_task;
       Client.VM.resume dbg id (Local "/tmp/suspend-image")
       |> wait_for_task
       |> success_task ;
@@ -982,8 +979,7 @@ let _ =
         , `Quick
         , VifDeviceTests.add_plug_unplug_many_remove )
       ; ("vif_remove_running", `Quick, VifDeviceTests.remove_running)
-      ; ("vm_test_suspend", `Quick, vm_test_suspend)
-      ; ("vm_test_resume", `Quick, vm_test_resume)
+      ; ("vm_test_suspend_resume", `Quick, vm_test_suspend_resume)
       ; ("ionice_qos_scheduler", `Quick, ionice_qos_scheduler)
       ; ("ionice_output", `Quick, ionice_output)
       ; ("barrier_ordering", `Quick, barrier_ordering)


### PR DESCRIPTION
Do a VM power-state check before executing VM_reboot, VM_start or VM_resume. Do this in `perform`, right before executing the operation, which should be exactly the right time. These checks replace similar power-state checks in xapi, which are done before queueing the operation. This is too early, because xenopsd may be busy responding to in-guest requests to shutdown or reboot.

The checks are done outside the exception handler that surrounds `perform`, because we want to just raise an error to the client that requested the operation (i.e. xapi) without entering `trigger_cleanup_after_failure` (the VM is good, but the request is bad).