### PR TITLE
CA-364138 log when about to stop varstored and varstore-guard

### DIFF
--- a/lib/xenops_sandbox.ml
+++ b/lib/xenops_sandbox.ml
@@ -143,6 +143,7 @@ module Varstore_guard = struct
   let stop dbg ~domid ~vm_uuid =
     let chroot = varstored_chroot ~domid ~vm_uuid in
     if Sys.file_exists chroot.root then (
+      D.debug "About to stop varstored for %d (%s) %s" domid vm_uuid __LOC__ ;
       let gid = chroot.Chroot.gid in
       let absolute_socket_path =
         Chroot.absolute_path_outside chroot socket_path
@@ -151,5 +152,7 @@ module Varstore_guard = struct
         (fun () ->
           Varstore_privileged_client.Client.destroy dbg gid absolute_socket_path) ;
       Chroot.destroy chroot
-    )
+    ) else
+      D.warn "Can't stop varstored for %d (%s): %s does not exist" domid vm_uuid
+        chroot.root
 end

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -2781,10 +2781,11 @@ module Dm_Common = struct
     in
     let stop_vgpu () = Vgpu.stop ~xs domid in
     let stop_varstored () =
+      let vm_uuid = Xenops_helpers.uuid_of_domid ~xs domid |> Uuidm.to_string in
+      debug "About to stop varstored for domain %d (%s)" domid vm_uuid ;
       Varstored.stop ~xs domid ;
       let dbg = Printf.sprintf "stop domid %d" domid in
-      Xenops_sandbox.Varstore_guard.stop dbg ~domid
-        ~vm_uuid:(Uuidm.to_string (Xenops_helpers.uuid_of_domid ~xs domid))
+      Xenops_sandbox.Varstore_guard.stop dbg ~domid ~vm_uuid
     in
     stop_vgpu () ; stop_varstored () ; stop_qemu ()
 


### PR DESCRIPTION
For debugging lost FDs in varstore-guard, log when whe call it to stop
serving a domain. Backport from xen-api.git

* 53d0f47642207d9fdf3ae2a08c19de17d57bf47f

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>