### PR TITLE
CP-38064: adapt code to ppxlib 0.9

### DIFF
--- a/cli/xn.ml
+++ b/cli/xn.ml
@@ -788,6 +788,8 @@ let pp x =
                (List.map (fun (s, t) -> Line (s ^ ": ") :: to_t t) xs))
         ; Line "}"
         ]
+    | Base64 x ->
+        [Line x]
     | Null ->
         []
   in

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-D=$(mktemp -d /tmp/configure.XXXXX)
+D=$(mktemp -d ${TMPDIR:-/tmp}/configure.XXXXX)
 function cleanup {
   cd /
   rm -rf $D

--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -276,6 +276,7 @@ let rpc_fn call =
             name= "VM.import_metadata"
           ; params=
               [Rpc.Dict [("debug_info", debug_info); ("metadata", metadata)]]
+          ; notif= false
           }
     | "query", [debug_info; unit_p] ->
         debug "Upgrading query" ;
@@ -283,6 +284,7 @@ let rpc_fn call =
           {
             name= "query"
           ; params= [Rpc.Dict [("debug_info", debug_info); ("unit", unit_p)]]
+          ; notif= false
           }
     | _ ->
         call

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -3290,8 +3290,8 @@ module Backend = struct
 
     (** File-descriptor event monitor implementation for the epoll library *)
     module Monitor = struct
-      module Epoll = Core.Linux_ext.Epoll
-      module Flags = Core.Linux_ext.Epoll.Flags
+      module Epoll = Linux_ext.Epoll
+      module Flags = Linux_ext.Epoll.Flags
 
       let num_file_descrs =
         match Core.Unix.RLimit.((get num_file_descriptors).cur) with

--- a/xc/dune
+++ b/xc/dune
@@ -6,6 +6,7 @@
 
  (libraries
    astring
+   core.linux_ext
    xenctrl
    xapi-xenopsd
    xenstore


### PR DESCRIPTION
I had to do an additional change regarding the usage of the epoll bindings because they were moved in Core 0.14.0, this was not needed on master because these were replaced by polly.

I've also added the workaround for opam 2.1.0 to be able to compile it locally with opam