### PR TITLE
maintenance: formatting + port sexp test + use Result.t rather than custom type

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,4 @@
 profile=ocamlformat
-version=0.14.1
 indicate-multiline-delimiters=closing-on-separate-line
 if-then-else=fit-or-vertical
 dock-collection-brackets=true

--- a/lib/suspend_image.mli
+++ b/lib/suspend_image.mli
@@ -12,7 +12,7 @@
  * GNU Lesser General Public License for more details.
  *)
 module M : sig
-  type ('a, 'b) t = [`Ok of 'a | `Error of 'b]
+  type ('a, 'b) t = ('a, 'b) Result.t
 
   val ( >>= ) : ('a, 'b) t -> ('a -> ('c, 'b) t) -> ('c, 'b) t
 
@@ -26,9 +26,9 @@ module Xenops_record : sig
 
   val make : ?vm_str:string -> ?xs_subtree:(string * string) list -> unit -> t
 
-  val to_string : t -> [`Ok of string | `Error of exn]
+  val to_string : t -> (string, exn) Result.t
 
-  val of_string : string -> [`Ok of t | `Error of exn]
+  val of_string : string -> (t, exn) Result.t
 end
 
 type header_type =
@@ -50,17 +50,16 @@ val string_of_header : header -> string
 
 val save_signature : string
 
-val read_save_signature : Unix.file_descr -> [`Ok of format | `Error of string]
+val read_save_signature : Unix.file_descr -> (format, string) Result.t
 
-val read_legacy_qemu_header :
-  Unix.file_descr -> [`Ok of int64 | `Error of string]
+val read_legacy_qemu_header : Unix.file_descr -> (int64, string) Result.t
 
 val write_qemu_header_for_legacy_libxc :
-  Unix.file_descr -> int64 -> [`Ok of unit | `Error of exn]
+  Unix.file_descr -> int64 -> (unit, exn) Result.t
 
-val write_header : Unix.file_descr -> header -> [`Ok of unit | `Error of exn]
+val write_header : Unix.file_descr -> header -> (unit, exn) Result.t
 
-val read_header : Unix.file_descr -> [`Ok of header | `Error of exn]
+val read_header : Unix.file_descr -> (header, exn) Result.t
 
 val with_conversion_script :
      Xenops_task.Xenops_task.task_handle
@@ -68,9 +67,8 @@ val with_conversion_script :
   -> bool
   -> Unix.file_descr
   -> (Unix.file_descr -> 'a)
-  -> [`Ok of 'a | `Error of exn]
+  -> ('a, exn) Result.t
 
-val wrap : (unit -> 'a) -> [`Ok of 'a | `Error of exn]
+val wrap : (unit -> 'a) -> ('a, exn) Result.t
 
-val wrap_exn :
-  (unit -> [`Ok of 'a | `Error of exn]) -> [`Ok of 'a | `Error of exn]
+val wrap_exn : (unit -> ('a, exn) Result.t) -> ('a, exn) Result.t

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -280,7 +280,8 @@ module PCI_DB = struct
 
   let add' x =
     let open Pci in
-    debug "PCI.add %s %s" (string_of_id x.id) (Jsonrpc.to_string (rpc_of Pci.t x)) ;
+    debug "PCI.add %s %s" (string_of_id x.id)
+      (Jsonrpc.to_string (rpc_of Pci.t x)) ;
     (* Only if the corresponding VM actually exists *)
     let vm = vm_of x.id in
     if not (VM_DB.exists vm) then (
@@ -340,7 +341,8 @@ module VBD_DB = struct
         remove id)
 
   let add' x =
-    debug "VBD.add %s %s" (string_of_id x.Vbd.id) (Jsonrpc.to_string (rpc_of Vbd.t x)) ;
+    debug "VBD.add %s %s" (string_of_id x.Vbd.id)
+      (Jsonrpc.to_string (rpc_of Vbd.t x)) ;
     (* Only if the corresponding VM actually exists *)
     let vm = vm_of x.id in
     if not (VM_DB.exists vm) then (
@@ -476,7 +478,8 @@ module VGPU_DB = struct
         remove id)
 
   let add' x =
-    debug "VGPU.add %s %s" (string_of_id x.Vgpu.id) (Jsonrpc.to_string (rpc_of Vgpu.t x)) ;
+    debug "VGPU.add %s %s" (string_of_id x.Vgpu.id)
+      (Jsonrpc.to_string (rpc_of Vgpu.t x)) ;
     (* Only if the corresponding VM actually exists *)
     let vm = vm_of x.id in
     if not (VM_DB.exists vm) then (
@@ -534,7 +537,8 @@ module VUSB_DB = struct
         remove id)
 
   let add' x =
-    debug "VUSB.add %s %s" (string_of_id x.Vusb.id) (Jsonrpc.to_string (rpc_of Vusb.t x)) ;
+    debug "VUSB.add %s %s" (string_of_id x.Vusb.id)
+      (Jsonrpc.to_string (rpc_of Vusb.t x)) ;
     (* Only if the corresponding VM actually exists *)
     let vm = vm_of x.id in
     if not (VM_DB.exists vm) then (
@@ -1151,9 +1155,7 @@ let import_metadata id md =
   let module B = (val get_backend () : S) in
   let platformdata = md.Metadata.vm.Vm.platformdata in
   debug "Platformdata:featureset=%s"
-    ( try List.assoc "featureset" platformdata
-      with Not_found -> "(absent)"
-    ) ;
+    (try List.assoc "featureset" platformdata with Not_found -> "(absent)") ;
   let platformdata =
     (* If platformdata does not contain a featureset, then we are
        importing a VM that comes from a levelling-v1 host. In this case,
@@ -1193,31 +1195,21 @@ let import_metadata id md =
       md.Metadata.vbds
   in
   let vifs =
-    List.map
-      (fun x -> {x with Vif.id= (vm, snd x.Vif.id)})
-      md.Metadata.vifs
+    List.map (fun x -> {x with Vif.id= (vm, snd x.Vif.id)}) md.Metadata.vifs
   in
   let pcis =
-    List.map
-      (fun x -> {x with Pci.id= (vm, snd x.Pci.id)})
-      md.Metadata.pcis
+    List.map (fun x -> {x with Pci.id= (vm, snd x.Pci.id)}) md.Metadata.pcis
   in
   let vgpus =
-    List.map
-      (fun x -> {x with Vgpu.id= (vm, snd x.Vgpu.id)})
-      md.Metadata.vgpus
+    List.map (fun x -> {x with Vgpu.id= (vm, snd x.Vgpu.id)}) md.Metadata.vgpus
   in
   let vusbs =
-    List.map
-      (fun x -> {x with Vusb.id= (vm, snd x.Vusb.id)})
-      md.Metadata.vusbs
+    List.map (fun x -> {x with Vusb.id= (vm, snd x.Vusb.id)}) md.Metadata.vusbs
   in
   (* Remove any VBDs, VIFs, PCIs and VGPUs not passed in - they must have
      been destroyed in the higher level *)
   let gc old cur remove =
-    let set_difference a b =
-      List.filter (fun x -> not (List.mem x b)) a
-    in
+    let set_difference a b = List.filter (fun x -> not (List.mem x b)) a in
     let to_remove = set_difference old cur in
     List.iter remove to_remove
   in
@@ -2836,7 +2828,8 @@ module VGPU = struct
 
   let add _ dbg x = Debug.with_thread_associated dbg (fun () -> DB.add' x) ()
 
-  let remove _ dbg x = Debug.with_thread_associated dbg (fun () -> DB.remove' x) ()
+  let remove _ dbg x =
+    Debug.with_thread_associated dbg (fun () -> DB.remove' x) ()
 
   let stat' id =
     debug "VGPU.stat %s" (string_of_id id) ;
@@ -3282,7 +3275,7 @@ module VM = struct
                (Internal_error
                   (Printf.sprintf "Unable to unmarshal metadata: %s" m)))
     in
-    md.Metadata.vm.Vm.id, md
+    (md.Metadata.vm.Vm.id, md)
 
   let import_metadata _ dbg s =
     Debug.with_thread_associated dbg
@@ -3293,7 +3286,10 @@ module VM = struct
            The metadata update will be queued so that ongoing operations
            do not see unexpected state changes. *)
         if DB.exists id then
-          let _ = queue_operation_and_wait dbg id (Atomic (VM_import_metadata (id, md))) in
+          let _ =
+            queue_operation_and_wait dbg id
+              (Atomic (VM_import_metadata (id, md)))
+          in
           id
         else
           import_metadata id md)

--- a/test/test.ml
+++ b/test/test.ml
@@ -930,6 +930,18 @@ let barrier_ordering () =
   List.map fst barriers
   |> assert_equal ~msg:"Barriers not in correct order" barrier_ids
 
+let test_ca351823 () =
+  let open Suspend_image.Xenops_record in
+  let s =
+    {|((time 20210219T17:16:27Z)(word_size 64)(vm_str "((id 434d1235-c58b-99f4-f652-c79d57e50719)(name vm-generic-linux)(ssidref 0)(xsdata((vm-data \"\")))(platformdata((featureset 17cbfbff-f7fa3223-2d93fbff-00000023-00000001-000007ab-00000000-00000000-00001000-9c000400)(generation-id \"\")(timeoffset 0)(usb true)(usb_tablet true)(device-model qemu-upstream-compat)(acpi 1)(apic true)(pae true)(hpet true)(vga std)(videoram 8)(nx true)(viridian false)(device_id 0001)))(bios_strings((bios-vendor Xen)(bios-version \"\")(system-manufacturer Xen)(system-product-name \"HVM domU\")(system-version \"\")(system-serial-number \"\")(hp-rombios \"\")(oem-1 Xen)(oem-2 MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d)))(ty(HVM((hap true)(shadow_multiplier 1)(timeoffset 0)(video_mib 8)(video Standard_VGA)(acpi true)(serial(pty))(keymap())(vnc_ip())(pci_emulations())(pci_passthrough false)(boot_order c)(qemu_disk_cmdline false)(qemu_stubdom false))))(suppress_spurious_page_faults false)(machine_address_size())(memory_static_max 4294967296)(memory_dynamic_max 4294967296)(memory_dynamic_min 4294967296)(vcpu_max 2)(vcpus 2)(scheduler_params((priority((256 0)))(affinity())))(on_crash(Pause))(on_shutdown(Shutdown))(on_reboot(Start))(pci_msitranslate true)(pci_power_mgmt false)(has_vendor_device false))")(xs_subtree()))|}
+  in
+  match of_string s with
+  | `Ok _ ->
+      ()
+  | `Error e ->
+      Printf.sprintf "test_ca351823 failed: %s" (Printexc.to_string e)
+      |> failwith
+
 let _ =
   Xenops_utils.set_fs_backend
     (Some (module Xenops_utils.MemFS : Xenops_utils.FS)) ;
@@ -983,6 +995,7 @@ let _ =
       ; ("ionice_qos_scheduler", `Quick, ionice_qos_scheduler)
       ; ("ionice_output", `Quick, ionice_output)
       ; ("barrier_ordering", `Quick, barrier_ordering)
+      ; ("test_ca351823", `Quick, test_ca351823)
       ] )
   in
   Debug.log_to_stdout () ;

--- a/test/test.ml
+++ b/test/test.ml
@@ -936,9 +936,9 @@ let test_ca351823 () =
     {|((time 20210219T17:16:27Z)(word_size 64)(vm_str "((id 434d1235-c58b-99f4-f652-c79d57e50719)(name vm-generic-linux)(ssidref 0)(xsdata((vm-data \"\")))(platformdata((featureset 17cbfbff-f7fa3223-2d93fbff-00000023-00000001-000007ab-00000000-00000000-00001000-9c000400)(generation-id \"\")(timeoffset 0)(usb true)(usb_tablet true)(device-model qemu-upstream-compat)(acpi 1)(apic true)(pae true)(hpet true)(vga std)(videoram 8)(nx true)(viridian false)(device_id 0001)))(bios_strings((bios-vendor Xen)(bios-version \"\")(system-manufacturer Xen)(system-product-name \"HVM domU\")(system-version \"\")(system-serial-number \"\")(hp-rombios \"\")(oem-1 Xen)(oem-2 MS_VM_CERT/SHA1/bdbeb6e0a816d43fa6d3fe8aaef04c2bad9d3e3d)))(ty(HVM((hap true)(shadow_multiplier 1)(timeoffset 0)(video_mib 8)(video Standard_VGA)(acpi true)(serial(pty))(keymap())(vnc_ip())(pci_emulations())(pci_passthrough false)(boot_order c)(qemu_disk_cmdline false)(qemu_stubdom false))))(suppress_spurious_page_faults false)(machine_address_size())(memory_static_max 4294967296)(memory_dynamic_max 4294967296)(memory_dynamic_min 4294967296)(vcpu_max 2)(vcpus 2)(scheduler_params((priority((256 0)))(affinity())))(on_crash(Pause))(on_shutdown(Shutdown))(on_reboot(Start))(pci_msitranslate true)(pci_power_mgmt false)(has_vendor_device false))")(xs_subtree()))|}
   in
   match of_string s with
-  | `Ok _ ->
+  | Ok _ ->
       ()
-  | `Error e ->
+  | Error e ->
       Printf.sprintf "test_ca351823 failed: %s" (Printexc.to_string e)
       |> failwith
 

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1935,7 +1935,7 @@ let move_xstree ~xs domid olduuid newuuid =
       let path' = String.concat "/" path in
       try t.Xs.directory path'
       with Xs_protocol.Invalid ->
-        info "ignored: xenstore EINVAL on 'directory %s'" path';
+        info "ignored: xenstore EINVAL on 'directory %s'" path' ;
         []
     in
     let subtrees = subtrees |> List.filter (fun s -> s <> "") in

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -2199,7 +2199,7 @@ module VM = struct
               let is_raw_image =
                 Unixext.with_file path [Unix.O_RDONLY] 0o400 (fun fd ->
                     match Suspend_image.read_save_signature fd with
-                    | `Ok _ ->
+                    | Ok _ ->
                         true
                     | _ ->
                         false)


### PR DESCRIPTION
 - add unit test from the xenopsd Stockholm branch
 - replace some usages of ``[`Ok of 'a | `Error of 'b]`` with `('a, b') Result.t`