### PR TITLE
CA-347611: Revert CA-332779 (a fix for XSI-555)

### DIFF
--- a/lib/suspend_image.ml
+++ b/lib/suspend_image.ml
@@ -35,9 +35,9 @@ module Xenops_record = struct
   type t = {
       time: string
     ; word_size: int
-    ; (* All additional fields below should use the [@sexp.option] extension *)
-      vm_str: string option [@sexp.option]
-    ; xs_subtree: (string * string) list option [@sexp.option]
+    ; (* All additional fields below should use the sexp_option extension *)
+      vm_str: string sexp_option
+    ; xs_subtree: (string * string) list sexp_option
   }
   [@@deriving sexp]
 

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -2514,24 +2514,9 @@ and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
   in
   one op
 
-and verify_power_state op =
-  let module B = (val get_backend () : S) in
-  let assert_power_state_is vm_id expected =
-    let power = (B.VM.get_state (VM_DB.read_exn vm_id)).Vm.power_state in
-    if not (List.mem power expected) then
-      let expected' = match expected with x :: _ -> x | [] -> failwith "Expectation missing" in
-      raise (Xenopsd_error (Bad_power_state (power, expected')))
-  in
-  match op with
-  | VM_start (id, _) -> assert_power_state_is id [Halted]
-  | VM_reboot (id, _) -> assert_power_state_is id [Running; Paused]
-  | VM_resume (id, _) -> assert_power_state_is id [Suspended]
-  | _ -> ()
-
 and perform ?subtask ?result (op : operation) (t : Xenops_task.task_handle) :
     unit =
   let one op =
-    verify_power_state op;
     try perform_exn ?subtask ?result op t
     with e ->
       Backtrace.is_important e ;

--- a/test/test.ml
+++ b/test/test.ml
@@ -595,7 +595,7 @@ let vm_test_halt _ =
         | _ ->
             false))
 
-let vm_test_suspend_resume _ =
+let vm_test_suspend _ =
   with_vm example_uuid (fun id ->
       Client.VM.create dbg id |> wait_for_task |> success_task ;
       Client.VM.build dbg id false |> wait_for_task |> success_task ;
@@ -605,7 +605,10 @@ let vm_test_suspend_resume _ =
       Client.VM.unpause dbg id |> wait_for_task |> success_task ;
       Client.VM.suspend dbg id (Local "/tmp/suspend-image")
       |> wait_for_task
-      |> success_task;
+      |> success_task)
+
+let vm_test_resume _ =
+  with_vm example_uuid (fun id ->
       Client.VM.resume dbg id (Local "/tmp/suspend-image")
       |> wait_for_task
       |> success_task ;
@@ -979,7 +982,8 @@ let _ =
         , `Quick
         , VifDeviceTests.add_plug_unplug_many_remove )
       ; ("vif_remove_running", `Quick, VifDeviceTests.remove_running)
-      ; ("vm_test_suspend_resume", `Quick, vm_test_suspend_resume)
+      ; ("vm_test_suspend", `Quick, vm_test_suspend)
+      ; ("vm_test_resume", `Quick, vm_test_resume)
       ; ("ionice_qos_scheduler", `Quick, ionice_qos_scheduler)
       ; ("ionice_output", `Quick, ionice_output)
       ; ("barrier_ordering", `Quick, barrier_ordering)


### PR DESCRIPTION
Testing suggests this introduced a regression in a rolling pool upgrade.

This reverts commit 5176b5b372fb2a67be9d5477d80d6080abbe52b8, reversing
changes made to aa8a311ee120238d11a078d59db2c7e1488d1219.