### PR TITLE
CA-366014 UPD-825 pass dm qemu to UEFI qemu, too

### DIFF
--- a/xc/device.ml
+++ b/xc/device.ml
@@ -49,8 +49,6 @@ module Profile = struct
 
   let fallback = Qemu_upstream_compat
 
-  let all = [Qemu_none; Qemu_upstream_compat; Qemu_upstream]
-
   module Name = struct
     let qemu_none = "qemu-none"
 

--- a/xc/device.mli
+++ b/xc/device.mli
@@ -40,9 +40,6 @@ module Profile : sig
   (** the fallback profile in case an invalid profile string is provided to
       [of_string] *)
 
-  val all : t list
-  (** all available profiles *)
-
   (** Valid names for a profile, used to define valid values for
       VM.platform.device-model *)
   module Name : sig

--- a/xc/domain.ml
+++ b/xc/domain.ml
@@ -1154,6 +1154,14 @@ let build (task : Xenops_task.task_handle) ~xc ~xs ~store_domid ~console_domid
 
 type suspend_flag = Live | Debug
 
+let dm_flags =
+  let open Device.Profile in
+  function
+  | Qemu_upstream | Qemu_upstream_compat | Qemu_upstream_uefi ->
+      ["-dm"; "qemu"]
+  | Qemu_trad | Qemu_none ->
+      []
+
 let with_emu_manager_restore (task : Xenops_task.task_handle) ~domain_type
     ~(dm : Device.Profile.t) ~store_port ~console_port ~extras manager_path
     domid uuid main_fd vgpu_fd f =
@@ -1185,12 +1193,7 @@ let with_emu_manager_restore (task : Xenops_task.task_handle) ~domain_type
     ; "-console_port"
     ; string_of_int console_port
     ]
-    @ ( match dm with
-      | Device.Profile.Qemu_upstream | Device.Profile.Qemu_upstream_compat ->
-          ["-dm"; "qemu"]
-      | _ ->
-          []
-      )
+    @ dm_flags dm
     @ extras
     @ vgpu_cmdline
   in
@@ -1569,12 +1572,7 @@ let suspend_emu_manager ~(task : Xenops_task.task_handle) ~xc ~xs ~domain_type
   let flags' = List.map cmdline_to_flag flags in
   let args =
     ["-fd"; fd_uuid; "-mode"; mode; "-domid"; string_of_int domid]
-    @ ( match dm with
-      | Device.Profile.Qemu_upstream | Device.Profile.Qemu_upstream_compat ->
-          ["-dm"; "qemu"]
-      | _ ->
-          []
-      )
+    @ dm_flags dm
     @ List.concat flags'
     @ vgpu_cmdline
   in


### PR DESCRIPTION
Backport from xe-api.git:

* c12905cfbd5ca7d502bb05468d98122457cf9aff
* 5f33eb2fd251e7183098f4ef96233f28b6198974
* ec2f3c0e0ae794c2ca3e4b966f8e7d4a90e33760

emu-manager needs '-dm qemu' flag for migration to work correctly with
upstream QEMU.  Otherwise emu-manager doesn't send
xen-set-global-dirty-log and some guest drivers may crash upon resume
(e.g. the mouse).

Treat Qemu_upstream_uefi as upstream too and pass the flag.

Commit 0e8624a6be6994a5aa2847147b20adcd4e32f02a introduced '-dm qemu'
but the UEFI version of the qemu profile didn't exist yet at the time.

Later commit 971d788ad9ee0aec3150141153ad4c553f1c2b43 introduced the
UEFI qemu profile, and the build still worked due to the wildcard,
so the missing flag went unnoticed until now.

Replace the wildcard with an explicit list of when '-dm qemu' shouldn't
be added, so the next time we introduce a new qemu profile we get a
build failure and must decide which behaviour would be correct.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>
Signed-off-by: Christian Lindig <christian.lindig@citrix.com>