### PR TITLE
Improved fix for XSA-354: backport

### DIFF
--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -635,3 +635,51 @@ let chunks size lst =
 			else [op]::xs::xss
 	) [] lst
 	|> List.map (fun xs -> List.rev xs) |> List.rev
+
+(* used only during startup *)
+let json_length rpc = rpc |> Jsonrpc.to_string |> String.length
+
+let xml_length rpc =
+  let xml = rpc |> Xmlrpc.to_string in
+  let length = ref (String.length xml) in
+  (* protect_fn in xml_spaces in XAPI escapes some additional characters *)
+  String.iter
+    (function ' ' | '\t' | '\n' | '\r' | '%' -> incr length | _ -> ())
+    xml ;
+  !length
+
+(* It is stored as Json in internal communication, but as xml in the database *)
+let char_max_encoded_length =
+  Array.init 256 (fun i ->
+      if i >= 0x80 then
+        3 (* Uutf.u_rep, see utf8_recode *)
+      else
+        let s = String.init 1 (fun _ -> Char.chr i) in
+        let rpc = Rpc.String s in
+        let empty = Rpc.String "" in
+        max
+          (json_length rpc - json_length empty)
+          (xml_length rpc - xml_length empty))
+
+let str_max_encoded_length str =
+  let s = ref 0 in
+  String.iter (fun c -> s := !s + char_max_encoded_length.(Char.code c)) str ;
+  !s
+
+let longest_encoded_char = Array.fold_left max 0 char_max_encoded_length
+
+let entry_overhead = String.length "(''%.'')%."
+
+let xenstore_encoded_entry_size_bytes key value =
+  (* The largest amount of memory used by a xenstore-data entry:
+     - in XAPI's database (encoded as an S-expression and then as XML)
+     - in the JSON-RPC format
+
+     Both of these have some constant per-entry overhead, e.g.:
+        ('xenstore-key'%.'xenstore-value')%.('k2'%.'v2')...
+        {"xenstore-key":"xenstore-value","k2":"v2"},...
+     For calculating the overhead I used the S-expression encoding since that is larger.
+     For individual bytes either the XML or JSON encoding could be larger,
+     hence the `char_max_encoded_length` table above to determine the largest encoding among the two.
+  *)
+  entry_overhead + str_max_encoded_length key + str_max_encoded_length value

--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -45,6 +45,20 @@ let vm_guest_agent_xenstore_quota = ref 128
 
 let vm_guest_agent_xenstore_quota_warn_interval = ref 3600
 
+(* for backward compatibility compute how much memory N entries
+   would've taken *)
+let max_bytes_of_xenstore_entries entries =
+  (* defaults from oxenstored.conf *)
+  let default_path_max = 1024 (* maximum size in bytes of a xenstore path *) in
+  let default_maxsize = 2048 (* maximum size in bytes of a xenstore value *) in
+  entries
+  * (Xenops_utils.entry_overhead
+    + default_path_max
+    + (Xenops_utils.longest_encoded_char * default_maxsize)
+    )
+
+let vm_guest_agent_xenstore_quota_bytes = ref (max_bytes_of_xenstore_entries 128)
+
 let options = [
     "queue", Arg.Set_string Xenops_interface.queue_name, (fun () -> !Xenops_interface.queue_name), "Listen on a specific queue";
     "sockets-path", Arg.Set_string sockets_path, (fun () -> !sockets_path), "Directory to create listening sockets";
@@ -62,9 +76,10 @@ let options = [
     "ca-140252-workaround", Arg.Bool (fun x -> ca_140252_workaround := x), (fun () -> string_of_bool !ca_140252_workaround), "Workaround for evtchn misalignment for legacy PV tools";
     "additional-ballooning-timeout", Arg.Set_float additional_ballooning_timeout, (fun () -> string_of_float !additional_ballooning_timeout), "Time we allow the guests to do additional memory ballooning before live migration";
     "pci-quarantine", Arg.Bool (fun b -> pci_quarantine := b), (fun () -> string_of_bool !pci_quarantine), "True if IOMMU contexts of PCI devices are needed to be placed in quarantine";
-    "vm-guest-agent-xenstore-quota", Arg.Set_int vm_guest_agent_xenstore_quota, (fun () -> string_of_int !vm_guest_agent_xenstore_quota), "Maximum entries in VM xenstore trees watched by xenopsd";
+    "vm-guest-agent-xenstore-quota", Arg.String (fun s -> if s <> "N/A" then vm_guest_agent_xenstore_quota_bytes := max_bytes_of_xenstore_entries (int_of_string s)), (fun () -> "N/A"), "(Deprecated, use vm-xenstore-data-quota-bytes instead)";
     "vm-guest-agent-xenstore-quota-warn-interval", Arg.Set_int vm_guest_agent_xenstore_quota_warn_interval, (fun () -> string_of_int !vm_guest_agent_xenstore_quota_warn_interval), "How often to warn that a VM is still over its xenstore quota";
-]
+    "vm-guest-agent-xenstore-quota-bytes", Arg.Set_int vm_guest_agent_xenstore_quota_bytes, (fun () -> string_of_int !vm_guest_agent_xenstore_quota_bytes), "Maximum size in bytes of VM xenstore-data field, and guest metrics  copied from guest's vm-data/ and data/ xenstore tree"
+  ]
 
 let path () = Filename.concat !sockets_path "xenopsd"
 let forwarded_path () = path () ^ ".forwarded" (* receive an authenticated fd from xapi *)

--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -45,19 +45,65 @@ let vm_guest_agent_xenstore_quota = ref 128
 
 let vm_guest_agent_xenstore_quota_warn_interval = ref 3600
 
+let oxenstored_conf = ref "/etc/xen/oxenstored.conf"
+
+let for_each_line path f =
+  let ic = open_in path in
+  log_and_ignore_exn (fun () ->
+      try
+        while true do
+          f ic
+        done
+      with End_of_file -> ()) ;
+  close_in_noerr ic
+
+let parse_oxenstored_conf path =
+  D.debug "Parsing %s" path ;
+  let config = ref [] in
+  log_and_ignore_exn (fun () ->
+      for_each_line path @@ fun ic ->
+      match ic |> input_line |> Xcp_service.Config_file.parse_line with
+      | Some (k, v) ->
+          config := (k, v) :: !config
+      | None ->
+          ()) ;
+  D.debug "%s: %d config entries" path (List.length !config) ;
+  !config
+
 (* for backward compatibility compute how much memory N entries
    would've taken *)
 let max_bytes_of_xenstore_entries entries =
   (* defaults from oxenstored.conf *)
-  let default_path_max = 1024 (* maximum size in bytes of a xenstore path *) in
-  let default_maxsize = 2048 (* maximum size in bytes of a xenstore value *) in
+  let conf = parse_oxenstored_conf !oxenstored_conf in
+  let get key default conv =
+    try List.assoc key conf |> conv with _ -> default
+  in
+  if not (get "quota-activate" true bool_of_string) then (
+    warn
+      "Quotas are turned off in oxenstored. This is insecure and not a \
+       supported configuration!" ;
+    max_int
+  ) else
+    let default_path_max =
+      get "quota-path-max" 1024 int_of_string
+      (* maximum size in bytes of a xenstore path *)
+    in
+    let default_maxsize =
+      get "quota-maxsize" 2048 int_of_string
+      (* maximum size in bytes of a xenstore value *)
+    in
+    D.debug "entry_overhead = %d" Xenops_utils.entry_overhead ;
+    D.debug "default_path_max = %d" default_path_max;
+    D.debug "longest_encoded_char = %d" Xenops_utils.longest_encoded_char;
+    D.debug "default_maxsize = %d" default_maxsize;
+    D.debug "entries = %d" entries ;
   entries
   * (Xenops_utils.entry_overhead
     + default_path_max
     + (Xenops_utils.longest_encoded_char * default_maxsize)
     )
 
-let vm_guest_agent_xenstore_quota_bytes = ref (max_bytes_of_xenstore_entries 128)
+let vm_guest_agent_xenstore_quota_bytes = ref (25 * 1024 * 1024)
 
 let options = [
     "queue", Arg.Set_string Xenops_interface.queue_name, (fun () -> !Xenops_interface.queue_name), "Listen on a specific queue";
@@ -76,6 +122,7 @@ let options = [
     "ca-140252-workaround", Arg.Bool (fun x -> ca_140252_workaround := x), (fun () -> string_of_bool !ca_140252_workaround), "Workaround for evtchn misalignment for legacy PV tools";
     "additional-ballooning-timeout", Arg.Set_float additional_ballooning_timeout, (fun () -> string_of_float !additional_ballooning_timeout), "Time we allow the guests to do additional memory ballooning before live migration";
     "pci-quarantine", Arg.Bool (fun b -> pci_quarantine := b), (fun () -> string_of_bool !pci_quarantine), "True if IOMMU contexts of PCI devices are needed to be placed in quarantine";
+    "oxenstored-conf", Arg.Set_string oxenstored_conf, (fun () -> !oxenstored_conf), "Path to oxenstored conf (for reading quotas)";
     "vm-guest-agent-xenstore-quota", Arg.String (fun s -> if s <> "N/A" then vm_guest_agent_xenstore_quota_bytes := max_bytes_of_xenstore_entries (int_of_string s)), (fun () -> "N/A"), "(Deprecated, use vm-xenstore-data-quota-bytes instead)";
     "vm-guest-agent-xenstore-quota-warn-interval", Arg.Set_int vm_guest_agent_xenstore_quota_warn_interval, (fun () -> string_of_int !vm_guest_agent_xenstore_quota_warn_interval), "How often to warn that a VM is still over its xenstore quota";
     "vm-guest-agent-xenstore-quota-bytes", Arg.Set_int vm_guest_agent_xenstore_quota_bytes, (fun () -> string_of_int !vm_guest_agent_xenstore_quota_bytes), "Maximum size in bytes of VM xenstore-data field, and guest metrics  copied from guest's vm-data/ and data/ xenstore tree"

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1681,15 +1681,17 @@ module VM = struct
                let value_opt, subdirs = ls_l ~depth root dir in
                let quota, acc =
                  match value_opt with
-                 | Some v ->
-                     (quota - 1, v :: acc)
+                  | Some ((k, v) as entry) ->
+                      ( quota
+                        - Xenops_utils.xenstore_encoded_entry_size_bytes k v
+                      , entry :: acc )
                  | None ->
                      (quota, acc)
                in
                let depth = depth - 1 in
                List.fold_left (ls_lR ~excludes ~depth root) (quota, acc) subdirs
            in
-           let quota = !Xenopsd.vm_guest_agent_xenstore_quota in
+            let quota = !Xenopsd.vm_guest_agent_xenstore_quota_bytes in
             (* depth is the number of directories descended into,
                keys at depth+1 are still read *)
            let quota, guest_agent =


### PR DESCRIPTION
Backport of https://github.com/xapi-project/xenopsd/pull/739

Note: this will need .spec file dependencies to ensure that we have the new message-switch from https://github.com/xapi-project/message-switch/pull/60 too!