### PR TITLE
CA-361220: xenopsd: introduce TASK.destroy_on_finish

### DIFF
--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -196,6 +196,9 @@ module TASK = struct
   let destroy _ _dbg id = destroy' id
 
   let list _ _dbg = list tasks |> List.map Xenops_task.to_interface_task
+
+  let destroy_on_finish () _dbg id =
+    id |> handle_of_id tasks |> destroy_on_finish
 end
 
 module VM_DB = struct
@@ -3502,6 +3505,7 @@ let _ =
   Server.TASK.stat (TASK.stat ()) ;
   Server.TASK.list (TASK.list ()) ;
   Server.TASK.destroy (TASK.destroy ()) ;
+  Server.TASK.destroy_on_finish (TASK.destroy_on_finish ()) ;
   Server.HOST.stat (HOST.stat ()) ;
   Server.HOST.get_console_data (HOST.get_console_data ()) ;
   Server.HOST.get_total_memory_mib (HOST.get_total_memory_mib ()) ;


### PR DESCRIPTION
There are certain tasks that are run asynchronously without anyone
waiting for the result (e.g. import_metadata_async).
Allow setting a flag on these tasks, so that they are cleaned up when
finished (either successfully or not).

Needed to avoid space leaks due to an ever growing tasks/updates list.

Signed-off-by: Edwin Török edvin.torok@citrix.com