### PR TITLE
CA-357785: squeezed logs to xensource.log

### DIFF
--- a/squeezed/lib/squeeze.ml
+++ b/squeezed/lib/squeeze.ml
@@ -25,27 +25,9 @@
    commandline *)
 let start = Unix.gettimeofday ()
 
-module D = Debug.Make (struct let name = "xenops" end)
+module D = Debug.Make (struct let name = "squeeze" end)
 
-let debug_oc = ref stdout
-
-let debug fmt =
-  Printf.kprintf
-    (fun x ->
-      Printf.fprintf !debug_oc "[%.2f] %s\n" (Unix.gettimeofday () -. start) x ;
-      flush !debug_oc ;
-      D.debug "%s" x
-      )
-    fmt
-
-let error fmt =
-  Printf.kprintf
-    (fun x ->
-      Printf.fprintf !debug_oc "[%.2f] %s\n" (Unix.gettimeofday () -. start) x ;
-      flush !debug_oc ;
-      D.error "%s" x
-      )
-    fmt
+open D
 
 let manage_domain_zero = ref false
 

--- a/squeezed/src/squeeze_xen.ml
+++ b/squeezed/src/squeeze_xen.ml
@@ -23,11 +23,9 @@ open Squeezed_xenstore
 
 open Xapi_stdext_threads.Threadext
 
-module M = Debug.Make (struct let name = "memory" end)
+module D = Debug.Make (struct let name = "squeeze_xen" end)
 
-let debug = Squeeze.debug
-
-let error = Squeeze.error
+open D
 
 let _domain_type = "/domain-type" (* immutable *)
 

--- a/squeezed/src/squeezed.ml
+++ b/squeezed/src/squeezed.ml
@@ -106,6 +106,7 @@ let bind () =
   S.get_domain_zero_policy get_domain_zero_policy
 
 let _ =
+  Debug.set_facility Syslog.Local5 ;
   debug "squeezed version %d.%d starting" major_version minor_version ;
   configure ~options () ;
   bind () ;

--- a/squeezed/test/dune
+++ b/squeezed/test/dune
@@ -1,11 +1,14 @@
 (test
  (name squeeze_test_main)
+ (package xapi-squeezed)
   (flags (:standard -bin-annot))
   (libraries
+    alcotest
     xapi-stdext-pervasives
     xapi-stdext-unix
     xenctrl
     unix
     squeeze
+    xapi-idl
   )
 )


### PR DESCRIPTION
Xcp_service used to be able to configure where squeezed logged to but it doesn't seem to work anymore.
Set the facility to local5 which logs to xensource.log

I've taken the liberty to change the tests to alcotest to avoid using the same (flawed) logging facilities for the testing code and the tested code.