### PR TITLE
Log when we receive EINVAL from xenstore

### DIFF
--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1898,8 +1898,11 @@ let move_xstree ~xs domid olduuid newuuid =
   let rec get_tree t path =
     let open Xenstore in
     let subtrees =
-      try t.Xs.directory (String.concat "/" path)
-      with Xs_protocol.Invalid -> []
+      let path' = String.concat "/" path in
+      try t.Xs.directory path'
+      with Xs_protocol.Invalid ->
+        info "ignored: xenstore EINVAL on 'directory %s'" path';
+        []
     in
     let subtrees = subtrees |> List.filter (fun s -> s <> "") in
     let contents = t.Xs.read (String.concat "/" path) in


### PR DESCRIPTION
To help with debugging EINVAL access seen in xenstore logs, log such
occurrences even when we expect and ignore them.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>