### PR TITLE
maintenance: avoid warnings, fix suspend_image_viewer

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -2114,7 +2114,7 @@ and trigger_cleanup_after_failure op t =
   | VM_receive_memory (id, final_id, _, _) ->
       immediate_operation dbg id (VM_check_state id) ;
       immediate_operation dbg final_id (VM_check_state final_id)
-  | VM_migrate {vmm_id; vmm_tmp_src_id} ->
+  | VM_migrate {vmm_id; vmm_tmp_src_id; _} ->
       immediate_operation dbg vmm_id (VM_check_state vmm_id) ;
       immediate_operation dbg vmm_tmp_src_id (VM_check_state vmm_tmp_src_id)
   | VBD_hotplug id | VBD_hotunplug (id, _) ->
@@ -2821,7 +2821,6 @@ module PCI = struct
 end
 
 module VGPU = struct
-  open Vgpu
   module DB = VGPU_DB
 
   let string_of_id (a, b) = a ^ "." ^ b
@@ -2847,7 +2846,6 @@ module VGPU = struct
 end
 
 module VUSB = struct
-  open Vusb
   module DB = VUSB_DB
 
   let string_of_id (a, b) = a ^ "." ^ b
@@ -2878,7 +2876,6 @@ module VUSB = struct
 end
 
 module VBD = struct
-  open Vbd
   module DB = VBD_DB
 
   let string_of_id (a, b) = a ^ "." ^ b
@@ -2914,7 +2911,6 @@ module VBD = struct
 end
 
 module VIF = struct
-  open Vif
   module DB = VIF_DB
 
   let string_of_id (a, b) = a ^ "." ^ b
@@ -3025,7 +3021,6 @@ module HOST = struct
 end
 
 module VM = struct
-  open Vm
   module DB = VM_DB
 
   let add _ dbg x = Debug.with_thread_associated dbg (fun () -> DB.add' x) ()

--- a/suspend_image_viewer/suspend_image_viewer.ml
+++ b/suspend_image_viewer/suspend_image_viewer.ml
@@ -14,8 +14,6 @@
 
 open Suspend_image
 
-let ( |> ) a b = b a
-
 let opt_debug = ref true
 
 let msg ~prefix s = Printf.printf "%s: %s\n%!" prefix s
@@ -45,12 +43,12 @@ let verify_libxc_v2_record fd =
 let parse_layout fd =
   debug "Reading save signature..." ;
   match read_save_signature fd with
-  | `Error e ->
+  | Error e ->
       error "Error reading save signature: %s" e ;
       failwith e
-  | `Ok Legacy ->
+  | Ok Legacy ->
       []
-  | `Ok Structured -> (
+  | Ok Structured -> (
       let open Suspend_image.M in
       let rec aux acc =
         debug "Reading header..." ;
@@ -82,9 +80,9 @@ let parse_layout fd =
             failwith "Unsupported: qemu-xen"
       in
       match aux [] with
-      | `Ok hs ->
+      | Ok hs ->
           List.rev hs
-      | `Error e ->
+      | Error e ->
           failwith
             (Printf.sprintf "Error parsing image: %s" (Printexc.to_string e))
     )


### PR DESCRIPTION
These were unused opens and an incomplete match to a record

suspend_image_viewer was not being built and the commit fixes
compilation errors

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>