### PR TITLE
CP-35537: Add the ability to control domid

### DIFF
--- a/cli/dune
+++ b/cli/dune
@@ -30,9 +30,8 @@
 )
 
 (rule
- (targets xenops-cli.1.gz)
- (action
-  (run gzip %{dep:xenops-cli.1}))
+ (with-stdout-to xenops-cli.1.gz
+  (run gzip -c %{dep:xenops-cli.1}))
 )
 
 (install

--- a/simulator/dune
+++ b/simulator/dune
@@ -20,9 +20,8 @@
 )
 
 (rule
- (targets xenopsd-simulator.1.gz)
- (action
-  (run gzip %{dep:xenopsd-simulator.1}))
+ (with-stdout-to xenopsd-simulator.1.gz
+  (run gzip -c %{dep:xenopsd-simulator.1}))
 )
 
 (install

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -355,7 +355,13 @@ let make ~xc ~xs vm_info vcpus domain_config uuid final_uuid no_sharept =
   in
   debug "Domain_config: [%s]"
     (rpc_of arch_domainconfig domain_config |> Jsonrpc.to_string) ;
-  let domid = Xenctrl.domain_create xc config in
+  let domid =
+    if List.mem_assoc "domid" vm_info.platformdata then
+      int_of_string (List.assoc "domid" vm_info.platformdata)
+    else
+      0
+  in
+  let domid = Xenctrlext.domain_create_domid xc config domid in
   let name =
     if vm_info.name <> "" then vm_info.name else sprintf "Domain-%d" domid
   in

--- a/xc/dune
+++ b/xc/dune
@@ -143,9 +143,8 @@
 )
 
 (rule
- (targets xenopsd-xc.1.gz)
- (action
-  (run gzip %{dep:xenopsd-xc.1}))
+ (with-stdout-to xenopsd-xc.1.gz
+  (run gzip -c %{dep:xenopsd-xc.1}))
 )
 
 (install

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -85,3 +85,6 @@ external cputopoinfo : handle -> cputopo array = "stub_xenctrlext_cputopoinfo"
 
 external xc_get_msr_arch_caps : handle -> int64
   = "stub_xenctrlext_get_msr_arch_caps"
+
+external domain_create_domid : handle -> domctl_create_config -> domid -> domid
+  = "stub_xc_domain_create_domid"

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -81,3 +81,6 @@ external cputopoinfo : handle -> cputopo array = "stub_xenctrlext_cputopoinfo"
 
 external xc_get_msr_arch_caps : handle -> int64
   = "stub_xenctrlext_get_msr_arch_caps"
+
+external domain_create_domid : handle -> domctl_create_config -> domid -> domid
+  = "stub_xc_domain_create_domid"


### PR DESCRIPTION
Useful for testing and migration.

Example usage:
```
xe vm-param-set uuid=af69645b-b3c0-9447-2ba4-a629f4207f81 platform:domid=42
xe vm-start uuid=af69645b-b3c0-9447-2ba4-a629f4207f81
list_domains
id |                                 uuid |  state
 0 | 60282df0-ca76-499d-8333-80cbcceda060 |     R 
42 | af69645b-b3c0-9447-2ba4-a629f4207f81 |      H
```

Trying to clone the VM and boot it will fail with:
```
The server failed to handle your request, due to an internal error. The given message may give details useful for debugging the problem.
message: xenopsd internal error: Xenctrlext.Unix_error(12, "22: Invalid argument")
```

This could be handled in a nicer way.

Draft, because the xenctrl stub needs upstreaming first.
