### PR TITLE
test: run as part of the xapi-xenopsd package

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -8,6 +8,7 @@
 
 (alias
  (name runtest)
+ (package xapi-xenopsd)
  (deps test.exe)
  (action
   (run %{deps} --show-errors)

--- a/xapi-xenopsd-cli.opam
+++ b/xapi-xenopsd-cli.opam
@@ -1,9 +1,9 @@
 opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: [ "xen-api@lists.xen.org" ]
-homepage: "https://github.com/xapi-project/xenops-cli"
-bug-reports: "https://github.com/xapi-project/xenops-cli/issues"
-dev-repo: "git+https://github.com/xapi-project/xenops-cli.git"
+homepage: "https://github.com/xapi-project/xenopsd"
+bug-reports: "https://github.com/xapi-project/xenopsd/issues"
+dev-repo: "git+https://github.com/xapi-project/xenopsd.git"
 build: [
   ["dune" "build" "-p" name]
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
@@ -23,5 +23,5 @@ description: """
 A simple command-line tool for interacting with xenopsd
 """
 url {
-  src: "https://github.com/xapi-project/xenops-cli/archive/master/master.tar.gz"
+  src: "https://github.com/xapi-project/xenopsd/archive/master/master.tar.gz"
 }


### PR DESCRIPTION
Otherwise the CI tries to run them as part of xapi-xenopsd-cli and will
fail to find a library

Signed-off-by: Pau Ruiz Safont <pau.safont@citrix.com>