### PR TITLE
configure: work around read-only /tmp found in opam's 2.1.0

### DIFF
--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-D=$(mktemp -d /tmp/configure.XXXXX)
+D=$(mktemp -d "${TMPDIR:-/tmp}/configure.XXXXX")
 function cleanup {
   cd /
   rm -rf $D


### PR DESCRIPTION
Use TMPDIR instead if it's provided

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>