### PR TITLE
CP-38343: xenopsd GC memory RRD stats

### DIFF
--- a/xapi-xenopsd-xc.opam
+++ b/xapi-xenopsd-xc.opam
@@ -36,6 +36,7 @@ depends: [
   "xapi-backtrace"
   "xapi-idl"
   "xapi-rrd"
+  "rrdd-plugin"
   "xapi-stdext-date"
   "xapi-stdext-pervasives"
   "xapi-stdext-std"

--- a/xc/dune
+++ b/xc/dune
@@ -22,6 +22,8 @@
   rpclib.core
   rpclib.json
   rresult
+  rrdd-plugin.base
+  rrdd-plugin.local
   sexplib0
   qmp
   threads.posix

--- a/xc/mem_stats.ml
+++ b/xc/mem_stats.ml
@@ -1,0 +1,349 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+module D = Debug.Make (struct let name = "mem_stats" end)
+
+module Compat = struct
+  (* backporting support *)
+
+  (*
+  open Stdext
+  let mtime_clock_counter = Mtime.counter
+  let mtime_clock_count = Mtime.count
+  let mtime_span_to_s = Mtime.to_s
+  let file_lines_fold = Stdext.Unixext.file_lines_fold
+  let mutex_execute = Stdext.Threadext.Mutex.execute
+
+  open Rrdd_plugin
+  let reporter_cache : Reporter.t option ref = ref None
+  let reporter_async ~shared_page_count ~dss_f =
+    Reporter.start_async
+      (module D : Debug.DEBUG)
+      ~uid:"mem-stats"
+      ~neg_shift:0.5
+      ~target:(Reporter.Local shared_page_count)
+      ~protocol:Rrd_interface.V2
+      ~dss_f
+  let reporter_cancel = Reporter.cancel
+  *)
+
+  let mtime_clock_counter = Mtime_clock.counter
+  let mtime_clock_count = Mtime_clock.count
+  let mtime_span_to_s = Mtime.Span.to_s
+  let file_lines_fold = Xapi_stdext_unix.Unixext.file_lines_fold
+  let mutex_execute = Xapi_stdext_Threads.Threadext.Mutex.execute
+  let reporter_async ~shared_page_count ~dssf =
+          let reporter = Reporter.make () in
+          let (th : Thread.t) =
+            Thread.create
+              (fun () ->
+                Reporter_local.start_local
+                  (module D : Debug.DEBUG)
+                  ~reporter:(Some reporter) ~uid:"xenopsd-stats"
+                  ~neg_shift:0.5 ~page_count:shared_page_count
+                  ~protocol:Rrd_interface.V2 ~dss_f:generate_stats
+                )
+              ()
+          in
+	  (th, reporter)
+  let reporter_cancel (th, reporter) =
+	Reporter.cancel reporter;
+	Thread.join th
+  let reporter_cache : (Thread.t * Reporter.t) option ref = ref None
+
+end
+open Compat
+
+module SlowReporter = struct
+  let ds_to_unknown = function
+    | Rrd.VT_Int64 _ -> Rrd.VT_Int64 (-1L)
+    | Rrd.VT_Float _ | Rrd.VT_Unknown -> Rrd.VT_Float nan
+
+  let to_unknown dss =
+    dss |> List.rev_map (fun ds -> { ds with Ds.ds_value = ds_to_unknown ds.Ds.ds_value } ) |> List.rev
+
+  (** [report ~interval_s ~generate_dss] calls [generate_dss] every [interval_s] only,
+      and substitutes VT_Unknown when called more often.
+      Report_local only supports reporting at 5s intervals, but some metrics are too costly to
+      gather that often, e.g. Gc.stat needs to walk the entire heap.
+   *)
+  let report ~interval_s ~generate_dss =
+    fun state ->
+      match state with
+      | Some (t0, dss) when mtime_clock_count t0 |> mtime_span_to_s < interval_s ->
+          state, (false, dss)
+      | None | Some _ ->
+          let dss = generate_dss () in
+          let next_state = Some (mtime_clock_counter (), dss) in
+          next_state, (true, dss)
+
+  let iter_of_fold f =
+    let last = ref None in
+    fun () ->
+      let next, r = f !last in
+      (* to make reasoning about metrics easier, this is the only place
+         that contains explicit mutation in this file
+         (other than hashtbl construction on startup)
+        *)
+      last := next;
+      r
+end
+
+module SimpleMetrics = struct
+  (* metric definitions *)
+
+  (* Caveats:
+    * do not use ~transform flag to ds_make: it is lost during rrd-transport with no warning!
+    * writing a VT_Unknown causes an exception and prevents other values from being written too
+    * the way to write an unknown value is to write something out of min/max range, which then gets
+    converted to nan upon reading (or write nan if the type is float, don't do this if type is int
+    since it causes a metadata change)
+    * use Sys.word_size, and not hard-coded word-to-kib conversion, the old code still had the
+    values for a 32-bit word
+    * the value type (int64 vs float) is cached by the transport, changing it causes a metadata
+    change
+    * it is best to always write out the same Rrd list, even if some values are missing, otherwise
+    the metadata would have to get reparsed (crc changed). But that doesn't actually work that way
+    because the metadata also includes the values (they are changed to uninitialized_ds only upon
+    read), thus any change in value triggers a metadata crc change, and a metadata reparse! Still
+    lets assume this will be fixed and avoid needless metadata changes!
+    * everything gets converted to a float in the end: int64 type just has some more precision prior
+    to delta calculation. However for our purposes here the 'float' type (which is double precision)
+    has 53-bits of precision, which is more than enough for KiB - it results in 63-bits of precision
+    in term of bytes (including sign)
+  *)
+
+  let ds_int64 i = Rrd.VT_Int64 i
+  let ds_int i = i |> Int64.of_int |> ds_int64
+  let ds_float f = Rrd.VT_Float f
+  let ds_update ds v = { ds with Ds.ds_value = v }
+
+  let executable = Filename.basename Sys.executable_name
+  let ds_name name = Printf.sprintf "%s_%s" executable (Astring.String.Ascii.lowercase name)
+  let ds_description desc = Printf.sprintf desc executable
+
+  let to_float ds = match ds.Ds.ds_value with
+    | Rrd.VT_Int64 i -> if i >= 0L then Int64.to_float i else nan
+    | Rrd.VT_Float f -> f
+    | Rrd.VT_Unknown -> nan
+
+  let define_unit ~ty ~units ~min ?(default=true) name description =
+    let name = ds_name name in
+    let description = ds_description description in
+    fun value ->
+    Ds.ds_make ~name ~description ~value ~ty ~default ~units ~min:0.0 ()
+
+  let kib ?default ?(min=0.0) v = define_unit ~ty:Rrd.Gauge ~units:"KiB" ~min ?default v
+  let kib_per_s = define_unit ~ty:Rrd.Derive ~units:"KiB/s" ~min:0.0
+
+  let count = define_unit ~ty:Rrd.Gauge ~units:"" ~min:0.0
+
+  let words_to_kib w = w *. float (Sys.word_size / 8) /. 1024. |> ds_float
+end
+
+module Proc = struct
+  module KV = Astring.String.Map
+  (** [drop_unit s] parses values of the form 'NN kB' or 'NN' and returns 'NN'. *)
+  let drop_unit s =
+    match Astring.String.cut ~sep:" " s with None -> s | Some (v, _) -> v
+
+  (** [parse_value s] parses values of the form '  N kB' or '    N'. *)
+  let parse_value s =
+    s |> Astring.String.trim |> drop_unit |> Int64.of_string
+
+  let file_lines_filter_map f ~path =
+    let fold acc line =
+      match f line with
+      | None -> acc
+      | Some (k, v) -> KV.add k v acc
+    in
+    file_lines_fold fold KV.empty path
+
+  open SimpleMetrics
+  let parse_keyvalue fields ~path () =
+    let parse_pairs = function
+      | None -> None
+      | Some (key, value) ->
+          match KV.find key fields with
+          | None -> None
+          | Some ds ->
+              let v = parse_value value in
+              Some (key, ds_update ds @@ ds_int64 v)
+    in
+    file_lines_filter_map ~path @@ fun line ->
+    line |> Astring.String.cut ~sep:":" |> parse_pairs
+
+  let define_fields ~path l =
+    let kv = ListLabels.fold_left l ~init:KV.empty ~f:(fun acc (key, ds) ->
+      KV.add key ds acc) in
+    parse_keyvalue kv ~path:(Filename.concat "/proc/self" path)
+
+  let unknown = ds_int64 (-1L)
+  let kib ?default key desc = key, kib ?default key desc unknown
+  let count ?default key desc = key, count ?default key desc unknown
+
+  module Fields = struct
+    let vmdata = "VmData"
+    let vmpte = "VmPTE"
+    let threads = "Threads"
+
+    (* there is also /proc/self/stat and /proc/self/statm, but we'd need to open and parse both *)
+    let status = define_fields ~path:"status"
+        [ count threads "Total number of threads used by %s"
+        ; count "FDSize" "Total number of file descriptors used by %s"
+        ; kib "VmSize" "Total amount of memory mapped by %s"
+        ; kib "VmLck" "Total amount of memory locked by %s"
+        ; kib "VmPin" "Total amount of memory pinned by %s"
+          (* VmRSS is inaccurate accoring to latest proc(5) *)
+        ; kib vmdata "Total amount of writable, non-shared and non-stack memory used by %s"
+        ; kib "VmStk" "Total amount of main stack memory used by %s"
+        ; kib vmpte "Total amount of page table entry memory used by %s"
+        ]
+
+    (* According to latest proc(5) these are slower, but provide more accurate information.
+       The RSS reported by other stat counters could be off depending on the number of threads. *)
+    let smaps_rollup = define_fields ~path:"smaps_rollup" [
+      kib "Rss" "Total amount of resident memory used by %s"
+    ]
+  end
+
+  let find key kv =
+    to_float (KV.get key kv)
+
+  let to_list kv =
+    KV.bindings kv |> List.rev_map snd
+end
+
+module GcStat = struct
+  open SimpleMetrics
+  open Gc
+
+  let ocaml_total =
+    let f = kib "ocaml_total" "Total OCaml memory used by %s" in
+    fun gc control ->
+    gc.heap_words + control.minor_heap_size
+    |> float |> words_to_kib |> f
+
+  let maybe_words name description v =
+    (* quick_stat would return a value of 0, which is not valid *)
+    v |> float |> words_to_kib |> kib ~min:0.001 name description
+
+  let compute (gc, control) =
+    [ ocaml_total gc control
+    ; gc.minor_words +. gc.major_words -. gc.promoted_words
+      |> words_to_kib
+      |> kib_per_s "ocaml_allocation_rate" "Amount of allocations done by OCaml in the given period by %s"
+    ]
+
+  let compute_slow (gc, control) =
+    [
+    (* see https://github.com/ocaml/ocaml/blob/trunk/stdlib/gc.mli#L50-L59, without running a major
+       cycle the live_words may overestimate the actual live words, "live" just means "not currently
+      known to be collectible"*)
+     gc.live_words |> maybe_words "ocaml_maybe_live" "OCaml memory not currently known to be collectable by %s"
+    ; gc.free_words |> maybe_words "ocaml_free" "OCaml memory available to %s"
+    ]
+end
+
+module Derived = struct
+  open SimpleMetrics
+  let memextra_kib =
+    kib "mem_extra" "Total amount of non-OCaml and non-stack memory used by %s"
+
+  let ulimit_stack =
+    let ic = Unix.open_process_in "ulimit -s" in
+    let r = ic |> input_line |> Int64.of_string in
+    close_in_noerr ic ; Int64.to_float r
+
+  let memextra_kib stats (gc_stat, control) =
+    let ocaml_total_kib = GcStat.ocaml_total gc_stat control |> to_float in
+    let vmdata = Proc.find Proc.Fields.vmdata stats in
+    let vmpte = Proc.find Proc.Fields.vmpte stats in
+    let threads = Proc.find Proc.Fields.threads stats in
+      (* Each thread, except the main one will allocate 'ulimit -s' worth of VmData.
+         This won't immediately show up in VmRss until actually used (e.g. by a deep calltree due to recursion) *)
+    vmdata -. vmpte -. ulimit_stack *. (threads -. 1.) -. ocaml_total_kib
+    |> ds_float |> memextra_kib
+end
+
+let observe_stats l =
+  let names = ListLabels.rev_map l ~f:(fun ds -> ds.Ds.ds_name) in
+  let values = ListLabels.rev_map l ~f:(fun ds ->
+    let f = match ds.Ds.ds_value with
+    | Rrd.VT_Int64 i -> Int64.to_float i
+    | Rrd.VT_Float f -> f
+    | Rrd.VT_Unknown -> nan in
+    ds.Ds.ds_pdp_transform_function f |> Printf.sprintf "%.0f")
+  in
+  D.debug "stats header: %s" (String.concat "," names);
+  D.debug "stats values: %s" (String.concat "," values)
+
+let generate_slow_stats =
+  let generate_dss () =
+    let stat = Gc.stat () in
+    let gc_control = Gc.get () in
+    let rss = Proc.Fields.smaps_rollup () |> Proc.to_list in
+    let gcstat = GcStat.compute_slow (stat, gc_control) in
+    List.rev_append rss gcstat
+  in
+  SlowReporter.iter_of_fold (SlowReporter.report ~interval_s:150. ~generate_dss)
+
+let generate_stats () =
+  let status = Proc.Fields.status () in
+  let gc_stat = Gc.quick_stat () in
+  let gc_control = Gc.get () in
+  let derived = Derived.memextra_kib status (gc_stat, gc_control) in
+  let gcstat = GcStat.compute (gc_stat, gc_control) in
+  let is_slow, slow_stats = generate_slow_stats () in
+  let stats = derived :: List.concat [
+    gcstat;
+    Proc.to_list status;
+    slow_stats
+  ] in
+  if is_slow then
+    observe_stats stats;
+  stats |> List.rev_map (fun x -> Rrd.Host, x)
+
+let generate_stats () =
+  try generate_stats ()
+  with e ->
+    D.log_backtrace ();
+    D.debug "Failed to generate stats: %s" (Printexc.to_string e);
+    []
+
+
+let reporter_m = Mutex.create ()
+
+(* xapi currently exports 5 datasources if a slave or 7 if a master; this
+ * comfortably fits into a single page. *)
+let shared_page_count = 1
+
+let start () =
+  mutex_execute reporter_m (fun () ->
+      match !reporter_cache with
+      | Some _ ->
+          ()
+      | None ->
+          reporter_cache := Some (reporter_async ~shared_page_count ~dss_f:generate_stats)
+  )
+
+let stop () =
+  mutex_execute reporter_m (fun () ->
+      match !reporter_cache with
+      | None ->
+          ()
+      | Some r ->
+	  reporter_cancel r;
+          reporter_cache := None
+  )

--- a/xc/mem_stats.mli
+++ b/xc/mem_stats.mli
@@ -1,0 +1,22 @@
+(*
+ * Copyright (C) Citrix Systems Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val start : unit -> unit
+(** Start a thread which will act as an RRDD plugin, and report interesting
+    stats to RRDD. *)
+
+val stop : unit -> unit
+(** Stop the stats reporting thread. *)
+
+val generate_stats : unit -> (Rrd.ds_owner * Ds.ds) list

--- a/xc/xenops_xc_main.ml
+++ b/xc/xenops_xc_main.ml
@@ -38,9 +38,12 @@ let check_domain0_uuid () =
   in
   let open Xenstore in
   with_xs (fun xs -> List.iter (fun (k, v) -> xs.Xs.write k v) kvs) ;
-  (* before daemonizing we need to forget the xenstore client because the
-     background thread will be gone after the fork() *)
-  forget_client ()
+  if !Xcp_service.daemon then
+    (* before daemonizing we need to forget the xenstore client because the
+       background thread will be gone after the fork().
+       Note that this leaks a thread.
+       *)
+    forget_client ()
 
 let make_var_run_xen () =
   Xapi_stdext_unix.Unixext.mkdir_rec Device_common.var_run_xen_path 0o0755

--- a/xc/xenops_xc_main.ml
+++ b/xc/xenops_xc_main.ml
@@ -58,4 +58,5 @@ let _ =
     ~specific_nonessential_paths:Xc_resources.nonessentials () ;
   check_domain0_uuid () ;
   make_var_run_xen () ;
+  Mem_stats.start () ;
   Xenopsd.main (module Xenops_server_xen : Xenops_server_plugin.S)


### PR DESCRIPTION
2 rrds: a quick one every 5s, and a slow one every 2.5m (that does the slower Gc.stat and smaps_rollup query).

I tried to be careful with units, not to mix words and KiB (i.e. always convert everything to KiB before doing arithmetic on them), the old xapi stats was buggy in this regard (and had some hardcoded constants based on word-size=32-bit which is no longer true).