### PR TITLE
Do not lose stacktraces when handling exception in VM.receive_memory

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -2468,6 +2468,7 @@ and perform_exn ?subtask ?result (op : operation) (t : Xenops_task.task_handle)
                   t ;
                 Handshake.send s Handshake.Success
               with e ->
+                Backtrace.is_important e;
                 let msg =
                   match e with
                   | Xenopsd_error error ->


### PR DESCRIPTION
If we call additional functions between `with e` and `raise e`, these may raise and catch internal exceptions of their own which would overwrite our stacktrace.
Make sure to save the stacktrace first thing in the exception handler, which marking it as important does.
One such example of lost stacktrace is a Not_found exception from Stringext.split which is caught internally (and probably caught by a Uri marshaling function?)