### PR TITLE
Reformat for compatibility with xapi

### DIFF
--- a/cli/main.ml
+++ b/cli/main.ml
@@ -48,7 +48,8 @@ let common_options_t =
     Arg.(
       value
       & opt file !Xenops_interface.default_path
-      & info ["socket"] ~docs ~doc)
+      & info ["socket"] ~docs ~doc
+    )
   in
   let queue =
     let default = Some "org.xen.xapi.xenops.classic" in
@@ -71,7 +72,8 @@ let events_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.events $ common_options_t))
-  , Term.info "events" ~sdocs:_common_options ~doc ~man )
+  , Term.info "events" ~sdocs:_common_options ~doc ~man
+  )
 
 let create_cmd =
   let doc = "register a VM and start it immediately" in
@@ -92,7 +94,8 @@ let create_cmd =
     Arg.(value & flag & info ["console"] ~doc)
   in
   ( Term.(ret (pure Xn.create $ common_options_t $ filename $ console))
-  , Term.info "create" ~sdocs:_common_options ~doc ~man )
+  , Term.info "create" ~sdocs:_common_options ~doc ~man
+  )
 
 let add_cmd =
   let doc = "register a new VM with xenopsd" in
@@ -104,7 +107,8 @@ let add_cmd =
     Arg.(value & pos 0 (some file) None & info [] ~doc)
   in
   ( Term.(ret (pure Xn.add $ common_options_t $ filename))
-  , Term.info "add" ~sdocs:_common_options ~doc ~man )
+  , Term.info "add" ~sdocs:_common_options ~doc ~man
+  )
 
 let list_cmd =
   let doc = "list the VMs registered with xenopsd" in
@@ -122,7 +126,8 @@ let list_cmd =
     @ help
   in
   ( Term.(pure Xn.list $ common_options_t)
-  , Term.info "list" ~sdocs:_common_options ~doc ~man )
+  , Term.info "list" ~sdocs:_common_options ~doc ~man
+  )
 
 let vm_arg verb =
   let doc = Printf.sprintf "The name or UUID of the VM to be %s." verb in
@@ -154,7 +159,8 @@ let remove_cmd =
     ]
   in
   ( Term.(ret (pure Xn.remove $ common_options_t $ vm))
-  , Term.info "remove" ~sdocs:_common_options ~doc ~man )
+  , Term.info "remove" ~sdocs:_common_options ~doc ~man
+  )
 
 let start_cmd =
   let vm = vm_arg "started" in
@@ -184,7 +190,8 @@ let start_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.start $ common_options_t $ paused $ console $ vm))
-  , Term.info "start" ~sdocs:_common_options ~doc ~man )
+  , Term.info "start" ~sdocs:_common_options ~doc ~man
+  )
 
 let console_cmd =
   let vm =
@@ -204,7 +211,8 @@ let console_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.console_connect $ common_options_t $ vm))
-  , Term.info "console" ~sdocs:_common_options ~doc ~man )
+  , Term.info "console" ~sdocs:_common_options ~doc ~man
+  )
 
 let shutdown_cmd =
   let vm = vm_arg "shutdown and powered off" in
@@ -231,7 +239,8 @@ let shutdown_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.shutdown $ common_options_t $ timeout $ vm))
-  , Term.info "shutdown" ~sdocs:_common_options ~doc ~man )
+  , Term.info "shutdown" ~sdocs:_common_options ~doc ~man
+  )
 
 let reboot_cmd =
   let vm = vm_arg "rebooted" in
@@ -259,7 +268,8 @@ let reboot_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.reboot $ common_options_t $ timeout $ vm))
-  , Term.info "reboot" ~sdocs:_common_options ~doc ~man )
+  , Term.info "reboot" ~sdocs:_common_options ~doc ~man
+  )
 
 let suspend_cmd =
   let vm = vm_arg "suspended" in
@@ -281,7 +291,8 @@ let suspend_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.suspend $ common_options_t $ device $ vm))
-  , Term.info "suspend" ~sdocs:_common_options ~doc ~man )
+  , Term.info "suspend" ~sdocs:_common_options ~doc ~man
+  )
 
 let resume_cmd =
   let vm = vm_arg "resumed" in
@@ -303,7 +314,8 @@ let resume_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.resume $ common_options_t $ device $ vm))
-  , Term.info "resume" ~sdocs:_common_options ~doc ~man )
+  , Term.info "resume" ~sdocs:_common_options ~doc ~man
+  )
 
 let pause_cmd =
   let vm = vm_arg "paused" in
@@ -322,7 +334,8 @@ let pause_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.pause $ common_options_t $ vm))
-  , Term.info "pause" ~sdocs:_common_options ~doc ~man )
+  , Term.info "pause" ~sdocs:_common_options ~doc ~man
+  )
 
 let unpause_cmd =
   let vm = vm_arg "unpaused" in
@@ -340,7 +353,8 @@ let unpause_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.unpause $ common_options_t $ vm))
-  , Term.info "unpause" ~sdocs:_common_options ~doc ~man )
+  , Term.info "unpause" ~sdocs:_common_options ~doc ~man
+  )
 
 let import_cmd =
   let filename =
@@ -367,7 +381,8 @@ let import_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.import $ common_options_t $ metadata $ filename))
-  , Term.info "import" ~sdocs:_common_options ~doc ~man )
+  , Term.info "import" ~sdocs:_common_options ~doc ~man
+  )
 
 let export_cmd =
   let vm = vm_arg "exported" in
@@ -395,8 +410,10 @@ let export_cmd =
     @ help
   in
   ( Term.(
-      ret (pure Xn.export $ common_options_t $ metadata $ xm $ filename $ vm))
-  , Term.info "export" ~sdocs:_common_options ~doc ~man )
+      ret (pure Xn.export $ common_options_t $ metadata $ xm $ filename $ vm)
+    )
+  , Term.info "export" ~sdocs:_common_options ~doc ~man
+  )
 
 let diagnostics_cmd =
   let doc = "retrieve diagnostic information" in
@@ -408,7 +425,8 @@ let diagnostics_cmd =
     @ help
   in
   ( Term.(ret (pure Xn.diagnostics $ common_options_t))
-  , Term.info "diagnostics" ~sdocs:_common_options ~doc ~man )
+  , Term.info "diagnostics" ~sdocs:_common_options ~doc ~man
+  )
 
 let tasks_cmd =
   let doc = "List in-progress tasks" in
@@ -416,7 +434,8 @@ let tasks_cmd =
     [`S "DESCRIPTION"; `P "Describe the set of in-progress tasks."] @ help
   in
   ( Term.(ret (pure Xn.task_list $ common_options_t))
-  , Term.info "tasks" ~sdocs:_common_options ~doc ~man )
+  , Term.info "tasks" ~sdocs:_common_options ~doc ~man
+  )
 
 let task_cancel_cmd =
   let doc = "Cancel an in-progress task" in
@@ -434,7 +453,8 @@ let task_cancel_cmd =
     Arg.(value & pos 0 (some string) None & info [] ~doc)
   in
   ( Term.(ret (pure Xn.task_cancel $ common_options_t $ task))
-  , Term.info "task-cancel" ~sdocs:_common_options ~doc ~man )
+  , Term.info "task-cancel" ~sdocs:_common_options ~doc ~man
+  )
 
 let cd_eject_cmd =
   let doc = "Eject a CDROM" in
@@ -444,7 +464,8 @@ let cd_eject_cmd =
     Arg.(value & pos 0 (some string) None & info [] ~doc)
   in
   ( Term.(ret (pure Xn.cd_eject $ common_options_t $ vbd))
-  , Term.info "cd-eject" ~sdocs:_common_options ~doc ~man )
+  , Term.info "cd-eject" ~sdocs:_common_options ~doc ~man
+  )
 
 let stat_vm_cmd =
   let doc = "Query the runtime status of a running VM." in
@@ -456,13 +477,15 @@ let stat_vm_cmd =
     Arg.(required & pos 0 (some string) None & info [] ~doc ~docv:"uuid")
   in
   ( Term.(ret (pure Xn.stat_vm $ common_options_t $ vm))
-  , Term.info "vm-stat" ~sdocs:_common_options ~doc ~man )
+  , Term.info "vm-stat" ~sdocs:_common_options ~doc ~man
+  )
 
 let default_cmd =
   let doc = "interact with the XCP xenopsd VM management service" in
   let man = help in
   ( Term.(ret (pure (fun _ -> `Help (`Pager, None)) $ common_options_t))
-  , Term.info "xenops-cli" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man )
+  , Term.info "xenops-cli" ~version:"1.0.0" ~sdocs:_common_options ~doc ~man
+  )
 
 let cmds =
   [

--- a/cli/xn.ml
+++ b/cli/xn.ml
@@ -157,7 +157,8 @@ let success_task f id =
             | Error (`Msg x) ->
                 Xenopsd_error
                   (Internal_error
-                     (Printf.sprintf "Error unmarshalling failure: %s" x))
+                     (Printf.sprintf "Error unmarshalling failure: %s" x)
+                  )
           in
           match exn with
           | Xenopsd_error (Failed_to_contact_remote_service x) ->
@@ -168,7 +169,8 @@ let success_task f id =
               raise exn
         )
       | Task.Pending _ ->
-          failwith "task pending")
+          failwith "task pending"
+    )
     (fun () -> Client.TASK.destroy dbg id)
 
 let parse_source x =
@@ -257,7 +259,8 @@ let parse_pci vm_id (x, idx) =
             | _ ->
                 Printf.fprintf stderr
                   "Failed to parse PCI option: %s. It should be key=value.\n" x ;
-                exit 2)
+                exit 2
+          )
           options
       in
       let bool_opt k opts =
@@ -390,7 +393,8 @@ let parse_vif vm_id (x, idx) =
               "I don't understand '%s'. Please use \
                'mac=xx:xx:xx:xx:xx:xx,bridge=xenbrX'.\n"
               x ;
-            exit 2)
+            exit 2
+      )
       xs
   in
   {
@@ -447,7 +451,9 @@ let print_vm id =
       ( _disk
       , Printf.sprintf "[ %s ]"
           (String.concat ", "
-             (List.map (fun x -> Printf.sprintf "'%s'" (print_disk x)) vbds)) )
+             (List.map (fun x -> Printf.sprintf "'%s'" (print_disk x)) vbds)
+          )
+      )
     ]
   in
   let vifs = Client.VIF.list dbg id |> List.map fst in
@@ -456,7 +462,9 @@ let print_vm id =
       ( _vif
       , Printf.sprintf "[ %s ]"
           (String.concat ", "
-             (List.map (fun x -> Printf.sprintf "'%s'" (print_vif x)) vifs)) )
+             (List.map (fun x -> Printf.sprintf "'%s'" (print_vif x)) vifs)
+          )
+      )
     ]
   in
   let pcis = Client.PCI.list dbg id |> List.map fst in
@@ -469,7 +477,9 @@ let print_vm id =
       ( _pci
       , Printf.sprintf "[ %s ]"
           (String.concat ", "
-             (List.map (fun x -> Printf.sprintf "'%s'" (print_pci x)) pcis)) )
+             (List.map (fun x -> Printf.sprintf "'%s'" (print_pci x)) pcis)
+          )
+      )
     ]
   in
   let global_pci_opts =
@@ -481,7 +491,8 @@ let print_vm id =
   String.concat "\n"
     (List.map
        (fun (k, v) -> Printf.sprintf "%s=%s" k v)
-       (name @ boot @ vcpus @ memory @ vbds @ vifs @ pcis @ global_pci_opts))
+       (name @ boot @ vcpus @ memory @ vbds @ vifs @ pcis @ global_pci_opts)
+    )
 
 let canonicalise_filename x =
   try
@@ -519,8 +530,10 @@ let add' _copts x () =
             List.rev
               (List.fold_left
                  (fun acc x ->
-                   match x.disk with None -> acc | Some x -> x :: acc)
-                 [] disks)
+                   match x.disk with None -> acc | Some x -> x :: acc
+                 )
+                 [] disks
+              )
           in
           let open Vm in
           let builder_info =
@@ -674,7 +687,8 @@ let add' _copts x () =
           let one x = x |> parse_pci id |> Client.PCI.add dbg in
           let (_ : Pci.id list) = List.map one pcis in
           Printf.fprintf stdout "%s\n" id ;
-          `Ok id)
+          `Ok id
+        )
         (fun () -> close_in ic)
 
 let add copts x () =
@@ -706,7 +720,8 @@ let list_verbose () =
       Printf.printf "%-45s%-5s\n" vm.Vm.name
         (state.Vm.power_state |> string_of_power_state) ;
       Printf.printf "  %s\n" (vm |> rpc_of Vm.t |> Jsonrpc.to_string) ;
-      Printf.printf "  %s\n" (state |> rpc_of Vm.state |> Jsonrpc.to_string))
+      Printf.printf "  %s\n" (state |> rpc_of Vm.state |> Jsonrpc.to_string)
+    )
     vms
 
 let list_compact () =
@@ -785,8 +800,7 @@ let pp x =
         [
           Line "{"
         ; Block
-            (List.concat
-               (List.map (fun (s, t) -> Line (s ^ ": ") :: to_t t) xs))
+            (List.concat (List.map (fun (s, t) -> Line (s ^ ": ") :: to_t t) xs))
         ; Line "}"
         ]
     | Base64 x ->
@@ -905,7 +919,8 @@ let import_metadata _copts filename =
           | n ->
               Buffer.add_bytes buf (Bytes.sub line 0 n)
         done
-      with End_of_file -> ())
+      with End_of_file -> ()
+    )
     (fun () -> close_in ic) ;
   let txt = Buffer.contents buf in
   let id = Client.VM.import_metadata dbg txt in
@@ -1056,7 +1071,8 @@ let vbd_list x =
           | Some (VDI path) ->
               path |> trim 32
         in
-        line id position mode ty plugged disk disk2)
+        line id position mode ty plugged disk disk2
+      )
       vbds
   in
   List.iter print_endline (header :: lines)
@@ -1072,7 +1088,8 @@ let console_list _copts x =
         let protocol =
           match c.Vm.protocol with Vm.Rfb -> "RFB" | Vm.Vt100 -> "VT100"
         in
-        line protocol (string_of_int c.Vm.port))
+        line protocol (string_of_int c.Vm.port)
+      )
       s.Vm.consoles
   in
   List.iter print_endline (header :: lines)
@@ -1179,7 +1196,8 @@ let raw_console_proxy sockaddr =
         (fun () ->
           Unix.connect s sockaddr ;
           delay := 0.1 ;
-          proxy s)
+          proxy s
+        )
         (fun () -> Unix.close s)
     with
     | Unix.Unix_error (_, _, _) when !delay <= long_connection_retry_timeout ->
@@ -1214,7 +1232,8 @@ let vncviewer_binary =
           then
             Some path
           else
-            None)
+            None
+    )
     None dirs
 
 let unix_proxy path =
@@ -1283,13 +1302,13 @@ let console_connect' _copts x =
   List.iter
     (fun exe ->
       if Sys.file_exists exe then
-        Unix.execv exe [|exe; string_of_int (List.hd s.Vm.domids)|])
+        Unix.execv exe [|exe; string_of_int (List.hd s.Vm.domids)|]
+    )
     xenconsoles ;
   Printf.fprintf stderr "Failed to find a text console.\n%!" ;
   exit 1
 
-let console_connect copts x =
-  diagnose_error (need_vm (console_connect' copts) x)
+let console_connect copts x = diagnose_error (need_vm (console_connect' copts) x)
 
 let start' copts paused console x =
   let vm, _ = find_by_name x in
@@ -1351,7 +1370,8 @@ let pci_list x =
           Printf.sprintf "%04x:%02x:%02x.%01x" pci.address.domain
             pci.address.bus pci.address.dev pci.address.fn
         in
-        line id (string_of_int pci.position) bdf)
+        line id (string_of_int pci.position) bdf
+      )
       pcis
   in
   List.iter print_endline (header :: lines)
@@ -1411,7 +1431,8 @@ let rec events_watch from =
         | Vgpu id ->
             Printf.sprintf "VGPU %s.%s" (fst id) (snd id)
         | Vusb id ->
-            Printf.sprintf "VUSB %s.%s" (fst id) (snd id))
+            Printf.sprintf "VUSB %s.%s" (fst id) (snd id)
+        )
       events
   in
   List.iter (fun x -> Printf.printf "%-8d %s\n" next x) lines ;
@@ -1438,8 +1459,10 @@ let task_list _ =
       List.iter
         (fun (name, state) ->
           Printf.printf "  |_ %-30s %s\n" name
-            (state |> rpc_of Task.state |> Jsonrpc.to_string))
-        t.Task.subtasks)
+            (state |> rpc_of Task.state |> Jsonrpc.to_string)
+        )
+        t.Task.subtasks
+    )
     all ;
   `Ok ()
 
@@ -1486,7 +1509,8 @@ let old_main () =
           ) else if x = key then
             (acc, true)
           else
-            (x :: acc, false))
+            (x :: acc, false)
+        )
         ([], false) args
       |> fst
       |> List.rev

--- a/configure.ml
+++ b/configure.ml
@@ -16,14 +16,16 @@ let libexecdir =
   Arg.(
     value
     & opt string "/usr/lib/xenopsd"
-    & info ["libexecdir"] ~docv:"LIBEXECDIR" ~doc)
+    & info ["libexecdir"] ~docv:"LIBEXECDIR" ~doc
+  )
 
 let qemu_wrapper_dir =
   let doc = "Set the directory for installing xen helper executables" in
   Arg.(
     value
     & opt string "/usr/lib/xenopsd"
-    & info ["qemu_wrapper_dir"] ~docv:"QEMU_WRAPPER_DIR" ~doc)
+    & info ["qemu_wrapper_dir"] ~docv:"QEMU_WRAPPER_DIR" ~doc
+  )
 
 let coverage =
   let doc = "Enable coverage profiling" in
@@ -34,7 +36,8 @@ let scriptsdir =
   Arg.(
     value
     & opt string "/usr/lib/xenopsd/scripts"
-    & info ["scriptsdir"] ~docv:"SCRIPTSDIR" ~doc)
+    & info ["scriptsdir"] ~docv:"SCRIPTSDIR" ~doc
+  )
 
 let etcdir =
   let doc = "Set the directory for installing configuration files" in
@@ -43,14 +46,16 @@ let etcdir =
 let mandir =
   let doc = "Set the directory for installing manpages" in
   Arg.(
-    value & opt string "/usr/share/man" & info ["mandir"] ~docv:"MANDIR" ~doc)
+    value & opt string "/usr/share/man" & info ["mandir"] ~docv:"MANDIR" ~doc
+  )
 
 let optdir =
   let doc = "Set the directory for installing system binaries" in
   Arg.(
     value
     & opt string "/opt/xensource/libexec"
-    & info ["optdir"] ~docv:"OPTDIR" ~doc)
+    & info ["optdir"] ~docv:"OPTDIR" ~doc
+  )
 
 let info =
   let doc = "Configures a package" in
@@ -90,7 +95,8 @@ let find_ml_val verbose name libs =
     Sys.command
       (Printf.sprintf "ocamlfind ocamlc -package %s -c %s %s"
          (String.concat "," libs) ml_file
-         (if verbose then "" else "2>/dev/null"))
+         (if verbose then "" else "2>/dev/null")
+      )
     = 0
   in
   if Sys.file_exists ml_file then Sys.remove ml_file ;
@@ -125,7 +131,8 @@ let find_xentoollog verbose =
   let found =
     Sys.command
       (Printf.sprintf "cc -Werror %s -lxentoollog -o %s %s" c_file exe_file
-         (if verbose then "" else "2>/dev/null"))
+         (if verbose then "" else "2>/dev/null")
+      )
     = 0
   in
   if Sys.file_exists c_file then Sys.remove c_file ;
@@ -197,7 +204,8 @@ let configure_t =
     $ etcdir
     $ mandir
     $ optdir
-    $ coverage)
+    $ coverage
+  )
 
 let () =
   match Term.eval (configure_t, info) with `Error _ -> exit 1 | _ -> exit 0

--- a/lib/bootloader.ml
+++ b/lib/bootloader.ml
@@ -115,7 +115,8 @@ let parse_output_simple x =
       | Some _ ->
           raise
             (Bad_error
-               ("More than one kernel line when parsing bootloader result: " ^ x))
+               ("More than one kernel line when parsing bootloader result: " ^ x)
+            )
       | None ->
           debug "Using kernel line from bootloader output: %s" l ;
           {acc with kernel= Some (String.sub l pos (String.length l - pos))}
@@ -127,7 +128,8 @@ let parse_output_simple x =
             (Bad_error
                ("More than one ramdisk line when parsing bootloader result: "
                ^ x
-               ))
+               )
+            )
       | None ->
           debug "Using ramdisk line from bootloader output: %s" l ;
           {acc with ramdisk= Some (String.sub l pos (String.length l - pos))}
@@ -137,7 +139,8 @@ let parse_output_simple x =
       | Some _ ->
           raise
             (Bad_error
-               ("More than one args line when parsing bootloader result: " ^ x))
+               ("More than one args line when parsing bootloader result: " ^ x)
+            )
       | None ->
           debug "Using args line from bootloader output: %s" l ;
           {acc with args= Some (String.sub l pos (String.length l - pos))}
@@ -149,7 +152,8 @@ let parse_output_simple x =
           (Bad_error
              ("Unrecognised start of line when parsing bootloader result: line="
              ^ l
-             ))
+             )
+          )
   in
   let parse_line acc l =
     try parse_line_optimistic acc l with Not_found -> acc
@@ -195,7 +199,8 @@ let sanity_check_path p =
   | p when Filename.is_relative p ->
       raise
         (Bad_error
-           ("Bootloader returned a relative path for kernel or ramdisk: " ^ p))
+           ("Bootloader returned a relative path for kernel or ramdisk: " ^ p)
+        )
   | p -> (
       let canonical_path = Xapi_stdext_unix.Unixext.resolve_dot_and_dotdot p in
       match Filename.dirname canonical_path with
@@ -209,7 +214,8 @@ let sanity_check_path p =
                ("Malicious guest? Bootloader returned a kernel or ramdisk path \
                  outside the allowed directories: "
                ^ p
-               ))
+               )
+            )
     )
 
 (** Extract the default kernel using the -q option *)

--- a/lib/cancellable_subprocess.ml
+++ b/lib/cancellable_subprocess.ml
@@ -27,7 +27,8 @@ let run (task : Xenops_task.task_handle) ?env ?stdin fds
     Option.map
       (fun str ->
         let x, y = Unix.pipe () in
-        (str, x, y))
+        (str, x, y)
+      )
       stdin
   in
   (* Used so that cancel -> kills subprocess -> Unix.WSIGNALED -> raise
@@ -51,16 +52,21 @@ let run (task : Xenops_task.task_handle) ?env ?stdin fds
                       (fun () ->
                         cancelled := true ;
                         info "Cancelling: sending SIGKILL to %d" pid' ;
-                        try Unix.kill pid' Sys.sigkill with _ -> ())
+                        try Unix.kill pid' Sys.sigkill with _ -> ()
+                      )
                       (fun () ->
                         Option.iter
                           (fun (str, _, wr) ->
-                            Unixext.really_write wr str 0 (String.length str))
+                            Unixext.really_write wr str 0 (String.length str)
+                          )
                           stdinandpipes ;
                         done_waitpid := true ;
-                        snd (Forkhelpers.waitpid t)))
-                  (fun () ->
-                    if not !done_waitpid then Forkhelpers.dontwaitpid t)))
+                        snd (Forkhelpers.waitpid t)
+                      )
+                  )
+                  (fun () -> if not !done_waitpid then Forkhelpers.dontwaitpid t)
+            )
+        )
       with
       | Success (out, Success (err, status)) -> (
         match status with
@@ -83,6 +89,8 @@ let run (task : Xenops_task.task_handle) ?env ?stdin fds
             )
       )
       | Success (_, Failure (_, exn)) | Failure (_, exn) ->
-          raise exn)
+          raise exn
+    )
     (fun () ->
-      Option.iter (fun (_, x, y) -> Unix.close x ; Unix.close y) stdinandpipes)
+      Option.iter (fun (_, x, y) -> Unix.close x ; Unix.close y) stdinandpipes
+    )

--- a/lib/io.ml
+++ b/lib/io.ml
@@ -115,7 +115,8 @@ let unmarshall_int64 ~endianness buffer =
     ||| shift_left e 24
     ||| shift_left f 16
     ||| shift_left g 8
-    ||| h)
+    ||| h
+  )
 
 let read_int64 ~endianness fd =
   let buffer = read fd 8 in

--- a/lib/resources.ml
+++ b/lib/resources.ml
@@ -48,15 +48,18 @@ let hvm_guests =
   ; ( X_OK
     , "qemu-dm-wrapper"
     , qemu_dm_wrapper
-    , "path to the qemu-dm-wrapper script" )
+    , "path to the qemu-dm-wrapper script"
+    )
   ; ( X_OK
     , "qemu-system-i386"
     , qemu_system_i386
-    , "path to the qemu-system-i386 binary" )
+    , "path to the qemu-system-i386 binary"
+    )
   ; ( X_OK
     , "upstream-compat-qemu-dm-wrapper"
     , upstream_compat_qemu_dm_wrapper
-    , "path to the upstream compat qemu-dm-wrapper script" )
+    , "path to the upstream compat qemu-dm-wrapper script"
+    )
   ]
 
 let pv_guests =
@@ -70,7 +73,8 @@ let pvinpvh_guests =
     ( X_OK
     , "pvinpvh-xen"
     , pvinpvh_xen
-    , "path to the inner-xen for PV-in-PVH guests" )
+    , "path to the inner-xen for PV-in-PVH guests"
+    )
   ]
 
 (* libvirt xc *)
@@ -89,21 +93,25 @@ let nonessentials =
     ( X_OK
     , "convert-legacy-stream"
     , legacy_conv_tool
-    , "path to convert-legacy-stream tool" )
+    , "path to convert-legacy-stream tool"
+    )
   ; (R_OK, "cpu-info-file", cpu_info_file, "Where to cache boot-time CPU info")
   ; ( X_OK
     , "verify-stream-v2"
     , verify_libxc_v2
-    , "tool to verify suspend image libxc stream" )
+    , "tool to verify suspend image libxc stream"
+    )
   ]
 
 let make_resources ~essentials ~nonessentials =
   let open Xcp_service in
   List.map
     (fun (perm, name, path, description) ->
-      {essential= true; name; description; path; perms= [perm]})
+      {essential= true; name; description; path; perms= [perm]}
+    )
     essentials
   @ List.map
       (fun (perm, name, path, description) ->
-        {essential= false; name; description; path; perms= [perm]})
+        {essential= false; name; description; path; perms= [perm]}
+      )
       nonessentials

--- a/lib/softaffinity.ml
+++ b/lib/softaffinity.ml
@@ -84,7 +84,8 @@ let plan host nodes ~vm =
     let candidate = nodes.(nodeidx) in
     ( NUMAResource.union allocated candidate
     , node :: picked
-    , NUMARequest.shrink requested candidate )
+    , NUMARequest.shrink requested candidate
+    )
   in
   let plan_valid (avg, nodes) =
     let allocated, picked, remaining =

--- a/lib/storage.ml
+++ b/lib/storage.ml
@@ -39,7 +39,8 @@ let id_of frontend vbd = Printf.sprintf "vbd/%s/%s" frontend (snd vbd)
 let epoch_begin task sr vdi domid persistent =
   transform_exception
     (fun () ->
-      Client.VDI.epoch_begin (Xenops_task.get_dbg task) sr vdi domid persistent)
+      Client.VDI.epoch_begin (Xenops_task.get_dbg task) sr vdi domid persistent
+    )
     ()
 
 let epoch_end task sr vdi domid =
@@ -64,12 +65,16 @@ let attach_and_activate ~task ~_vm ~vmdomid ~dp ~sr ~vdi ~read_write =
       (Printf.sprintf "VDI.attach3 %s" dp)
       (transform_exception (fun () ->
            Client.VDI.attach3 "attach_and_activate_impl" dp sr vdi vmdomid
-             read_write))
+             read_write
+       )
+      )
   in
   Xenops_task.with_subtask task
     (Printf.sprintf "VDI.activate3 %s" dp)
     (transform_exception (fun () ->
-         Client.VDI.activate3 "attach_and_activate_impl" dp sr vdi vmdomid)) ;
+         Client.VDI.activate3 "attach_and_activate_impl" dp sr vdi vmdomid
+     )
+    ) ;
   result
 
 let deactivate task dp sr vdi vmdomid =
@@ -77,7 +82,9 @@ let deactivate task dp sr vdi vmdomid =
   Xenops_task.with_subtask task
     (Printf.sprintf "VDI.deactivate %s" dp)
     (transform_exception (fun () ->
-         Client.VDI.deactivate "deactivate" dp sr vdi vmdomid))
+         Client.VDI.deactivate "deactivate" dp sr vdi vmdomid
+     )
+    )
 
 let dp_destroy task dp =
   Xenops_task.with_subtask task
@@ -102,7 +109,9 @@ let dp_destroy task dp =
                warn "DP destroy returned unexpected exception: %s"
                  (Printexc.to_string e) ;
                waiting_for_plugin := false
-         done))
+         done
+     )
+    )
 
 let get_disk_by_name _task path =
   match Astring.String.cut ~sep:"/" path with

--- a/lib/suspend_image.ml
+++ b/lib/suspend_image.ml
@@ -168,8 +168,7 @@ let read_legacy_qemu_header fd =
 
 let write_qemu_header_for_legacy_libxc fd size =
   wrap (fun () -> Io.write fd qemu_save_signature_legacy_libxc) >>= fun () ->
-  wrap (fun () ->
-      Io.write_int ~endianness:`little fd (Io.int_of_int64_exn size))
+  wrap (fun () -> Io.write_int ~endianness:`little fd (Io.int_of_int64_exn size))
 
 let read_header fd =
   read_int64 fd >>= fun x ->
@@ -186,7 +185,8 @@ let check_conversion_script () =
   with _ ->
     `Error
       (Failure
-         (Printf.sprintf "Executable not found: %s" !Resources.legacy_conv_tool))
+         (Printf.sprintf "Executable not found: %s" !Resources.legacy_conv_tool)
+      )
 
 type 'a thread_status = Running | Thread_failure of exn | Success of 'a
 
@@ -228,11 +228,14 @@ let with_conversion_script task name hvm fd f =
             let result = finally (fun () -> f ()) (fun () -> Unix.close fd') in
             Mutex.execute m (fun () ->
                 status := Success result ;
-                Condition.signal c)
+                Condition.signal c
+            )
           with e ->
             Mutex.execute m (fun () ->
                 status := Thread_failure e ;
-                Condition.signal c))
+                Condition.signal c
+            )
+        )
         ()
     in
     (thread, status)
@@ -243,7 +246,8 @@ let with_conversion_script task name hvm fd f =
           (String.concat "; " args) ;
         Cancellable_subprocess.run task
           [(fd_uuid, fd); (pipe_w_uuid, pipe_w)]
-          conv_script args)
+          conv_script args
+    )
   and f_th, f_st = spawn_thread_and_close_fd name pipe_r (fun () -> f pipe_r) in
   debug "Spawned threads for conversion script and %s" name ;
   let rec handle_threads () =
@@ -254,30 +258,38 @@ let with_conversion_script task name hvm fd f =
         match status with
         | Unix.WEXITED n ->
             `Error
-              (Failure
-                 (Printf.sprintf "Conversion script exited with code %d" n))
+              (Failure (Printf.sprintf "Conversion script exited with code %d" n)
+              )
         | Unix.WSIGNALED n ->
             `Error
               (Failure
                  (Printf.sprintf "Conversion script exited with signal %s"
-                    (Unixext.string_of_signal n)))
+                    (Unixext.string_of_signal n)
+                 )
+              )
         | Unix.WSTOPPED n ->
             `Error
               (Failure
                  (Printf.sprintf "Conversion script stopped with signal %s"
-                    (Unixext.string_of_signal n)))
+                    (Unixext.string_of_signal n)
+                 )
+              )
       )
       | _ ->
           `Error
             (Failure
                (Printf.sprintf "Conversion script thread caught exception: %s"
-                  (Printexc.to_string e)))
+                  (Printexc.to_string e)
+               )
+            )
     )
     | _, Thread_failure e ->
         `Error
           (Failure
              (Printf.sprintf "Thread executing %s caught exception: %s" name
-                (Printexc.to_string e)))
+                (Printexc.to_string e)
+             )
+          )
     | Running, _ | _, Running ->
         Condition.wait c m ; handle_threads ()
     | Success _, Success res ->

--- a/lib/topology.ml
+++ b/lib/topology.ml
@@ -57,7 +57,8 @@ module NUMAResource = struct
         [
           Dump.field "affinity" (fun t -> t.affinity) CPUSet.pp_dump
         ; Dump.field "memfree" (fun t -> t.memfree) int64
-        ])
+        ]
+    )
 end
 
 module NUMARequest = struct
@@ -85,7 +86,8 @@ module NUMARequest = struct
         [
           Dump.field "memory" (fun t -> t.memory) int64
         ; Dump.field "vcpus" (fun t -> t.vcpus) int
-        ])
+        ]
+    )
 end
 
 (** [seq_range a b] is the sequence of numbers between [a, b). *)
@@ -192,13 +194,14 @@ module NUMA = struct
         let d = distances.(i).(i) in
         if d <> 10 then
           invalid_arg
-            (Printf.sprintf "NUMA distance from node to itself must be 10: %d"
-               d) ;
+            (Printf.sprintf "NUMA distance from node to itself must be 10: %d" d) ;
         Array.iteri
           (fun _ d ->
             if d < 10 then
-              invalid_arg (Printf.sprintf "NUMA distance must be >= 10: %d" d))
-          row)
+              invalid_arg (Printf.sprintf "NUMA distance must be >= 10: %d" d)
+          )
+          row
+      )
       distances ;
     let all = Array.fold_left CPUSet.union CPUSet.empty node_cpus in
     let candidates = gen_candidates distances in
@@ -266,5 +269,6 @@ module NUMA = struct
         ; Dump.field "node_cpus"
             (fun t -> t.node_cpus)
             (Dump.array CPUSet.pp_dump)
-        ])
+        ]
+    )
 end

--- a/lib/xenops_hooks.ml
+++ b/lib/xenops_hooks.ml
@@ -107,7 +107,10 @@ let execute_vm_hook ~script_name ~id ~reason ~extra_args =
           raise
             (Xenopsd_error
                (Errors.Hook_failed
-                  (script_name ^ "/" ^ script, reason, stdout, string_of_int i))))
+                  (script_name ^ "/" ^ script, reason, stdout, string_of_int i)
+               )
+            )
+    )
     scripts
 
 type script =

--- a/lib/xenops_sandbox.ml
+++ b/lib/xenops_sandbox.ml
@@ -51,7 +51,8 @@ end = struct
       if not (Filename.is_implicit relative) then
         invalid_arg
           (Printf.sprintf "Expected implicit filename, but got '%s' (at %s)"
-             relative __LOC__) ;
+             relative __LOC__
+          ) ;
       relative
   end
 
@@ -87,7 +88,8 @@ end = struct
       let prepare path =
         let fullpath = absolute_path_outside chroot path in
         Xenops_utils.Unixext.with_file fullpath [Unix.O_CREAT; Unix.O_EXCL]
-          0o600 (fun fd -> Unix.fchown fd chroot.uid chroot.gid)
+          0o600 (fun fd -> Unix.fchown fd chroot.uid chroot.gid
+        )
       in
       List.iter prepare paths ; chroot
     with e ->
@@ -98,7 +100,8 @@ end = struct
 
   let destroy chroot =
     Xenops_utils.best_effort (Printf.sprintf "removing chroot %s" chroot.root)
-      (fun () -> Xenops_utils.FileFS.rmtree chroot.root)
+      (fun () -> Xenops_utils.FileFS.rmtree chroot.root
+    )
 end
 
 module Varstore_guard = struct
@@ -150,7 +153,8 @@ module Varstore_guard = struct
       in
       Xenops_utils.best_effort "Stop listening on deprivileged socket"
         (fun () ->
-          Varstore_privileged_client.Client.destroy dbg gid absolute_socket_path) ;
+          Varstore_privileged_client.Client.destroy dbg gid absolute_socket_path
+      ) ;
       Chroot.destroy chroot
     ) else
       D.warn "Can't stop varstored for %d (%s): %s does not exist" domid vm_uuid

--- a/lib/xenops_server_simulator.ml
+++ b/lib/xenops_server_simulator.ml
@@ -249,7 +249,8 @@ let add_vbd (vm : Vm.id) (vbd : Vbd.t) () =
     debug "VBD.plug %s.%s: Already exists" (fst vbd.Vbd.id) (snd vbd.Vbd.id) ;
     raise
       (Xenopsd_error
-         (Already_exists ("vbd", Device_number.to_debug_string this_dn)))
+         (Already_exists ("vbd", Device_number.to_debug_string this_dn))
+      )
   ) else
     DB.write vm
       {
@@ -269,7 +270,9 @@ let move_vif vm vif network () =
       raise
         (Xenopsd_error
            (Does_not_exist
-              ("VIF", Printf.sprintf "%s.%s" (fst vif.Vif.id) (snd vif.Vif.id))))
+              ("VIF", Printf.sprintf "%s.%s" (fst vif.Vif.id) (snd vif.Vif.id))
+           )
+        )
   | _ ->
       assert false
 
@@ -375,7 +378,9 @@ let remove_vif vm vif () =
     raise
       (Xenopsd_error
          (Does_not_exist
-            ("VIF", Printf.sprintf "%s.%s" (fst vif.Vif.id) (snd vif.Vif.id))))
+            ("VIF", Printf.sprintf "%s.%s" (fst vif.Vif.id) (snd vif.Vif.id))
+         )
+      )
   else
     DB.write vm
       {
@@ -392,7 +397,8 @@ let set_carrier vm vif carrier () =
         {
           vif with
           Vif.carrier= (if this_one vif then carrier else vif.Vif.carrier)
-        })
+        }
+      )
       d.Domain.vifs
   in
   DB.write vm {d with Domain.vifs}
@@ -406,7 +412,8 @@ let set_locking_mode vm vif mode () =
         {
           vif with
           Vif.locking_mode= (if this_one vif then mode else vif.Vif.locking_mode)
-        })
+        }
+      )
       d.Domain.vifs
   in
   DB.write vm {d with Domain.vifs}
@@ -425,7 +432,8 @@ let set_ipv4_configuration vm vif ipv4_configuration () =
             else
               vif.Vif.ipv4_configuration
             )
-        })
+        }
+      )
       d.Domain.vifs
   in
   DB.write vm {d with Domain.vifs}
@@ -444,7 +452,8 @@ let set_ipv6_configuration vm vif ipv6_configuration () =
             else
               vif.Vif.ipv6_configuration
             )
-        })
+        }
+      )
       d.Domain.vifs
   in
   DB.write vm {d with Domain.vifs}
@@ -458,7 +467,8 @@ let set_pvs_proxy vm vif proxy () =
         {
           vif with
           Vif.pvs_proxy= (if this_one vif then proxy else vif.Vif.pvs_proxy)
-        })
+        }
+      )
       d.Domain.vifs
   in
   DB.write vm {d with Domain.vifs}
@@ -470,7 +480,9 @@ let remove_pci vm pci () =
     raise
       (Xenopsd_error
          (Does_not_exist
-            ("PCI", Printf.sprintf "%s.%s" (fst pci.Pci.id) (snd pci.Pci.id))))
+            ("PCI", Printf.sprintf "%s.%s" (fst pci.Pci.id) (snd pci.Pci.id))
+         )
+      )
   else
     DB.write vm
       {
@@ -485,7 +497,9 @@ let remove_vbd vm vbd () =
     raise
       (Xenopsd_error
          (Does_not_exist
-            ("VBD", Printf.sprintf "%s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id))))
+            ("VBD", Printf.sprintf "%s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id))
+         )
+      )
   else
     DB.write vm
       {
@@ -500,7 +514,9 @@ let set_qos_vbd vm vbd () =
     raise
       (Xenopsd_error
          (Does_not_exist
-            ("VBD", Printf.sprintf "%s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id)))) ;
+            ("VBD", Printf.sprintf "%s.%s" (fst vbd.Vbd.id) (snd vbd.Vbd.id))
+         )
+      ) ;
   (* XXX *)
   ()
 
@@ -588,7 +604,8 @@ module VM = struct
     let vbds =
       List.map
         (fun vbd ->
-          {vbd with Vbd.backend= Option.map (remap_vdi vdi_map) vbd.Vbd.backend})
+          {vbd with Vbd.backend= Option.map (remap_vdi vdi_map) vbd.Vbd.backend}
+        )
         state.Domain.vbds
     in
     let vifs = List.map (fun vif -> remap_vif vif_map vif) state.Domain.vifs in
@@ -604,7 +621,9 @@ module VM = struct
         raise
           (Xenopsd_error
              (Internal_error
-                (Printf.sprintf "Failed to unmarshal Domain.t: %s" m)))
+                (Printf.sprintf "Failed to unmarshal Domain.t: %s" m)
+             )
+          )
 
   let wait_ballooning _ _ = ()
 
@@ -670,8 +689,7 @@ module VIF = struct
 
   let move _ vm vif network = Mutex.execute m (move_vif vm vif network)
 
-  let set_carrier _ vm vif carrier =
-    Mutex.execute m (set_carrier vm vif carrier)
+  let set_carrier _ vm vif carrier = Mutex.execute m (set_carrier vm vif carrier)
 
   let set_locking_mode _ vm vif mode =
     Mutex.execute m (set_locking_mode vm vif mode)
@@ -682,8 +700,7 @@ module VIF = struct
   let set_ipv6_configuration _ vm vif ipv6_configuration =
     Mutex.execute m (set_ipv6_configuration vm vif ipv6_configuration)
 
-  let set_pvs_proxy _ vm vif proxy =
-    Mutex.execute m (set_pvs_proxy vm vif proxy)
+  let set_pvs_proxy _ vm vif proxy = Mutex.execute m (set_pvs_proxy vm vif proxy)
 
   let get_state vm vif = Mutex.execute m (vif_state vm vif)
 

--- a/lib/xenops_utils.ml
+++ b/lib/xenops_utils.ml
@@ -102,7 +102,8 @@ let prefixes_of k =
   let prefixes, _ =
     List.fold_left
       (fun (acc, prefix) element ->
-        ((element :: prefix) :: acc, element :: prefix))
+        ((element :: prefix) :: acc, element :: prefix)
+      )
       ([], []) k
   in
   List.map List.rev prefixes
@@ -180,7 +181,8 @@ module FileFS = struct
         | e ->
             (* Anything else probably is an error, but we just log and continue *)
             error "Failed to DB.delete %s : %s" path (Printexc.to_string e) ;
-            ())
+            ()
+      )
       (paths_of path)
 
   (** [rmtree path] removes a file or directory recursively without following
@@ -255,7 +257,8 @@ module MemFS = struct
       (fun p ->
         let dir = dir_locked (dirname p) in
         if not (StringMap.mem (filename p) !dir) then
-          dir := StringMap.add (filename p) (Dir (ref StringMap.empty)) !dir)
+          dir := StringMap.add (filename p) (Dir (ref StringMap.empty)) !dir
+      )
       (List.rev (prefixes_of path))
 
   let mkdir path = Mutex.execute m (fun () -> mkdir_locked path)
@@ -268,24 +271,28 @@ module MemFS = struct
               Some x
           | Dir _ ->
               None
-        with _ -> None)
+        with _ -> None
+    )
 
   let write path x =
     Mutex.execute m (fun () ->
         (* debug "DB.write %s <- %s" (String.concat "/" path) x; *)
         mkdir_locked (dirname path) ;
         let dir = dir_locked (dirname path) in
-        dir := StringMap.add (filename path) (Leaf x) !dir)
+        dir := StringMap.add (filename path) (Leaf x) !dir
+    )
 
   let exists path =
     Mutex.execute m (fun () ->
         try StringMap.mem (filename path) !(dir_locked (dirname path))
-        with _ -> false)
+        with _ -> false
+    )
 
   let readdir path =
     Mutex.execute m (fun () ->
         try StringMap.fold (fun x _ acc -> x :: acc) !(dir_locked path) []
-        with _ -> [])
+        with _ -> []
+    )
 
   let rm path =
     Mutex.execute m (fun () ->
@@ -302,8 +309,10 @@ module MemFS = struct
               else
                 false
             in
-            if deletable then dir := StringMap.remove (filename p) !dir)
-          (prefixes_of path))
+            if deletable then dir := StringMap.remove (filename p) !dir
+          )
+          (prefixes_of path)
+    )
 
   let rename path path' =
     Mutex.execute m (fun () ->
@@ -319,11 +328,13 @@ module MemFS = struct
                   (Printf.sprintf
                      "Invalid: rename must be called on files not directories. \
                       %s is a directory"
-                     (filename path))
+                     (filename path)
+                  )
           in
           let dir = dir_locked (dirname path') in
           dir := StringMap.add (filename path') (Leaf contents) !dir
-        with _ -> ())
+        with _ -> ()
+    )
 
   let init () = ()
 end
@@ -380,7 +391,8 @@ functor
               x
           | Error (`Msg m) ->
               failwith
-                (Printf.sprintf "Failed to unmarshal '%s': %s" I.namespace m))
+                (Printf.sprintf "Failed to unmarshal '%s': %s" I.namespace m)
+        )
         (FS.read path)
 
     let read_exn (k : I.key) =
@@ -390,7 +402,9 @@ functor
       | None ->
           raise
             (Xenopsd_error
-               (Errors.Does_not_exist (I.namespace, I.key k |> String.concat "/")))
+               (Errors.Does_not_exist (I.namespace, I.key k |> String.concat "/")
+               )
+            )
 
     let exists (k : I.key) =
       let module FS = (val get_fs_backend () : FS) in
@@ -415,7 +429,8 @@ functor
             debug "Key %s already exists" path ;
             raise (Xenopsd_error (Errors.Already_exists (I.namespace, path)))
           ) else
-            write k x)
+            write k x
+      )
 
     let remove (k : I.key) =
       Mutex.execute m (fun () ->
@@ -425,7 +440,8 @@ functor
             debug "Key %s does not exist" path ;
             raise (Xenopsd_error (Errors.Does_not_exist (I.namespace, path)))
           ) else
-            delete k)
+            delete k
+      )
 
     (* The call `update k f` reads key `k` from the DB, passes the value to `f`,
        and updates the DB with the result. If the result is `None`, then the key
@@ -445,7 +461,8 @@ functor
             | Some y' ->
                 write k y' ; true
           ) else
-            false)
+            false
+      )
 
     let rename (k : I.key) (k' : I.key) =
       Mutex.execute m (fun () ->
@@ -461,7 +478,8 @@ functor
             debug "Key %s does not exist" path ;
             raise (Xenopsd_error (Errors.Does_not_exist (I.namespace, path)))
           ) ;
-          rename k k')
+          rename k k'
+      )
 
     (* Version of `update` that raises an exception if the read fails *)
     let update_exn (k : I.key) (f : t -> t option) =
@@ -470,9 +488,12 @@ functor
             raise
               (Xenopsd_error
                  (Errors.Does_not_exist
-                    (I.namespace, I.key k |> String.concat "/")))
+                    (I.namespace, I.key k |> String.concat "/")
+                 )
+              )
         | Some x ->
-            f x)
+            f x
+        )
   end
 
 (******************************************************************************)
@@ -568,7 +589,8 @@ let get_network_backend () =
   with _ ->
     failwith
       (Printf.sprintf "Failed to read network backend from: %s"
-         !Resources.network_conf)
+         !Resources.network_conf
+      )
 
 let _sys_hypervisor_type = "/sys/hypervisor/type"
 
@@ -610,7 +632,8 @@ let chunks size lst =
           if List.length xs < size then
             (op :: xs) :: xss
           else
-            [op] :: xs :: xss)
+            [op] :: xs :: xss
+    )
     [] lst
   |> List.map (fun xs -> List.rev xs)
   |> List.rev
@@ -642,7 +665,8 @@ let char_max_encoded_length =
         let empty = Rpc.String "" in
         max
           (json_length rpc - json_length empty)
-          (xml_length rpc - xml_length empty))
+          (xml_length rpc - xml_length empty)
+  )
 
 let str_max_encoded_length str =
   let s = ref 0 in

--- a/lib/xenopsd.ml
+++ b/lib/xenopsd.ml
@@ -80,7 +80,8 @@ let for_each_line path f =
         while true do
           f ic
         done
-      with End_of_file -> ()) ;
+      with End_of_file -> ()
+  ) ;
   close_in_noerr ic
 
 let parse_oxenstored_conf path =
@@ -92,7 +93,8 @@ let parse_oxenstored_conf path =
       | Some (k, v) ->
           config := (k, v) :: !config
       | None ->
-          ()) ;
+          ()
+  ) ;
   D.debug "%s: %d config entries" path (List.length !config) ;
   !config
 
@@ -136,125 +138,154 @@ let options =
     ( "queue"
     , Arg.Set_string Xenops_interface.queue_name
     , (fun () -> !Xenops_interface.queue_name)
-    , "Listen on a specific queue" )
+    , "Listen on a specific queue"
+    )
   ; ( "sockets-path"
     , Arg.Set_string sockets_path
     , (fun () -> !sockets_path)
-    , "Directory to create listening sockets" )
+    , "Directory to create listening sockets"
+    )
   ; ( "persist"
     , Arg.Bool (fun b -> persist := b)
     , (fun () -> string_of_bool !persist)
-    , "True if we want to persist metadata across restarts" )
+    , "True if we want to persist metadata across restarts"
+    )
   ; ( "worker-pool-size"
     , Arg.Set_int worker_pool_size
     , (fun () -> string_of_int !worker_pool_size)
-    , "Number of threads for the worker pool" )
+    , "Number of threads for the worker pool"
+    )
   ; ( "database-path"
     , Arg.String (fun x -> Xenops_utils.root := Some x)
     , (fun () -> Xenops_utils.get_root ())
-    , "Location to store the metadata" )
+    , "Location to store the metadata"
+    )
   ; ( "run_hotplug_scripts"
     , Arg.Bool (fun x -> run_hotplug_scripts := x)
     , (fun () -> string_of_bool !run_hotplug_scripts)
-    , "True if xenopsd should execute the hotplug scripts directly" )
+    , "True if xenopsd should execute the hotplug scripts directly"
+    )
   ; ( "use_old_pci_add"
     , Arg.Bool (fun x -> use_old_pci_add := x)
     , (fun () -> string_of_bool !use_old_pci_add)
-    , "True if xenopsd should use the old pci add function" )
+    , "True if xenopsd should use the old pci add function"
+    )
   ; ( "hotplug_timeout"
     , Arg.Set_float hotplug_timeout
     , (fun () -> string_of_float !hotplug_timeout)
-    , "Time before we assume hotplug scripts have failed" )
+    , "Time before we assume hotplug scripts have failed"
+    )
   ; ( "qemu_dm_ready_timeout"
     , Arg.Set_float qemu_dm_ready_timeout
     , (fun () -> string_of_float !qemu_dm_ready_timeout)
-    , "Time before we assume qemu has become stuck" )
+    , "Time before we assume qemu has become stuck"
+    )
   ; ( "vgpu-ready-timeout"
     , Arg.Set_float vgpu_ready_timeout
     , (fun () -> string_of_float !vgpu_ready_timeout)
-    , "Time before we assume vgpu has become stuck or unresponsive" )
+    , "Time before we assume vgpu has become stuck or unresponsive"
+    )
   ; ( "varstored-ready-timeout"
     , Arg.Set_float varstored_ready_timeout
     , (fun () -> string_of_float !varstored_ready_timeout)
-    , "Time before we assume varstored has become stuck or unresponsive" )
+    , "Time before we assume varstored has become stuck or unresponsive"
+    )
   ; ( "watch_queue_length"
     , Arg.Set_int watch_queue_length
     , (fun () -> string_of_int !watch_queue_length)
-    , "Maximum number of unprocessed xenstore watch events before we restart" )
+    , "Maximum number of unprocessed xenstore watch events before we restart"
+    )
   ; ( "use-upstream-qemu"
     , Arg.Bool (fun x -> use_upstream_qemu := x)
     , (fun () -> string_of_bool !use_upstream_qemu)
-    , "True if we want to use upsteam QEMU" )
+    , "True if we want to use upsteam QEMU"
+    )
   ; ( "default-vbd-backend-kind"
     , Arg.Set_string default_vbd_backend_kind
     , (fun () -> !default_vbd_backend_kind)
-    , "Default backend for VBDs" )
+    , "Default backend for VBDs"
+    )
   ; ( "ca-140252-workaround"
     , Arg.Bool (fun x -> ca_140252_workaround := x)
     , (fun () -> string_of_bool !ca_140252_workaround)
-    , "Workaround for evtchn misalignment for legacy PV tools" )
+    , "Workaround for evtchn misalignment for legacy PV tools"
+    )
   ; ( "additional-ballooning-timeout"
     , Arg.Set_float additional_ballooning_timeout
     , (fun () -> string_of_float !additional_ballooning_timeout)
     , "Time we allow the guests to do additional memory ballooning before live \
-       migration" )
+       migration"
+    )
   ; ( "domain_shutdown_ack_timeout"
     , Arg.Set_float Xenops_server.domain_shutdown_ack_timeout
     , (fun () -> string_of_float !Xenops_server.domain_shutdown_ack_timeout)
     , "Time to wait for in-guest PV drivers to acknowledge a shutdown request \
-       before we conclude that the drivers have failed" )
+       before we conclude that the drivers have failed"
+    )
   ; ( "vif-ready-for-igmp-query-timeout"
     , Arg.Set_int vif_ready_for_igmp_query_timeout
     , (fun () -> string_of_int !vif_ready_for_igmp_query_timeout)
-    , "Time before we assume vif has connected" )
+    , "Time before we assume vif has connected"
+    )
   ; ( "action-after-qemu-crash"
     , Arg.String
         (fun x -> action_after_qemu_crash := if x = "" then None else Some x)
     , (fun () -> match !action_after_qemu_crash with None -> "" | Some x -> x)
     , "Action to take for VMs if QEMU crashes or dies unexpectedly: pause, \
-       poweroff. Otherwise, no action (default)." )
+       poweroff. Otherwise, no action (default)."
+    )
   ; ( "feature-flags-path"
     , Arg.Set_string feature_flags_path
     , (fun () -> !feature_flags_path)
-    , "Directory of experimental feature flags" )
+    , "Directory of experimental feature flags"
+    )
   ; ( "pvinpvh-xen-cmdline"
     , Arg.Set_string pvinpvh_xen_cmdline
     , (fun () -> !pvinpvh_xen_cmdline)
-    , "Command line for the inner-xen for PV-in-PVH guests" )
+    , "Command line for the inner-xen for PV-in-PVH guests"
+    )
   ; ( "numa-placement"
     , Arg.Bool (fun x -> numa_placement := x)
     , (fun () -> string_of_bool !numa_placement)
-    , "NUMA-aware placement of VMs" )
+    , "NUMA-aware placement of VMs"
+    )
   ; ( "numa-placement-strict"
     , Arg.Bool (fun x -> numa_placement_strict := x)
     , (fun () -> string_of_bool !numa_placement)
-    , "Fail if NUMA-aware placement is not possible" )
+    , "Fail if NUMA-aware placement is not possible"
+    )
   ; ( "pci-quarantine"
     , Arg.Bool (fun b -> pci_quarantine := b)
     , (fun () -> string_of_bool !pci_quarantine)
     , "True if IOMMU contexts of PCI devices are needed to be placed in \
-       quarantine" )
+       quarantine"
+    )
   ; ( "vm-guest-agent-xenstore-quota"
     , Arg.String
         (fun s ->
           if s <> "N/A" then
             vm_guest_agent_xenstore_quota_bytes :=
-              max_bytes_of_xenstore_entries (int_of_string s))
+              max_bytes_of_xenstore_entries (int_of_string s)
+        )
     , (fun () -> "N/A")
-    , "(Deprecated, use vm-xenstore-data-quota-bytes instead)" )
+    , "(Deprecated, use vm-xenstore-data-quota-bytes instead)"
+    )
   ; ( "vm-guest-agent-xenstore-quota-warn-interval"
     , Arg.Set_int vm_guest_agent_xenstore_quota_warn_interval
     , (fun () -> string_of_int !vm_guest_agent_xenstore_quota_warn_interval)
-    , "How often to warn that a VM is still over its xenstore quota" )
+    , "How often to warn that a VM is still over its xenstore quota"
+    )
   ; ( "oxenstored-conf"
     , Arg.Set_string oxenstored_conf
     , (fun () -> !oxenstored_conf)
-    , "Path to oxenstored conf (for reading quotas)" )
+    , "Path to oxenstored conf (for reading quotas)"
+    )
   ; ( "vm-guest-agent-xenstore-quota-bytes"
     , Arg.Set_int vm_guest_agent_xenstore_quota_bytes
     , (fun () -> string_of_int !vm_guest_agent_xenstore_quota_bytes)
     , "Maximum size in bytes of VM xenstore-data field, and guest metrics \
-       copied from guest's vm-data/ and data/ xenstore tree" )
+       copied from guest's vm-data/ and data/ xenstore tree"
+    )
   ]
 
 let path () = Filename.concat !sockets_path "xenopsd"
@@ -278,6 +309,7 @@ let rpc_fn call =
               [Rpc.Dict [("debug_info", debug_info); ("metadata", metadata)]]
           ; notif= false
           }
+        
     | "query", [debug_info; unit_p] ->
         debug "Upgrading query" ;
         Rpc.
@@ -286,6 +318,7 @@ let rpc_fn call =
           ; params= [Rpc.Dict [("debug_info", debug_info); ("unit", unit_p)]]
           ; notif= false
           }
+        
     | _ ->
         call
   in
@@ -339,7 +372,8 @@ let handle_received_fd this_connection =
           Cohttp.Response.make ~version:`HTTP_1_1 ~status:`Not_found ~headers ()
         in
         Response.write (fun _ -> ()) response this_connection
-      ))
+      )
+    )
     (fun () -> Unix.close received_fd)
 
 let doc =
@@ -401,7 +435,8 @@ let main backend =
            (module Xenops_utils.FileFS : Xenops_utils.FS)
        else
          (module Xenops_utils.MemFS : Xenops_utils.FS)
-       )) ;
+       )
+    ) ;
   Xenops_server.register_objects () ;
   Xenops_server.set_backend (Some backend) ;
   Xenops_server.upgrade_internal_state_of_running_vms () ;
@@ -413,7 +448,8 @@ let main backend =
       let (_ : Thread.t) =
         Thread.create (fun () -> Xcp_service.serve_forever xml_server) ()
       in
-      ())
+      ()
+    )
     () ;
   Xenops_server.WorkerPool.start !worker_pool_size ;
   while true do

--- a/list_domains/list_domains.ml
+++ b/list_domains/list_domains.ml
@@ -87,7 +87,8 @@ let select table keys =
     (fun key ->
       if not (Hashtbl.mem table key) then
         failwith (Printf.sprintf "Failed to find key: %s" key) ;
-      Hashtbl.find table key)
+      Hashtbl.find table key
+    )
     keys
 
 let columns () =
@@ -142,16 +143,20 @@ let _ =
          , Arg.Unit
              (fun () ->
                memory := true ;
-               all_the_rest := true)
-         , " show all available stats (needs a wide window!)" )
+               all_the_rest := true
+             )
+         , " show all available stats (needs a wide window!)"
+         )
        ; ("-bytes", Arg.Set bytes, " use bytes for memory values")
        ; ( "-domid"
          , Arg.Int (fun i -> domid := Some i)
-         , " show only a particular domain" )
+         , " show only a particular domain"
+         )
        ; ("-memory", Arg.Set memory, " show memory statistics")
        ; ("-minimal", Arg.Set minimal, " show only domain UUID")
        ; ("-pages", Arg.Set pages, " use pages for memory values")
-       ])
+       ]
+    )
     (fun x -> Printf.printf "Warning, ignoring unknown argument: %s" x)
     "List domains" ;
   let cols = columns () in

--- a/suspend_image_viewer/suspend_image_viewer.ml
+++ b/suspend_image_viewer/suspend_image_viewer.ml
@@ -121,7 +121,8 @@ module D = Debug.Make (struct let name = "suspend-image-viewer" end)
 
 let print_image path =
   Xapi_stdext_unix.Unixext.with_file path [Unix.O_RDONLY] 0o400 (fun fd ->
-      print_layout (parse_layout fd))
+      print_layout (parse_layout fd)
+  )
 
 (* Command line interface *)
 let () =
@@ -136,7 +137,8 @@ let () =
       ( "path"
       , Arg.Set_string path
       , (fun () -> !path)
-      , "Path to the suspend image device" )
+      , "Path to the suspend image device"
+      )
     ]
   in
   match

--- a/test/test_topology.ml
+++ b/test/test_topology.ml
@@ -4,8 +4,7 @@ module D = Debug.Make (struct let name = "test_topology" end)
 
 let make_numa ~numa ~cores =
   let distances =
-    Array.init numa (fun i ->
-        Array.init numa (fun j -> 10 + (11 * abs (j - i))))
+    Array.init numa (fun i -> Array.init numa (fun j -> 10 + (11 * abs (j - i))))
   in
   let cores_per_numa = cores / numa in
   let cpu_to_node = Array.init cores (fun core -> core / cores_per_numa) in
@@ -41,7 +40,8 @@ let pp =
       ; Dump.field "average" (fun t -> t.average) float
       ; Dump.field "nodes" (fun t -> t.nodes) (Dump.list NUMA.pp_dump_node)
       ; Dump.field "best" (fun t -> t.best) int
-      ])
+      ]
+  )
 
 let sum_costs l =
   D.debug "====" ;
@@ -52,7 +52,8 @@ let sum_costs l =
       ; average= accum.average +. cost.average
       ; nodes= cost.nodes @ accum.nodes
       ; best= min accum.best cost.best
-      })
+      }
+    )
     {worst= min_int; average= 0.; nodes= []; best= max_int}
     l
 
@@ -72,7 +73,8 @@ let vm_access_costs host all_vms (vcpus, nodes, cpuset) =
            let worst = List.fold_left max 0 distances in
            let best = List.fold_left min max_int distances in
            let average = float (List.fold_left ( + ) 0 distances) /. float n in
-           {worst; best; nodes= []; average})
+           {worst; best; nodes= []; average}
+       )
     |> sum_costs
   in
   D.debug "Costs: %s" (Fmt.to_to_string pp costs) ;
@@ -91,12 +93,14 @@ let cost_not_worse ~default c =
     (Fmt.to_to_string pp c) ;
   Alcotest.(
     check int "The worst-case access time must not be changed from default"
-      default.worst worst) ;
+      default.worst worst
+  ) ;
   Alcotest.(check int "Best case access time must not change" best c.best) ;
   Alcotest.(
     check (float 1e-3)
       "Average access times could improve, but must not be worse" average
-      c.average) ;
+      c.average
+  ) ;
   if c.best < default.best then
     D.debug "The new plan has improved the best-case access time!" ;
   if c.worst < default.worst then
@@ -120,7 +124,8 @@ let check_aggregate_costs_not_worse (default, next, plans) ~cores ~vms =
   let balancing_next = balancing next.nodes ~vms in
   let balancing_best = max balancing_next balancing_default in
   Alcotest.(
-    check (float 1e-3) "Balancing could improve" balancing_best balancing_next) ;
+    check (float 1e-3) "Balancing could improve" balancing_best balancing_next
+  ) ;
   if balancing_next > balancing_default then D.debug "Balancing has improved!" ;
   let used_cpus =
     plans
@@ -174,7 +179,9 @@ let test_allocate ?(mem = default_mem) (expected_cores, h) ~vms () =
              cost_not_worse ~default:costs_default costs_numa_aware ;
              ( costs_default :: costs_old
              , costs_numa_aware :: costs_new
-             , ((vm_cores, List.of_seq usednodes), plan) :: plans ))
+             , ((vm_cores, List.of_seq usednodes), plan) :: plans
+             )
+       )
        ([], [], [])
   |> check_aggregate_costs_not_worse ~cores ~vms
 
@@ -185,35 +192,47 @@ let suite =
   , [
       ( "Allocation of 1 VM on 1 node"
       , `Quick
-      , test_allocate ~vms:1 @@ make_numa ~numa:1 ~cores:2 )
+      , test_allocate ~vms:1 @@ make_numa ~numa:1 ~cores:2
+      )
     ; ( "Allocation of 10 VMs on 1 node"
       , `Quick
-      , test_allocate ~vms:10 @@ make_numa ~numa:1 ~cores:8 )
+      , test_allocate ~vms:10 @@ make_numa ~numa:1 ~cores:8
+      )
     ; ( "Allocation of 1 VM on 2 nodes"
       , `Quick
-      , test_allocate ~vms:1 @@ make_numa ~numa:2 ~cores:4 )
+      , test_allocate ~vms:1 @@ make_numa ~numa:2 ~cores:4
+      )
     ; ( "Allocation of 10 VM on 2 nodes"
       , `Quick
-      , test_allocate ~vms:10 @@ make_numa ~numa:2 ~cores:4 )
+      , test_allocate ~vms:10 @@ make_numa ~numa:2 ~cores:4
+      )
     ; ( "Allocation of 1 VM on 4 nodes"
       , `Quick
-      , test_allocate ~vms:1 @@ make_numa ~numa:4 ~cores:16 )
+      , test_allocate ~vms:1 @@ make_numa ~numa:4 ~cores:16
+      )
     ; ( "Allocation of 10 VM on 4 nodes"
       , `Quick
-      , test_allocate ~vms:10 @@ make_numa ~numa:4 ~cores:16 )
+      , test_allocate ~vms:10 @@ make_numa ~numa:4 ~cores:16
+      )
     ; ( "Allocation of 40 VM on 16 nodes"
       , `Quick
-      , test_allocate ~vms:40 @@ make_numa ~numa:16 ~cores:256 )
+      , test_allocate ~vms:40 @@ make_numa ~numa:16 ~cores:256
+      )
     ; ( "Allocation of 40 VM on 32 nodes"
       , `Quick
-      , test_allocate ~vms:40 @@ make_numa ~numa:32 ~cores:256 )
+      , test_allocate ~vms:40 @@ make_numa ~numa:32 ~cores:256
+      )
     ; ( "Allocation of 40 VM on 64 nodes"
       , `Quick
-      , test_allocate ~vms:80 @@ make_numa ~numa:64 ~cores:256 )
+      , test_allocate ~vms:80 @@ make_numa ~numa:64 ~cores:256
+      )
     ; ( "Allocation of 10 VM on assymetric nodes"
       , `Quick
-      , test_allocate ~vms:10 (make_numa_amd ~cores_per_numa:4) )
+      , test_allocate ~vms:10 (make_numa_amd ~cores_per_numa:4)
+      )
     ; ( "Allocation of 10 VM on assymetric nodes"
       , `Quick
-      , test_allocate ~vms:6 ~mem:mem3 (make_numa_amd ~cores_per_numa:4) )
-    ] )
+      , test_allocate ~vms:6 ~mem:mem3 (make_numa_amd ~cores_per_numa:4)
+      )
+    ]
+  )

--- a/tools/set_domain_uuid.ml
+++ b/tools/set_domain_uuid.ml
@@ -17,7 +17,8 @@ let set domain uuid =
       `Error
         ( false
         , Printf.sprintf "Caught exception while setting uuid: %s"
-            (Printexc.to_string e) )
+            (Printexc.to_string e)
+        )
 
 open Cmdliner
 

--- a/xc/cancel_utils.ml
+++ b/xc/cancel_utils.ml
@@ -131,7 +131,8 @@ let on_shutdown ~xs domid =
         info
           "Not cancelling watches associated with domid: %d- domain nolonger \
            exists"
-          domid)
+          domid
+  )
 
 let with_path ~xs key f =
   let path = cancel_path_of ~xs key in
@@ -143,7 +144,8 @@ let with_path ~xs key f =
         debug "ignoring cancel request: operation has already terminated" ;
         (* This means a cancel happened just as we succeeded; it was too late
            and we ignore it. *)
-        ())
+        ()
+    )
 
 let cancellable_watch key good_watches error_watches
     (task : Xenops_task.task_handle) ~xs ~timeout () =
@@ -158,7 +160,9 @@ let cancellable_watch key good_watches error_watches
                 (Watch.any_of
                    (List.map
                       (fun w -> ((), w))
-                      (good_watches @ error_watches @ cancel_watches)))
+                      (good_watches @ error_watches @ cancel_watches)
+                   )
+                )
             in
             let any_have_fired ws =
               List.fold_left ( || ) false (List.map (Watch.has_fired ~xs) ws)
@@ -170,7 +174,8 @@ let cancellable_watch key good_watches error_watches
             match
               ( any_have_fired good_watches
               , any_have_fired error_watches
-              , any_have_fired cancel_watches )
+              , any_have_fired cancel_watches
+              )
             with
             | true, _, _ ->
                 true
@@ -182,4 +187,6 @@ let cancellable_watch key good_watches error_watches
                 (* they must have fired and then fired again: retest *)
                 loop ()
           in
-          loop ()))
+          loop ()
+        )
+  )

--- a/xc/cancel_utils_test.ml
+++ b/xc/cancel_utils_test.ml
@@ -28,7 +28,8 @@ let xenstore_test xs _ =
     Thread.create
       (fun () ->
         Thread.delay 1. ;
-        Xenops_task.cancel tasks task.Xenops_task.id)
+        Xenops_task.cancel tasks task.Xenops_task.id
+      )
       ()
   in
   try
@@ -45,7 +46,8 @@ let subprocess_test _ =
     Thread.create
       (fun () ->
         Thread.delay 1. ;
-        Xenops_task.cancel tasks task.Xenops_task.id)
+        Xenops_task.cancel tasks task.Xenops_task.id
+      )
       ()
   in
   try

--- a/xc/device.ml
+++ b/xc/device.ml
@@ -170,7 +170,9 @@ module Generic = struct
               ) ;
             t.Xst.mkdirperms extra_xenserver_path
               (Xenbus_utils.rwperm_for_guest device.frontend.domid) ;
-            t.Xst.writev extra_xenserver_path xenserver_list))
+            t.Xst.writev extra_xenserver_path xenserver_list
+        )
+    )
 
   let get_private_key ~xs device x =
     let private_data_path =
@@ -238,7 +240,8 @@ module Generic = struct
         if state <> Xenbus_utils.Closed then (
           debug "Device.del_device setting backend to Closing" ;
           t.Xst.write state_path (Xenbus_utils.string_of Xenbus_utils.Closing)
-        ))
+        )
+    )
 
   let unplug_watch ~xs (x : device) =
     Hotplug.path_written_by_hotplug_scripts x |> Watch.key_to_disappear
@@ -251,7 +254,8 @@ module Generic = struct
       (fun () -> "")
       (Watch.value_to_become
          (frontend_rw_path_of_device ~xs x ^ "/state")
-         (Xenbus_utils.string_of Xenbus_utils.Closed))
+         (Xenbus_utils.string_of Xenbus_utils.Closed)
+      )
 
   let backend_closed ~xs (x : device) =
     Watch.value_to_become
@@ -270,7 +274,8 @@ module Generic = struct
            debug "Backend closed for %s, deleting hotplug-status"
              (string_of_device x) ;
            (* deleting this key causes the udev rule to fire *)
-           safe_rm ~xs (Hotplug.path_written_by_hotplug_scripts x))
+           safe_rm ~xs (Hotplug.path_written_by_hotplug_scripts x)
+       )
 
   let clean_shutdown_wait (task : Xenops_task.task_handle) ~xs
       ~ignore_transients (x : device) =
@@ -605,7 +610,8 @@ module Vbd_Common = struct
           |> Device_number.spec
           |> function
           | _, disk, _ ->
-              disk)
+              disk
+        )
         (Device_common.list_frontends ~xs domid)
     in
     let next = List.fold_left max 0 disks + 1 in
@@ -673,7 +679,8 @@ module Vbd_Common = struct
           | Disk ->
               "disk"
           | Floppy ->
-              "floppy" )
+              "floppy"
+        )
       ] ;
     List.iter
       (fun (k, v) -> Hashtbl.replace back_tbl k v)
@@ -707,7 +714,8 @@ module Vbd_Common = struct
     ) ;
     Option.iter
       (fun protocol ->
-        Hashtbl.add front_tbl "protocol" (string_of_protocol protocol))
+        Hashtbl.add front_tbl "protocol" (string_of_protocol protocol)
+      )
       x.protocol ;
     let back = Hashtbl.fold (fun k v acc -> (k, v) :: acc) back_tbl [] in
     let front = Hashtbl.fold (fun k v acc -> (k, v) :: acc) front_tbl [] in
@@ -807,9 +815,11 @@ module Vif = struct
       (match rate with None -> "none" | Some (a, b) -> sprintf "(%Ld,%Ld)" a b)
       (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) other_config))
       (String.concat "; "
-         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_private_keys))
+         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_private_keys)
+      )
       (String.concat "; "
-         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_xenserver_keys)) ;
+         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_xenserver_keys)
+      ) ;
     (* Filter the other_config keys using vif_udev_keys as a whitelist *)
     let other_config =
       List.filter (fun (x, _) -> List.mem x vif_udev_keys) other_config
@@ -980,9 +990,11 @@ module NetSriovVf = struct
       vlan_str mac carrier rate_str
       (String.concat "; " (List.map (fun (k, v) -> k ^ "=" ^ v) other_config))
       (String.concat "; "
-         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_private_keys))
+         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_private_keys)
+      )
       (String.concat "; "
-         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_xenserver_keys)) ;
+         (List.map (fun (k, v) -> k ^ "=" ^ v) extra_xenserver_keys)
+      ) ;
     let frontend = {domid; kind= NetSriovVf; devid} in
     let backend = {domid= backend_domid; kind= NetSriovVf; devid} in
     let device = {backend; frontend} in
@@ -1018,7 +1030,9 @@ module NetSriovVf = struct
               "Failed to configure network SR-IOV VF (pci:%s) with mac=%s \
                vlan=%s rate=%s: %s"
               (Pci.string_of_address pci)
-              mac vlan_str rate_str s)) ;
+              mac vlan_str rate_str s
+           )
+    ) ;
     device
 
   let hard_shutdown ~xs (x : device) =
@@ -1109,7 +1123,8 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
                 None
               with Unix.Unix_error (Unix.EAGAIN, _, _) ->
                 (* cannot obtain lock: process is alive *)
-                Some pid)
+                Some pid
+          )
       | _ ->
           (* backward compatibility during update installation: only has
              xenstore pid *)
@@ -1142,8 +1157,7 @@ module DaemonMgmt (D : DAEMONPIDPATH) = struct
         | None ->
             ()
         | Some path ->
-            best_effort (sprintf "removing %s" path) (fun () ->
-                Unix.unlink path)
+            best_effort (sprintf "removing %s" path) (fun () -> Unix.unlink path)
       )
 
   let syslog_key ~domid = Printf.sprintf "%s-%d" D.name domid
@@ -1298,8 +1312,8 @@ module PV_Vnc = struct
     else
       try
         Some
-          (Socket.Port
-             (int_of_string (xs.Xs.read (Generic.vnc_port_path domid))))
+          (Socket.Port (int_of_string (xs.Xs.read (Generic.vnc_port_path domid)))
+          )
       with _ -> None
 
   let get_tc_port ~xs domid =
@@ -1407,19 +1421,20 @@ module PCI = struct
           Some
             (Printf.sprintf "Domain_not_running(inserting pci=%s,domid=%d)"
                (Xenops_interface.Pci.string_of_address addr)
-               domid)
+               domid
+            )
       | Cannot_add (devices, e) ->
           let addrs =
             devices
             |> List.map Xenops_interface.Pci.string_of_address
             |> String.concat ";"
           in
-          Some
-            (Printf.sprintf "Cannot_add(%s, %s)" addrs (Printexc.to_string e))
+          Some (Printf.sprintf "Cannot_add(%s, %s)" addrs (Printexc.to_string e))
       | Ioemu_failed (name, msg) ->
           Some (Printf.sprintf "Ioemu_failed(%s, %s)" name msg)
       | _ ->
-          None)
+          None
+      )
 
   (* From
      https://github.com/torvalds/linux/blob/v4.19/include/linux/pci.h#L76-L102 *)
@@ -1450,7 +1465,8 @@ module PCI = struct
           ()
         with e ->
           debug "xl %s: %s" cmd (Printexc.to_string e) ;
-          raise e)
+          raise e
+      )
       pcidevs
 
   let add_xl = xl_pci "pci-attach"
@@ -1476,14 +1492,16 @@ module PCI = struct
       (* remove the silly prefix *)
       int_of_string
         (String.sub x (String.length prefix)
-           (String.length x - String.length prefix))
+           (String.length x - String.length prefix)
+        )
     in
     let pairs =
       List.map
         (fun x ->
           ( device_number_of_string x
           , Xenops_interface.Pci.address_of_string (xs.Xs.read (path ^ "/" ^ x))
-          ))
+          )
+        )
         all
     in
     (* Sort into the order the devices were plugged *)
@@ -1551,7 +1569,8 @@ module PCI = struct
                      ; hostaddr= string_of_address host
                      ; permissive= false
                      }
-               })
+               }
+            )
         in
         ()
       else
@@ -1576,7 +1595,8 @@ module PCI = struct
             let scan_start = Nativeint.(shift_right_logical scan_start 12) in
             let scan_size =
               Nativeint.(
-                shift_right_logical (add _page_size scan_size |> pred) 12)
+                shift_right_logical (add _page_size scan_size |> pred) 12
+              )
             in
             Xenctrl.domain_iomem_permission xc domid scan_start scan_size true
     in
@@ -1602,8 +1622,10 @@ module PCI = struct
           xs.Xs.write
             (Printf.sprintf "%s/dev-%d"
                (device_model_pci_device_path xs 0 domid)
-               dev)
-            (Pci.string_of_address pcidev))
+               dev
+            )
+            (Pci.string_of_address pcidev)
+        )
         pcidevs
     with exn ->
       Backtrace.is_important exn ;
@@ -1628,7 +1650,8 @@ module PCI = struct
           ignore
             (Forkhelpers.execute_command_get_output
                !Xc_resources.pci_flr_script
-               [s; devstr])
+               [s; devstr]
+            )
         with _ -> ()
     in
     callscript "flr-pre" device ;
@@ -1711,7 +1734,8 @@ module PCI = struct
           | Some ("i915", _) ->
               true
           | _ ->
-              false)
+              false
+        )
         false "/proc/modules"
     in
     if not is_loaded then
@@ -1727,7 +1751,10 @@ module PCI = struct
           (Xenopsd_error
              (Internal_error
                 (Printf.sprintf "Fail to bind to i915, device is bound to %s"
-                   (string_of_driver drv))))
+                   (string_of_driver drv)
+                )
+             )
+          )
 
   let unbind devstr driver =
     let driverstr = string_of_driver driver in
@@ -1899,8 +1926,10 @@ module PCI = struct
             (* Unbinding from one driver and binding to another driver. *)
             | Some old_driver, new_driver ->
                 unbind_from devstr old_driver ;
-                bind_to devstr new_driver)
-          devices)
+                bind_to devstr new_driver
+          )
+          devices
+    )
 
   let enumerate_devs ~xs (x : device) =
     let backend_path = backend_path_of_device ~xs x in
@@ -1918,7 +1947,8 @@ module PCI = struct
     List.rev
       (List.fold_left
          (fun acc dev -> match dev with None -> acc | Some dev -> dev :: acc)
-         [] (Array.to_list devs))
+         [] (Array.to_list devs)
+      )
 
   let reset ~xs address =
     let devstr = Xenops_interface.Pci.string_of_address address in
@@ -1929,7 +1959,8 @@ module PCI = struct
     debug "Device.Pci.clean_shutdown %s" (string_of_device x) ;
     let devs = enumerate_devs ~xs x in
     Xenctrl.with_intf (fun xc ->
-        try release devs x.frontend.domid with _ -> ()) ;
+        try release devs x.frontend.domid with _ -> ()
+    ) ;
     ()
 
   let hard_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
@@ -1958,7 +1989,8 @@ module PCI = struct
           [
             (Printf.sprintf "device-model/%d/command" domid, cmd)
           ; (Printf.sprintf "device-model/%d/parameter" domid, parameter)
-          ])
+          ]
+    )
 
   (* Return a list of PCI devices *)
   let list = read_pcidir
@@ -1987,14 +2019,16 @@ module PCI = struct
         else (
           t.Xst.mkdirperms frontend_path
             Xs_protocol.ACL.
-              {owner= frontend_domid; other= NONE; acl= [(backend_domid, READ)]} ;
+              {owner= frontend_domid; other= NONE; acl= [(backend_domid, READ)]}
+             ;
           t.Xst.writev frontend_path
             [
               ("backend", backend_path)
             ; ("backend-id", string_of_int backend_domid)
             ; ("state", "1")
             ]
-        ))
+        )
+    )
 end
 
 module Vfs = struct
@@ -2032,7 +2066,8 @@ module Vfs = struct
         let perms = Xs_protocol.ACL.{owner= domid; other= NONE; acl= []} in
         let request_path = Printf.sprintf "%s/%d" request_path 0 in
         t.Xst.mkdirperms request_path perms ;
-        t.Xst.write (request_path ^ "/frontend") frontend_path) ;
+        t.Xst.write (request_path ^ "/frontend") frontend_path
+    ) ;
     ()
 
   let hard_shutdown (task : Xenops_task.task_handle) ~xs (x : device) =
@@ -2125,7 +2160,10 @@ module Vusb = struct
         (Xenopsd_error
            (Internal_error
               (Printf.sprintf "Call to usb reset failed: %s"
-                 (Printexc.to_string err))))
+                 (Printexc.to_string err)
+              )
+           )
+        )
 
   let cleanup domid =
     try
@@ -2189,13 +2227,15 @@ module Vusb = struct
           qmp_send_cmd domid
             Qmp.(
               Device_add
-                Device.{driver; device= USB {USB.id= driver_id; params= None}})
+                Device.{driver; device= USB {USB.id= driver_id; params= None}}
+            )
           |> ignore
       in
       let usb_bus0 = ("usb-bus.0", fun () -> ()) in
       let ehci0 =
         ( "ehci.0"
-        , fun () -> vusb_controller_plug ~driver:"usb-ehci" ~driver_id:"ehci" )
+        , fun () -> vusb_controller_plug ~driver:"usb-ehci" ~driver_id:"ehci"
+        )
       in
       let speed_of_float x =
         if x <= 0. then
@@ -2249,7 +2289,9 @@ module Vusb = struct
           raise
             (Xenopsd_error
                (Internal_error
-                  (Printf.sprintf "qemu pid does not exist for vm %d" domid)))
+                  (Printf.sprintf "qemu pid does not exist for vm %d" domid)
+               )
+            )
       ) ;
       let cmd =
         Qmp.(
@@ -2258,7 +2300,9 @@ module Vusb = struct
               {
                 driver= "usb-host"
               ; device= USB {USB.id; params= Some USB.{bus; hostbus; hostport}}
-              })
+              }
+            
+        )
       in
       qmp_send_cmd domid cmd |> ignore
     )
@@ -2270,7 +2314,8 @@ module Vusb = struct
         if Qemu.is_running ~xs domid then
           try qmp_send_cmd domid Qmp.(Device_del id) |> ignore
           with QMP_connection_error _ ->
-            raise (Xenopsd_error Device_not_connected))
+            raise (Xenopsd_error Device_not_connected)
+      )
       (fun () -> usb_reset_detach ~hostbus ~hostport ~domid ~privileged)
 end
 
@@ -2445,7 +2490,8 @@ module Dm_Common = struct
         | None ->
             ()
         | Some param ->
-            t.Xst.write (cmdpath ^ "/parameter") param) ;
+            t.Xst.write (cmdpath ^ "/parameter") param
+    ) ;
     match wait_for with
     | Some state ->
         let pw = cmdpath ^ "/state" in
@@ -2519,7 +2565,8 @@ module Dm_Common = struct
         | Some domid ->
             ( []
             , Printf.sprintf "%s,lock-key-sync=off"
-                (Socket.Unix.path (vnc_socket_path domid)) )
+                (Socket.Unix.path (vnc_socket_path domid))
+            )
       in
       let vnc_opt = ["-vnc"; vnc_arg] in
       let keymap_opt = match keymap with Some k -> ["-k"; k] | None -> [] in
@@ -2561,14 +2608,16 @@ module Dm_Common = struct
                | k, None ->
                    ["-" ^ k]
                | k, Some v ->
-                   ["-" ^ k; v])
+                   ["-" ^ k; v]
+               )
           |> List.concat
         ; (info.monitor |> function None -> [] | Some x -> ["-monitor"; x])
         ; (Qemu.pidfile_path domid |> function
            | None ->
                []
            | Some x ->
-               ["-pidfile"; x])
+               ["-pidfile"; x]
+          )
         ]
     in
     {argv; fd_map= []}
@@ -2645,9 +2694,13 @@ module Dm_Common = struct
                    (Xenopsd_error
                       (Internal_error
                          (Printf.sprintf "NVidia vGPU metadata incomplete (%s)"
-                            __LOC__)))
+                            __LOC__
+                         )
+                      )
+                   )
              | _ ->
-                 "")
+                 ""
+         )
     in
     let suspend_file = sprintf demu_save_path domid in
     let base_args =
@@ -2677,14 +2730,16 @@ module Dm_Common = struct
       |> List.map (fun domid ->
              let path = Printf.sprintf "%s/%s/device/vgpu" root domid in
              try List.map (fun x -> path ^ "/" ^ x) (xs.Xs.directory path)
-             with Xs_protocol.Enoent _ -> [])
+             with Xs_protocol.Enoent _ -> []
+         )
       |> List.concat
       |> List.exists (fun vgpu ->
              try
                let path = Printf.sprintf "%s/pf" vgpu in
                let pf = xs.Xs.read path in
                pf = physical_function
-             with Xs_protocol.Enoent _ -> false)
+             with Xs_protocol.Enoent _ -> false
+         )
     with Xs_protocol.Enoent _ -> false
 
   let call_gimtool args =
@@ -2760,21 +2815,26 @@ module Dm_Common = struct
           let open Generic in
           best_effort
             "signalling that qemu is ending as expected, mask further signals"
-            (fun () -> Qemu.SignalMask.set Qemu.signal_mask domid) ;
+            (fun () -> Qemu.SignalMask.set Qemu.signal_mask domid
+          ) ;
           best_effort "killing qemu-dm" (fun () -> really_kill qemu_pid) ;
           best_effort "removing qemu-pid from xenstore" (fun () ->
-              xs.Xs.rm qemu_pid_path) ;
+              xs.Xs.rm qemu_pid_path
+          ) ;
           best_effort
             "unmasking signals, qemu-pid is already gone from xenstore"
-            (fun () -> Qemu.SignalMask.unset Qemu.signal_mask domid) ;
+            (fun () -> Qemu.SignalMask.unset Qemu.signal_mask domid
+          ) ;
           best_effort "removing device model path from xenstore" (fun () ->
-              xs.Xs.rm (device_model_path ~qemu_domid domid)) ;
+              xs.Xs.rm (device_model_path ~qemu_domid domid)
+          ) ;
           match Qemu.pidfile_path domid with
           | None ->
               ()
           | Some path ->
               best_effort (sprintf "removing %s" path) (fun () ->
-                  Unix.unlink path)
+                  Unix.unlink path
+              )
         )
     in
     let stop_vgpu () = Vgpu.stop ~xs domid in
@@ -2806,7 +2866,8 @@ module Dm_Common = struct
            ; (if file <> "" then ["auto-read-only=off"] else [])
            ; Media.readonly_of media
            ; Media.format_of media file
-           ])
+           ]
+        )
     ; "-device"
     ; String.concat ","
         (List.concat
@@ -2818,7 +2879,8 @@ module Dm_Common = struct
              ; sprintf "unit=%d" (index mod 2)
              ]
            ; (if trad_compat then Media.lba_of media else [])
-           ])
+           ]
+        )
     ]
 
   let nvme = "nvme"
@@ -2873,7 +2935,8 @@ module Dm_Common = struct
                | None ->
                    []
              )
-           ])
+           ]
+        )
     ]
 
   let cant_suspend_reason_path domid =
@@ -3002,8 +3065,10 @@ module Backend = struct
             try
               Some
                 (Socket.Port
-                   (int_of_string (xs.Xs.read (Generic.vnc_port_path domid))))
-            with _ -> None)
+                   (int_of_string (xs.Xs.read (Generic.vnc_port_path domid)))
+                )
+            with _ -> None
+        )
 
       let assert_can_suspend ~xs _ = ()
 
@@ -3338,12 +3403,14 @@ module Backend = struct
           (fun () ->
             Lookup.remove c domid ;
             Monitor.remove m (Qmp_protocol.to_fd c) ;
-            debug "Removed QMP Event fd for domain %d" domid)
+            debug "Removed QMP Event fd for domain %d" domid
+          )
           (fun () -> Qmp_protocol.close c)
       with e ->
         debug_exn
           (Printf.sprintf "Got exception trying to remove QMP on domain-%d"
-             domid)
+             domid
+          )
           e
 
     let add domid =
@@ -3358,7 +3425,8 @@ module Backend = struct
       with e ->
         debug_exn
           (Printf.sprintf "QMP domain-%d: negotiation failed: removing socket"
-             domid)
+             domid
+          )
           e ;
         remove domid ;
         raise
@@ -3381,7 +3449,9 @@ module Backend = struct
           @@ Xenopsd_error
                (Internal_error
                   (sprintf "Unexpected result for QMP command: %s"
-                     Qmp.(other |> as_msg |> string_of_message)))
+                     Qmp.(other |> as_msg |> string_of_message)
+                  )
+               )
       | exception QMP_Error (_, msg) -> (
         match Astring.String.find_sub ~sub:"CommandNotFound" msg with
         | None ->
@@ -3407,7 +3477,8 @@ module Backend = struct
                 Int64.(add timeoffset (of_string rtc) |> to_string)
             with e ->
               error "Failed to process RTC_CHANGE for domain %d: %s" domid
-                (Printexc.to_string e))
+                (Printexc.to_string e)
+        )
       in
       let xen_platform_pv_driver_info pv_info =
         with_xs (fun xs ->
@@ -3426,7 +3497,8 @@ module Backend = struct
                 (write_local_domain "control/feature-")
                 ["suspend"; "poweroff"; "reboot"; "vcpu-hotplug"] ;
               List.iter (write_local_domain "data/") ["updated"]
-            ))
+            )
+        )
       in
       qmp_event.data |> function
       | Some (RTC_CHANGE timeoffset) ->
@@ -3488,7 +3560,8 @@ module Backend = struct
                    debug "EPOLL error on domain-%d, close QMP socket" domid ;
                    Readln.free qmp ;
                    remove domid
-                 ))
+                 )
+             )
         with e -> debug_exn "Exception in QMP_Event_thread: %s" e
       done
   end
@@ -3520,7 +3593,9 @@ module Backend = struct
             raise
               (Xenopsd_error
                  (Internal_error
-                    (Printf.sprintf "unexpected disk for devid %d" devid)))
+                    (Printf.sprintf "unexpected disk for devid %d" devid)
+                 )
+              )
 
       let qemu_media_change ~xs device _type params =
         Vbd_Common.qemu_media_change ~xs device _type params ;
@@ -3544,7 +3619,10 @@ module Backend = struct
                         (Xenopsd_error
                            (Internal_error
                               (sprintf "Unexpected result for QMP command: %s"
-                                 Qmp.(other |> as_msg |> string_of_message))))
+                                 Qmp.(other |> as_msg |> string_of_message)
+                              )
+                           )
+                        )
                 in
                 finally
                   (fun () ->
@@ -3556,24 +3634,31 @@ module Backend = struct
                         ; medium_filename= path
                         ; medium_format= Some "raw"
                         }
+                      
                     in
                     let cmd = Qmp.(Blockdev_change_medium medium) in
-                    qmp_send_cmd domid cmd |> ignore)
+                    qmp_send_cmd domid cmd |> ignore
+                  )
                   (fun () ->
                     let cmd = Qmp.(Remove_fd fd_info.fdset_id) in
-                    qmp_send_cmd domid cmd |> ignore))
+                    qmp_send_cmd domid cmd |> ignore
+                  )
+              )
               (fun () -> Unix.close fd_cd)
         with
         | Unix.Unix_error (Unix.ECONNREFUSED, "connect", p) ->
             raise
               (Xenopsd_error
                  (Internal_error
-                    (Printf.sprintf "Failed to connnect QMP socket: %s" p)))
+                    (Printf.sprintf "Failed to connnect QMP socket: %s" p)
+                 )
+              )
         | Unix.Unix_error (Unix.ENOENT, "open", p) ->
             raise
               (Xenopsd_error
-                 (Internal_error
-                    (Printf.sprintf "Failed to open CD Image: %s" p)))
+                 (Internal_error (Printf.sprintf "Failed to open CD Image: %s" p)
+                 )
+              )
         | Xenopsd_error (Internal_error _) as e ->
             raise e
         | e ->
@@ -3582,7 +3667,10 @@ module Backend = struct
                  (Internal_error
                     (Printf.sprintf
                        "Get unexpected error trying to change CD: %s"
-                       (Printexc.to_string e))))
+                       (Printexc.to_string e)
+                    )
+                 )
+              )
     end
 
     (* Backend.Qemu_upstream_compat.Vbd *)
@@ -3612,7 +3700,9 @@ module Backend = struct
                     {
                       driver= VCPU.Driver.(string_of QEMU32_I386_CPU)
                     ; device= VCPU {VCPU.id; socket_id; core_id; thread_id}
-                    })
+                    }
+                  
+              )
             |> ignore
         | false ->
             (* hotunplug *)
@@ -3623,7 +3713,8 @@ module Backend = struct
                   x
                   |> List.filter
                        (fun Qmp.Device.VCPU.{qom_path; props= {socket_id}} ->
-                         socket_id = devid)
+                         socket_id = devid
+                     )
                   |> function
                   | [] ->
                       err (sprintf "No QEMU CPU found with devid %d" devid)
@@ -3636,7 +3727,8 @@ module Backend = struct
                   let as_msg cmd = Qmp.(Success (Some __LOC__, cmd)) in
                   err
                     (sprintf "Unexpected result for QMP command: %s"
-                       Qmp.(other |> as_msg |> string_of_message))
+                       Qmp.(other |> as_msg |> string_of_message)
+                    )
             in
             qom_path |> fun id ->
             qmp_send_cmd domid Qmp.(Device_del id) |> ignore
@@ -3647,7 +3739,8 @@ module Backend = struct
     module Dm = struct
       let get_vnc_port ~xs domid =
         Dm_Common.get_vnc_port ~xs domid ~f:(fun () ->
-            Some (Socket.Unix (Dm_Common.vnc_socket_path domid)))
+            Some (Socket.Unix (Dm_Common.vnc_socket_path domid))
+        )
 
       let assert_can_suspend ~xs domid =
         QMP_Event.update_cant_suspend domid xs ;
@@ -3661,7 +3754,9 @@ module Backend = struct
                     , domid
                       |> Xenops_helpers.uuid_of_domid ~xs
                       |> Uuidm.to_string
-                    , msg ))
+                    , msg
+                    )
+                 )
         | exception e ->
             debug "assert_can_suspend: OK (domid=%d)" domid ;
             ()
@@ -3684,15 +3779,21 @@ module Backend = struct
                     (Xenopsd_error
                        (Internal_error
                           (sprintf "Unexpected result for QMP command: %s"
-                             Qmp.(other |> as_msg |> string_of_message))))
+                             Qmp.(other |> as_msg |> string_of_message)
+                          )
+                       )
+                    )
             in
             finally
               (fun () ->
                 let path = sprintf "/dev/fdset/%d" fd.Qmp.fdset_id in
                 qmp_send_cmd domid Qmp.Stop |> ignore ;
-                qmp_send_cmd domid Qmp.(Xen_save_devices_state path) |> ignore)
+                qmp_send_cmd domid Qmp.(Xen_save_devices_state path) |> ignore
+              )
               (fun () ->
-                qmp_send_cmd domid Qmp.(Remove_fd fd.fdset_id) |> ignore))
+                qmp_send_cmd domid Qmp.(Remove_fd fd.fdset_id) |> ignore
+              )
+          )
           (fun () -> Unix.close save_fd)
 
       (* Wait for QEMU's event socket to appear. Connect to it to make sure it
@@ -3728,7 +3829,8 @@ module Backend = struct
                   Thread.delay 0.1
               ) else
                 Thread.delay 0.05
-            done)
+            done
+          )
           (fun () -> Unix.close socket) ;
         if not !finished then
           raise (Ioemu_failed (name, "Timeout reached while starting daemon"))
@@ -3758,7 +3860,8 @@ module Backend = struct
         (* unmounts devices in /var/xen/qemu/root-* *)
         let path = Printf.sprintf "/var/xen/qemu/root-%d" domid in
         Generic.best_effort (Printf.sprintf "removing %s" path) (fun () ->
-            Xenops_utils.FileFS.rmtree path)
+            Xenops_utils.FileFS.rmtree path
+        )
 
       let tap_open ifname =
         let uuid = Uuidm.to_string (Uuidm.create `V4) in
@@ -3779,7 +3882,8 @@ module Backend = struct
               let devs =
                 devices
                 |> List.map (fun (x, y) ->
-                       ["-device"; sprintf "usb-%s,port=%d" x y])
+                       ["-device"; sprintf "usb-%s,port=%d" x y]
+                   )
                 |> List.concat
               in
               "-usb" :: devs
@@ -3823,7 +3927,9 @@ module Backend = struct
                 (Ioemu_failed
                    ( sprintf "domid %d" domid
                    , sprintf "Unknown platform:disk_type=%s in device-model=%s"
-                       disk_type Config.name ))
+                       disk_type Config.name
+                   )
+                )
         in
         if not (Config.Firmware.supported info.firmware) then
           (* XAPI itself should've already prevented this, but lets double check *)
@@ -3831,14 +3937,17 @@ module Backend = struct
             (Ioemu_failed
                ( sprintf "domid %d" domid
                , sprintf "The firmware doesn't support device-model=%s"
-                   Config.name )) ;
+                   Config.name
+               )
+            ) ;
         let qmp =
           ["libxl"; "event"]
           |> List.map (fun x ->
                  [
                    "-qmp"
                  ; sprintf "unix:/var/run/xen/qmp-%s-%d,server,nowait" x domid
-                 ])
+                 ]
+             )
           |> List.concat
         in
         let pv_device addr =
@@ -3860,8 +3969,7 @@ module Backend = struct
                 "-xen-domid"
               ; string_of_int domid
               ; "-m"
-              ; "size="
-                ^ Int64.to_string (Int64.div info.Dm_Common.memory 1024L)
+              ; "size=" ^ Int64.to_string (Int64.div info.Dm_Common.memory 1024L)
               ; "-boot"
               ; "order=" ^ info.Dm_Common.boot
               ]
@@ -3884,7 +3992,8 @@ module Backend = struct
                | None ->
                    ["-parallel"; "null"]
                | Some x ->
-                   ["-parallel"; x])
+                   ["-parallel"; x]
+              )
             ; qmp
             ; Config.XenPlatform.device ~xs ~domid ~info
             ]
@@ -3979,6 +4088,7 @@ module Backend = struct
                   common.argv @ misc @ disks' @ pv_device pv_device_addr @ none
               ; fd_map= common.fd_map
               }
+            
         | _, fds, argv ->
             Dm_Common.
               {
@@ -3986,6 +4096,7 @@ module Backend = struct
                   common.argv @ misc @ disks' @ pv_device pv_device_addr @ argv
               ; fd_map= common.fd_map @ fds
               }
+            
 
       let after_suspend_image ~xs ~qemu_domid domid =
         (* device model not needed anymore after suspend image has been created *)
@@ -4151,7 +4262,8 @@ module Dm = struct
        | None ->
            return ()
        | Some x ->
-           Add.many ["--pidfile"; x])
+           Add.many ["--pidfile"; x]
+      )
       >>= fun () ->
       Add.many @@ argf "uuid:%s" vm_uuid >>= fun () ->
       on reset_on_boot @@ Add.arg "--nonpersistent" >>= fun () ->
@@ -4220,14 +4332,17 @@ module Dm = struct
           raise
             (Ioemu_failed
                ( "vgpu"
-               , Printf.sprintf "Daemon vgpu returned error: %s" error_code ))
+               , Printf.sprintf "Daemon vgpu returned error: %s" error_code
+               )
+            )
     | [{physical_pci_address= pci; implementation= GVT_g vgpu}] ->
         PCI.bind [pci] PCI.I915
     | [{physical_pci_address= pci; implementation= MxGPU vgpu}] ->
         Mutex.execute gimtool_m (fun () ->
             configure_gim ~xs pci vgpu.vgpus_per_pgpu vgpu.framebufferbytes ;
             let keys = [("pf", Xenops_interface.Pci.string_of_address pci)] in
-            write_vgpu_data ~xs domid 0 keys)
+            write_vgpu_data ~xs domid 0 keys
+        )
     | _ ->
         failwith "Unsupported vGPU configuration"
 
@@ -4278,7 +4393,8 @@ module Dm = struct
       finally
         (fun () ->
           init_daemon ~task ~path:(Profile.wrapper_of dm) ~args:argv ~domid ~xs
-            ~ready_path ~timeout ~cancel ~fds:args.fd_map dm)
+            ~ready_path ~timeout ~cancel ~fds:args.fd_map dm
+        )
         (fun () -> List.iter close args.fd_map)
     in
     match !Xenopsd.action_after_qemu_crash with
@@ -4298,8 +4414,10 @@ module Dm = struct
                        Forkhelpers.waitpid_fail_if_bad_exit x ;
                        None
                      with e -> Some e
-                   ))
-               x)
+                   )
+               )
+               x
+            )
         in
         waitpid_async qemu_pid ~callback:(fun qemu_crash ->
             Forkhelpers.(
@@ -4342,7 +4460,9 @@ module Dm = struct
                 | Some _ ->
                     (* before expected qemu stop: qemu-pid is available in
                        domain xs tree: signal action to take *)
-                    xs.Xs.write (Qemu.pid_path_signal domid) crash_reason))
+                    xs.Xs.write (Qemu.pid_path_signal domid) crash_reason
+            )
+        )
 
   let start (task : Xenops_task.task_handle) ~xc ~xs ~dm ?timeout info domid =
     __start task ~xc ~xs ~dm ?timeout Start info domid

--- a/xc/device_common.ml
+++ b/xc/device_common.ml
@@ -215,13 +215,15 @@ let add_backend_keys ~xs (x : device) subdir keys =
     backend ;
   Xs.transaction xs (fun t ->
       ignore (t.Xst.read backend_stub) ;
-      t.Xst.writev backend keys)
+      t.Xst.writev backend keys
+  )
 
 let remove_backend_keys ~xs (x : device) subdir keys =
   let backend_stub = backend_path_of_device ~xs x in
   let backend = backend_stub ^ "/" ^ subdir in
   Xs.transaction xs (fun t ->
-      List.iter (fun key -> t.Xst.rm (backend ^ "/" ^ key)) keys)
+      List.iter (fun key -> t.Xst.rm (backend ^ "/" ^ key)) keys
+  )
 
 let string_of_device (x : device) =
   sprintf "frontend %s; backend %s"
@@ -340,7 +342,8 @@ let list_frontends ~xs ?for_devids domid =
                    try
                      ignore (xs.Xs.read (sprintf "%s/%d" dir devid)) ;
                      true
-                   with _ -> false)
+                   with _ -> false
+                 )
                  devids
          in
          to_list
@@ -355,9 +358,13 @@ let list_frontends ~xs ?for_devids domid =
                       Some {backend= b; frontend}
                   | None ->
                       None
-                with _ -> None)
-              devids))
-       kinds)
+                with _ -> None
+              )
+              devids
+           )
+       )
+       kinds
+    )
 
 (* NB: we only read data from the backend directory. Therefore this gives the
    "backend's point of view". *)
@@ -392,10 +399,16 @@ let list_backends ~xs domid =
                              Some {backend; frontend= f}
                          | None ->
                              None
-                       with _ -> None)
-                     devids))
-              domids))
-       kinds)
+                       with _ -> None
+                     )
+                     devids
+                  )
+              )
+              domids
+           )
+       )
+       kinds
+    )
 
 (** Return a list of devices connecting two domains. Ignore those whose kind we
     don't recognise *)
@@ -550,4 +563,5 @@ let qmp_send_cmd ?send_fd domid cmd =
       | message ->
           let msg' = Qmp.string_of_message message in
           error "QMP result for domid %d: %s (%s)" domid msg' __LOC__ ;
-          raise (QMP_Error (domid, msg')))
+          raise (QMP_Error (domid, msg'))
+  )

--- a/xc/domain_sethandle.ml
+++ b/xc/domain_sethandle.ml
@@ -25,11 +25,14 @@ let _ =
        [
          ( "-domid"
          , Arg.Int (fun i -> domid := Some i)
-         , " the domain id whose handle we will change" )
+         , " the domain id whose handle we will change"
+         )
        ; ( "-handle"
          , Arg.String (fun i -> handle := Some i)
-         , " the new handle value" )
-       ])
+         , " the new handle value"
+         )
+       ]
+    )
     (fun x -> Printf.printf "Warning, ignoring unknown argument: %s" x)
     "Set a domain's handle" ;
   match (!domid, !handle) with

--- a/xc/emu_manager.ml
+++ b/xc/emu_manager.ml
@@ -79,7 +79,8 @@ let connect path domid (args : string list)
   , Unix.out_channel_of_descr server_to_slave_w
   , slave_to_server_r
   , server_to_slave_w
-  , pid )
+  , pid
+  )
 
 (** Wait for the (hopefully dead) child process *)
 let disconnect (_, _, r, w, pid) =
@@ -208,7 +209,8 @@ let non_debug_receive ?debug_callback cnx =
         error "Memory F %Ld KiB S %Ld KiB T %Ld MiB"
           (p.free_pages |> of_nativeint |> kib_of_pages)
           (p.scrub_pages |> of_nativeint |> kib_of_pages)
-          (p.total_pages |> of_nativeint |> mib_of_pages_free))
+          (p.total_pages |> of_nativeint |> mib_of_pages_free)
+    )
   in
   try
     match non_debug_receive ?debug_callback cnx with
@@ -239,5 +241,7 @@ let with_connection (task : Xenops_task.task_handle) path domid
             if !cancelled then
               Xenops_task.raise_cancelled task
             else
-              raise e))
+              raise e
+      )
+    )
     (fun () -> disconnect t)

--- a/xc/hotplug.ml
+++ b/xc/hotplug.ml
@@ -78,7 +78,8 @@ let path_written_by_hotplug_scripts (x : device) =
   | k ->
       failwith
         (Printf.sprintf "No xenstore interface for this kind of device: %s"
-           (string_of_kind k))
+           (string_of_kind k)
+        )
 
 let error_path_written_by_hotplug_scripts (x : device) =
   sprintf "/local/domain/%d/backend/%s/%d/%d/hotplug-error" x.backend.domid
@@ -176,7 +177,8 @@ let wait_for_plug (task : Xenops_task.task_handle) ~xs (x : device) =
           (* If an error node exists, return the error *)
           raise (Hotplug_error (xs.Xs.read error_path))
         with Xs_protocol.Enoent _ -> ()
-        (* common case *)) ;
+        (* common case *)
+    ) ;
     debug "Synchronised ok with hotplug script: %s" (string_of_device x)
   with Watch.Timeout _ -> raise (Device_timeout x)
 
@@ -190,7 +192,8 @@ let wait_for_unplug (task : Xenops_task.task_handle) ~xs (x : device) =
             [Watch.map (fun _ -> ()) (Watch.key_to_disappear path)]
             [] task ~xs ~timeout:!Xenopsd.hotplug_timeout ()
         in
-        ()) ;
+        ()
+    ) ;
     debug "Synchronised ok with hotplug script: %s" (string_of_device x)
   with Watch.Timeout _ -> raise (Device_timeout x)
 
@@ -202,12 +205,10 @@ let wait_for_frontend_plug (task : Xenops_task.task_handle) ~xs (x : device) =
       Watch.value_to_appear (frontend_status_node x) |> Watch.map (fun _ -> ())
     in
     let tapdisk_error_watch =
-      Watch.value_to_appear (tapdisk_error_node ~xs x)
-      |> Watch.map (fun _ -> ())
+      Watch.value_to_appear (tapdisk_error_node ~xs x) |> Watch.map (fun _ -> ())
     in
     let blkback_error_watch =
-      Watch.value_to_appear (blkback_error_node ~xs x)
-      |> Watch.map (fun _ -> ())
+      Watch.value_to_appear (blkback_error_node ~xs x) |> Watch.map (fun _ -> ())
     in
     let cancel = Device x in
     Stats.time_this "udev frontend add event" (fun () ->
@@ -228,7 +229,8 @@ let wait_for_frontend_plug (task : Xenops_task.task_handle) ~xs (x : device) =
           let e = tapdisk_error ^ "/" ^ blkback_error in
           error "Failed waiting for frontend device %s: %s" (string_of_device x)
             e ;
-          raise (Frontend_device_error e))
+          raise (Frontend_device_error e)
+    )
   with Watch.Timeout _ ->
     error "Timed out waiting for the frontend udev event to fire on device: %s"
       (string_of_device x) ;
@@ -244,9 +246,9 @@ let wait_for_frontend_unplug (task : Xenops_task.task_handle) ~xs (x : device) =
             [Watch.map (fun _ -> ()) (Watch.key_to_disappear path)]
             [] task ~xs ~timeout:!Xenopsd.hotplug_timeout ()
         in
-        ()) ;
-    debug "Synchronised ok with frontend hotplug script: %s"
-      (string_of_device x)
+        ()
+    ) ;
+    debug "Synchronised ok with frontend hotplug script: %s" (string_of_device x)
   with Watch.Timeout _ -> raise (Frontend_device_timeout x)
 
 (* If we're running the hotplug scripts ourselves then we must wait for the VIF
@@ -266,7 +268,8 @@ let wait_for_connect (task : Xenops_task.task_handle) ~xs (x : device) =
             ]
             [] task ~xs ~timeout:!Xenopsd.hotplug_timeout ()
         in
-        ()) ;
+        ()
+    ) ;
     debug "Synchronised ok with device backend: %s" (string_of_device x)
   with Watch.Timeout _ -> raise (Device_timeout x)
 
@@ -292,7 +295,8 @@ let release (task : Xenops_task.task_handle) ~xc ~xs (x : device) =
   Xs.transaction xs (fun t ->
       t.Xst.rm hotplug_path ;
       Option.iter t.Xst.rm private_data_path ;
-      t.Xst.rm extra_xenserver_path)
+      t.Xst.rm extra_xenserver_path
+  )
 
 let run_hotplug_script device args =
   let kind = string_of_kind device.backend.kind in

--- a/xc/list_domains.ml
+++ b/xc/list_domains.ml
@@ -105,7 +105,8 @@ let select table keys =
     (fun key ->
       if not (Hashtbl.mem table key) then
         failwith (Printf.sprintf "Failed to find key: %s" key) ;
-      Hashtbl.find table key)
+      Hashtbl.find table key
+    )
     keys
 
 let columns () =
@@ -160,16 +161,20 @@ let _ =
          , Arg.Unit
              (fun () ->
                memory := true ;
-               all_the_rest := true)
-         , " show all available stats (needs a wide window!)" )
+               all_the_rest := true
+             )
+         , " show all available stats (needs a wide window!)"
+         )
        ; ("-bytes", Arg.Set bytes, " use bytes for memory values")
        ; ( "-domid"
          , Arg.Int (fun i -> domid := Some i)
-         , " show only a particular domain" )
+         , " show only a particular domain"
+         )
        ; ("-memory", Arg.Set memory, " show memory statistics")
        ; ("-minimal", Arg.Set minimal, " show only domain UUID")
        ; ("-pages", Arg.Set pages, " use pages for memory values")
-       ])
+       ]
+    )
     (fun x -> Printf.printf "Warning, ignoring unknown argument: %s" x)
     "List domains" ;
   let cols = columns () in

--- a/xc/memory_breakdown.ml
+++ b/xc/memory_breakdown.ml
@@ -37,10 +37,12 @@ let cli_arguments_named =
   [
     ( "-pad"
     , Arg.Set_string cli_argument_existing_file_to_pad
-    , "Pads an existing data file" )
+    , "Pads an existing data file"
+    )
   ; ( "-period"
     , Arg.Set_float cli_argument_delay_period_seconds
-    , "Delay between updates" )
+    , "Delay between updates"
+    )
   ]
 
 let cli_arguments_extra x = Printf.fprintf stderr "Ignoring argument: %s" x
@@ -162,8 +164,7 @@ let guest_balloonable xc xs g =
     (xs_exists xs (supports_ballooning_path (guest_domain_id xc xs g)))
 
 let guest_uncooperative xc xs g =
-  string_of_bool
-    (xs_exists xs (is_uncooperative_path (guest_domain_id xc xs g)))
+  string_of_bool (xs_exists xs (is_uncooperative_path (guest_domain_id xc xs g)))
 
 let guest_shadow_bytes xc xs g =
   Int64.to_string
@@ -221,7 +222,8 @@ let print_memory_field_values xc xs =
   let guests =
     List.sort
       (fun g1 g2 ->
-        compare_guests control_domain_id g1.Xenctrl.handle g2.Xenctrl.handle)
+        compare_guests control_domain_id g1.Xenctrl.handle g2.Xenctrl.handle
+      )
       (Xenctrl.domain_getinfolist xc 0)
   in
   let print_host_info field =
@@ -239,8 +241,7 @@ let print_memory_field_values xc xs =
   flush stdout
 
 (** Sleeps for the given time period in seconds. *)
-let sleep time_period_seconds =
-  ignore (Unix.select [] [] [] time_period_seconds)
+let sleep time_period_seconds = ignore (Unix.select [] [] [] time_period_seconds)
 
 (** Prints a header line of memory field names, and then periodically prints a
     line of memory field values. *)
@@ -250,7 +251,8 @@ let record_new_data () =
       while true do
         print_memory_field_values xc xs ;
         sleep !cli_argument_delay_period_seconds
-      done)
+      done
+  )
 
 (** {2 Functions that transform sparse data files into padded data files} *)
 
@@ -291,7 +293,8 @@ let pad_value_list guest_ids_all guest_ids values default_value =
            "Expected: guest_ids subset of guest_ids_all"
          else
            "Unknown failure"
-         ))
+         )
+      )
   in
   let rec pad ids_all ids vs vs_padded =
     match (ids_all, ids, vs) with
@@ -313,13 +316,16 @@ let pad_value_string guest_ids_all guest_ids (value_string, default_value) =
     (String.concat " "
        (pad_value_list guest_ids_all guest_ids
           (Astring.String.cuts ~sep:" " value_string)
-          default_value))
+          default_value
+       )
+    )
 
 let pad_value_strings guest_ids_all guest_ids value_strings =
   String.concat " "
     (List.map
        (pad_value_string guest_ids_all guest_ids)
-       (List.combine value_strings (List.tl guest_field_defaults)))
+       (List.combine value_strings (List.tl guest_field_defaults))
+    )
 
 let pad_data_line guest_ids_all line =
   match sections_of_line line with
@@ -327,7 +333,8 @@ let pad_data_line guest_ids_all line =
       Printf.sprintf "| %s | %s" host_string
         (pad_value_strings guest_ids_all
            (guest_ids_of_string guest_ids_string)
-           value_strings)
+           value_strings
+        )
   | _ ->
       line
 
@@ -351,8 +358,12 @@ let print_padded_header_line guest_count =
             String.concat " "
               (List.map
                  (Printf.sprintf "%s_%i" name)
-                 (range 0 (guest_count - 1))))
-          (List.tl guest_field_names)))
+                 (range 0 (guest_count - 1))
+              )
+          )
+          (List.tl guest_field_names)
+       )
+    )
 
 let pad_existing_data () =
   let guest_ids_all = guest_ids_of_file !cli_argument_existing_file_to_pad in

--- a/xc/memory_summary.ml
+++ b/xc/memory_summary.ml
@@ -47,7 +47,8 @@ let _ =
     let domains =
       List.map
         (fun di ->
-          (di.Xenctrl.domid, Int64.of_nativeint di.Xenctrl.total_memory_pages))
+          (di.Xenctrl.domid, Int64.of_nativeint di.Xenctrl.total_memory_pages)
+        )
         domains
     in
     if not !hash then (
@@ -81,7 +82,8 @@ let _ =
       List.iter
         (fun (domid, total) ->
           Printf.printf "%10s %s (%Ld MiB)\n" (string_of_int domid)
-            (hashes total) (total /* 256L))
+            (hashes total) (total /* 256L)
+        )
         domains
     )
   done

--- a/xc/readln.ml
+++ b/xc/readln.ml
@@ -20,7 +20,8 @@ let read fd =
       else
         Error
           (Printf.sprintf "Unconsumed data at EOF: '%s'"
-             (Bytes.to_string pending))
+             (Bytes.to_string pending)
+          )
   | n ->
       let data = Bytes.sub buffer 0 n in
       let inpt = try Hashtbl.find input fd with Not_found -> Bytes.empty in

--- a/xc/stats.ml
+++ b/xc/stats.ml
@@ -80,7 +80,8 @@ let sample (name : string) (x : float) : unit =
           Normal_population.empty
       in
       let p' = Normal_population.sample p x' in
-      Hashtbl.replace timings name p')
+      Hashtbl.replace timings name p'
+  )
 
 (** Helper function to time a specific thing *)
 let time_this (name : string) f =
@@ -91,11 +92,13 @@ let time_this (name : string) f =
         sample name (end_time -. start_time)
       with e ->
         warn "Ignoring exception %s while timing: %s" (Printexc.to_string e)
-          name)
+          name
+  )
 
 let summarise () =
   Mutex.execute timings_m (fun () ->
-      Hashtbl.fold (fun k v acc -> (k, string_of v) :: acc) timings [])
+      Hashtbl.fold (fun k v acc -> (k, string_of v) :: acc) timings []
+  )
 
 (*****************************)
 (* Database stats            *)
@@ -151,7 +154,8 @@ let log_db_call task_opt dbcall ty =
               :: (try Hashtbl.find dbstats_task task with _ -> [])
               )
         | None ->
-            ())
+            ()
+    )
 
 let summarise_db_calls () =
   let string_of_ty = function
@@ -181,8 +185,10 @@ let summarise_db_calls () =
             ( k
             , List.map
                 (fun (dbcall, ty) -> (string_of_ty ty, dbcall))
-                (List.rev v) )
-            :: acc)
+                (List.rev v)
+            )
+            :: acc
+          )
           dbstats_task []
       , List.sort
           (fun (a, _) (b, _) -> compare a b)
@@ -191,6 +197,11 @@ let summarise_db_calls () =
                ( k
                , List.map
                    (fun (dbcall, ty) -> (string_of_ty ty, dbcall))
-                   (List.rev v) )
-               :: acc)
-             dbstats_threads []) ))
+                   (List.rev v)
+               )
+               :: acc
+             )
+             dbstats_threads []
+          )
+      )
+  )

--- a/xc/xc_resources.ml
+++ b/xc/xc_resources.ml
@@ -64,11 +64,13 @@ let essentials =
   ; ( X_OK
     , "setup-vif-rules"
     , setup_vif_rules
-    , "path to the setup-vif-rules script" )
+    , "path to the setup-vif-rules script"
+    )
   ; ( X_OK
     , "setup-pvs-proxy-rules"
     , setup_pvs_proxy_rules
-    , "path to the setup-pvs-proxy-rules script" )
+    , "path to the setup-pvs-proxy-rules script"
+    )
   ]
   @ Resources.network_configuration
 
@@ -77,7 +79,8 @@ let nonessentials =
     ( X_OK
     , "pci-flr-script"
     , pci_flr_script
-    , "path to the PCI function-level reset script" )
+    , "path to the PCI function-level reset script"
+    )
   ; (X_OK, "alternatives", alternatives, "path to the alternative xenguests")
   ; (X_OK, "vgpu", vgpu, "path to the vgpu binary")
   ; (X_OK, "varstored", varstored, "path to the varstored binary")
@@ -86,7 +89,8 @@ let nonessentials =
   ; ( X_OK
     , "igmp-query-injector-script"
     , igmp_query_injector_script
-    , "path to the igmp query injector script" )
+    , "path to the igmp query injector script"
+    )
   ]
   @ Resources.hvm_guests
   @ Resources.pv_guests

--- a/xc/xenbus_utils.ml
+++ b/xc/xenbus_utils.ml
@@ -93,6 +93,7 @@ let device_frontend device =
     ; other= NONE
     ; acl= [(device.backend.domid, READ)]
     }
+  
 
 let device_backend device =
   Xs_protocol.ACL.
@@ -101,6 +102,7 @@ let device_backend device =
     ; other= NONE
     ; acl= [(device.frontend.domid, READ)]
     }
+  
 
 let hotplug device =
   Xs_protocol.ACL.{owner= device.backend.domid; other= NONE; acl= []}

--- a/xc/xenguestHelper.ml
+++ b/xc/xenguestHelper.ml
@@ -82,7 +82,8 @@ let connect path domid (args : string list)
   , Unix.out_channel_of_descr server_to_slave_w
   , slave_to_server_r
   , server_to_slave_w
-  , pid )
+  , pid
+  )
 
 (** Wait for the (hopefully dead) child process *)
 let disconnect (_, _, r, w, pid) =
@@ -121,7 +122,9 @@ let with_connection (task : Xenops_task.task_handle) path domid
             if !cancelled then
               Xenops_task.raise_cancelled task
             else
-              raise e))
+              raise e
+      )
+    )
     (fun () -> disconnect t)
 
 (** immediately write a command to the control channel *)
@@ -206,7 +209,8 @@ let non_debug_receive ?debug_callback cnx =
         error "Memory F %Ld KiB S %Ld KiB T %Ld MiB"
           (p.free_pages |> of_nativeint |> kib_of_pages)
           (p.scrub_pages |> of_nativeint |> kib_of_pages)
-          (p.total_pages |> of_nativeint |> mib_of_pages_free))
+          (p.total_pages |> of_nativeint |> mib_of_pages_free)
+    )
   in
   try
     match non_debug_receive ?debug_callback cnx with
@@ -233,7 +237,8 @@ let receive_success ?(debug_callback = fun s -> debug "%s" s) cnx =
       | "hvm_build_params" :: code :: msg ->
           raise
             (Domain_builder_error
-               ("hvm_build_params", int_of_string code, pp msg))
+               ("hvm_build_params", int_of_string code, pp msg)
+            )
       | "hvm_build_mem" :: code :: msg ->
           raise
             (Domain_builder_error ("hvm_build_mem", int_of_string code, pp msg))

--- a/xc/xenops_helpers.ml
+++ b/xc/xenops_helpers.ml
@@ -22,7 +22,8 @@ let with_xc_and_xs f = Xenctrl.with_intf (fun xc -> with_xs (fun xs -> f xc xs))
 
 let with_xc_and_xs_final f cf =
   with_xc_and_xs (fun xc xs ->
-      Xapi_stdext_pervasives.Pervasiveext.finally (fun () -> f xc xs) cf)
+      Xapi_stdext_pervasives.Pervasiveext.finally (fun () -> f xc xs) cf
+  )
 
 exception Domain_not_found
 

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -70,7 +70,8 @@ let choose_qemu_dm x =
     if List.mem_assoc _device_model x then
       Profile.of_string (List.assoc _device_model x)
     else
-      Profile.fallback)
+      Profile.fallback
+  )
 
 (* We allow xenguest to be overriden via a platform flag *)
 let choose_xenguest x = choose_alternative _xenguest !Xc_resources.xenguest x
@@ -208,6 +209,7 @@ module DB = struct
               x
           )
       }
+    
 
   let revision_of vm persistent = persistent |> revise_profile_qemu_trad vm
 end
@@ -258,7 +260,10 @@ let di_of_uuid ~xc ~xs uuid =
         (Xenopsd_error
            (Internal_error
               (Printf.sprintf "More than one domain with uuid (%s): %s" uuid'
-                 domid_list)))
+                 domid_list
+              )
+           )
+        )
 
 let domid_of_uuid ~xc ~xs uuid =
   (* We don't fully control the domain lifecycle because libxenguest will
@@ -280,7 +285,10 @@ let domid_of_uuid ~xc ~xs uuid =
           (Xenopsd_error
              (Internal_error
                 (Printf.sprintf "More than one domain with uuid (%s): %s"
-                   (Uuidm.to_string uuid) domid_list)))
+                   (Uuidm.to_string uuid) domid_list
+                )
+             )
+          )
   with e ->
     error "Failed to read %s: has this domain already been cleaned up?" dir ;
     None
@@ -312,7 +320,9 @@ let params_of_backend backend =
                 ^ (Storage_interface.(rpc_of backend) backend
                   |> Jsonrpc.to_string
                   )
-                )))
+                )
+             )
+          )
   in
   let params, extra_keys =
     match (blockdevs, files, nbds, xendisks) with
@@ -328,7 +338,9 @@ let params_of_backend backend =
                 ^ (Storage_interface.(rpc_of backend) backend
                   |> Jsonrpc.to_string
                   )
-                )))
+                )
+             )
+          )
   in
   (params, xenstore_data, extra_keys)
 
@@ -359,7 +371,9 @@ let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
                   ^ (Storage_interface.(rpc_of backend) vdi.attach_info
                     |> Jsonrpc.to_string
                     )
-                  )))
+                  )
+               )
+            )
     )
   | Some backend_domid ->
       let params, xenstore_data, extra_keys =
@@ -386,7 +400,8 @@ let create_vbd_frontend ~xc ~xs task frontend_domid vdi =
       in
       let device =
         Xenops_task.with_subtask task "Vbd.add" (fun () ->
-            Device.Vbd.add task ~xc ~xs ~hvm:false t frontend_domid)
+            Device.Vbd.add task ~xc ~xs ~hvm:false t frontend_domid
+        )
       in
       Device device
 
@@ -400,7 +415,8 @@ let destroy_vbd_frontend ~xc ~xs task disk =
              this can be safely ignored because we're controlling the frontend
              and all users of it. *)
           Device.Vbd.clean_shutdown_async ~xs device ;
-          Device.Vbd.clean_shutdown_wait task ~xs ~ignore_transients:true device)
+          Device.Vbd.clean_shutdown_wait task ~xs ~ignore_transients:true device
+      )
 
 module Storage = struct
   open Storage
@@ -422,9 +438,12 @@ module Storage = struct
     let backend =
       Xenops_task.with_subtask task
         (Printf.sprintf "Policy.get_backend_vm %s %s %s" vm (Sr.string_of sr)
-           (Vdi.string_of vdi))
+           (Vdi.string_of vdi)
+        )
         (transform_exception (fun () ->
-             Client.Policy.get_backend_vm "attach_and_activate" vm sr vdi))
+             Client.Policy.get_backend_vm "attach_and_activate" vm sr vdi
+         )
+        )
     in
     match domid_of_uuid ~xc ~xs (uuid_of_string backend) with
     | None ->
@@ -483,7 +502,8 @@ module NbdClient = struct
         try stop_nbd_client ~nbd_device
         with e ->
           warn "ignoring exception while disconnecting nbd-client from %s: %s"
-            nbd_device (Printexc.to_string e))
+            nbd_device (Printexc.to_string e)
+      )
 
   let with_nbd_device ~nbd =
     let unix_socket_path, export_name = Storage_interface.parse_nbd_uri nbd in
@@ -521,8 +541,10 @@ let with_disk ~xc ~xs task disk write f =
               | Nbd nbd ->
                   debug "with_disk: using nbd-client for %s"
                     (Storage_interface.(rpc_of nbd) nbd |> Jsonrpc.to_string) ;
-                  NbdClient.with_nbd_device ~nbd f)
-            (fun () -> destroy_vbd_frontend ~xc ~xs task device))
+                  NbdClient.with_nbd_device ~nbd f
+            )
+            (fun () -> destroy_vbd_frontend ~xc ~xs task device)
+        )
         (fun () -> dp_destroy task dp)
 
 module Mem = struct
@@ -542,7 +564,8 @@ module Mem = struct
             let vms =
               List.map (get_uuid ~xc) domids |> List.map Uuidm.to_string
             in
-            raise (Xenopsd_error (Vms_failed_to_cooperate vms)))
+            raise (Xenopsd_error (Vms_failed_to_cooperate vms))
+        )
     | Unix.Unix_error (Unix.ECONNREFUSED, "connect", _) ->
         info
           "ECONNREFUSED talking to squeezed: assuming it has been switched off" ;
@@ -569,7 +592,8 @@ module Mem = struct
         | None ->
             let s = do_login dbg in
             cached_session_id := Some s ;
-            s)
+            s
+    )
 
   (** If we fail to allocate because VMs either failed to co-operate or because
       they are still booting and haven't written their feature-balloon flag then
@@ -612,12 +636,14 @@ module Mem = struct
               in
               debug "Memory reservation size = %Ld (reservation_id = %s)" kib
                 reservation_id ;
-              (reservation_id, kib))
+              (reservation_id, kib)
+          )
         in
         (* Post condition: *)
         assert (reserved_memory >= min) ;
         assert (reserved_memory <= max) ;
-        (reserved_memory, (reservation_id, reserved_memory)))
+        (reserved_memory, (reservation_id, reserved_memory))
+      )
       (get_session_id dbg)
 
   let reserve_memory_range dbg min max : (int64 * (string * int64)) option =
@@ -628,7 +654,8 @@ module Mem = struct
     Option.map
       (fun session_id ->
         debug "delete_reservation %s" reservation_id ;
-        Client.delete_reservation dbg session_id reservation_id)
+        Client.delete_reservation dbg session_id reservation_id
+      )
       (get_session_id dbg)
 
   let delete_reservation dbg r =
@@ -734,7 +761,8 @@ module DeviceCache = struct
   let discard (cache, mutex) domid =
     Mutex.execute mutex (fun () ->
         debug "removing device cache for domid %d" domid ;
-        remove cache domid)
+        remove cache domid
+    )
 
   exception NotFoundIn of string option list
 
@@ -747,7 +775,8 @@ module DeviceCache = struct
             let domid_cache = PerVMCache.create 16 in
             debug "adding device cache for domid %d" domid ;
             replace cache domid domid_cache ;
-            domid_cache)
+            domid_cache
+      )
     in
     Mutex.execute domid_mutex (fun () ->
         let refresh_cache () =
@@ -776,7 +805,8 @@ module DeviceCache = struct
             try PerVMCache.fold (fun k v acc -> k :: acc) domid_cache []
             with _ -> []
           in
-          raise (NotFoundIn keys))
+          raise (NotFoundIn keys)
+    )
 end
 
 let device_cache = DeviceCache.create 256
@@ -961,7 +991,8 @@ module HOST = struct
       , find "flags"
       , find "stepping"
       , find "model"
-      , find "cpu family" )
+      , find "cpu family"
+      )
     in
     let vendor, modelname, speed, flags, stepping, model, family =
       get_cpuinfo ()
@@ -1013,7 +1044,8 @@ module HOST = struct
         ; hypervisor=
             {Host.version= xen_version_string; capabilities= xen_capabilities}
         ; chipset_info= {iommu; hvm}
-        })
+        }
+    )
 
   let stat () =
     match !stat_cache with
@@ -1032,7 +1064,8 @@ module HOST = struct
           x = 13 || x = 10 || (x >= 0x20 && x <= 0x7e)
         in
         Xenctrl.readconsolering xc
-        |> String.mapi (fun i c -> if not (is_printable c) then ' ' else c))
+        |> String.mapi (fun i c -> if not (is_printable c) then ' ' else c)
+    )
 
   let get_total_memory_mib () =
     with_xc_and_xs (fun xc xs ->
@@ -1040,7 +1073,9 @@ module HOST = struct
         Int64.(
           div
             ((Xenctrl.physinfo xc).Xenctrl.total_pages |> of_nativeint)
-            pages_per_mib))
+            pages_per_mib
+        )
+    )
 
   let send_debug_keys keys =
     with_xc_and_xs (fun xc xs -> Xenctrl.send_debug_keys xc keys)
@@ -1068,9 +1103,13 @@ module HOST = struct
                   (if feature.Host.licensed then "1" else "0") ;
                 List.iter
                   (fun (key, value) ->
-                    write_with_perms (Filename.concat parameters_root key) value)
-                  feature.Host.parameters)
-              features))
+                    write_with_perms (Filename.concat parameters_root key) value
+                  )
+                  feature.Host.parameters
+              )
+              features
+        )
+    )
 end
 
 let dB_m = Mutex.create ()
@@ -1086,7 +1125,8 @@ let dm_of ~vm =
             Device.Profile.fallback
         | Some x, _ ->
             x
-      with _ -> Device.Profile.fallback)
+      with _ -> Device.Profile.fallback
+  )
 
 module VM = struct
   open Vm
@@ -1141,7 +1181,8 @@ module VM = struct
   let get_initial_target ~xs domid =
     Int64.of_string
       (xs.Xs.read
-         (Printf.sprintf "/local/domain/%d/memory/initial-target" domid))
+         (Printf.sprintf "/local/domain/%d/memory/initial-target" domid)
+      )
 
   let domain_type_path domid =
     Printf.sprintf "/local/domain/%d/domain-type" domid
@@ -1219,6 +1260,7 @@ module VM = struct
         last_start_time= 0.0
       ; profile= profile_of ~vm
       }
+    
     |> rpc_of VmExtra.persistent_t
     |> Jsonrpc.to_string
 
@@ -1254,13 +1296,17 @@ module VM = struct
         (List.fold_left
            (fun (idx, acc) mask ->
              ( idx + 1
-             , (Printf.sprintf "vcpu/%d/affinity" idx, bitmap mask) :: acc ))
-           (0, []) masks)
+             , (Printf.sprintf "vcpu/%d/affinity" idx, bitmap mask) :: acc
+             )
+           )
+           (0, []) masks
+        )
     in
     let weight =
       vm.scheduler_params.priority
       |> Option.map (fun (w, c) ->
-             [("vcpu/weight", string_of_int w); ("vcpu/cap", string_of_int c)])
+             [("vcpu/weight", string_of_int w); ("vcpu/cap", string_of_int c)]
+         )
       |> Option.value ~default:[]
     in
     let vcpus =
@@ -1268,7 +1314,8 @@ module VM = struct
         ("vcpu/number", string_of_int vm.vcpu_max)
       ; ( "vcpu/current"
         , string_of_int
-            (match vm.ty with PVinPVH _ -> vm.vcpu_max | _ -> vm.vcpus) )
+            (match vm.ty with PVinPVH _ -> vm.vcpu_max | _ -> vm.vcpus)
+        )
       ]
       @ affinity
       @ weight
@@ -1377,8 +1424,10 @@ module VM = struct
                     ; pci_power_mgmt= vm.Vm.pci_power_mgmt
                     ; platformdata= vm.Vm.platformdata
                     }
+                  
                 in
-                Some VmExtra.{persistent})
+                Some VmExtra.{persistent}
+            )
         in
         let _ =
           DB.update k (fun vmextra ->
@@ -1416,7 +1465,8 @@ module VM = struct
                       debug "VM = %s; using stored suspend_memory_bytes = %Ld"
                         vm.Vm.id persistent.VmExtra.suspend_memory_bytes ;
                       ( persistent.VmExtra.suspend_memory_bytes
-                      , persistent.VmExtra.suspend_memory_bytes )
+                      , persistent.VmExtra.suspend_memory_bytes
+                      )
                     ) else (
                       debug
                         "VM = %s; using memory_dynamic_min = %Ld and \
@@ -1441,8 +1491,8 @@ module VM = struct
                            stored some persistent data but it was before we
                            recorded emulation flags. Let's regenerate them now
                            and store them persistently *)
-                        ( (* Sanity check *)
-                        match vm.Xenops_interface.Vm.ty with
+                        (* Sanity check *)
+                        ( match vm.Xenops_interface.Vm.ty with
                         | PVinPVH _ ->
                             failwith
                               "Invalid state! No domain_config persistently \
@@ -1454,6 +1504,7 @@ module VM = struct
                         let persistent =
                           VmExtra.
                             {persistent with domain_config= Some domain_config}
+                          
                         in
                         (domain_config, persistent)
                   in
@@ -1491,9 +1542,12 @@ module VM = struct
                       (i < vm.vcpus)
                   done ;
                   set_domain_type ~xs domid vm ;
-                  Some VmExtra.{persistent}))
+                  Some VmExtra.{persistent}
+              )
+          )
         in
-        ())
+        ()
+    )
 
   let create = create_exn
 
@@ -1504,7 +1558,8 @@ module VM = struct
         | None ->
             raise (Xenopsd_error (Does_not_exist ("domain", vm.Vm.id)))
         | Some di ->
-            f xc xs task vm di)
+            f xc xs task vm di
+    )
 
   let on_domain_if_exists f (task : Xenops_task.task_handle) vm =
     try on_domain f task vm
@@ -1528,25 +1583,31 @@ module VM = struct
               ; ("domid", string_of_int di.Xenctrl.domid)
               ; ("vm", "/vm/" ^ vm.Vm.id)
               ; ( "memory/dynamic-min"
-                , Int64.(to_string (div vm.Vm.memory_dynamic_min 1024L)) )
+                , Int64.(to_string (div vm.Vm.memory_dynamic_min 1024L))
+                )
               ; ( "memory/target"
-                , Int64.(to_string (div vm.Vm.memory_dynamic_min 1024L)) )
+                , Int64.(to_string (div vm.Vm.memory_dynamic_min 1024L))
+                )
               ; ( "memory/dynamic-max"
-                , Int64.(to_string (div vm.Vm.memory_dynamic_max 1024L)) )
+                , Int64.(to_string (div vm.Vm.memory_dynamic_max 1024L))
+                )
               ]
               |> List.map (fun (k, v) ->
-                     (Printf.sprintf "/local/domain/%d/%s" di.Xenctrl.domid k, v))
+                     (Printf.sprintf "/local/domain/%d/%s" di.Xenctrl.domid k, v)
+                 )
             in
             let minimal_vm_kvs =
               [
                 ("uuid", vm.Vm.id)
               ; ("name", vm.Vm.name)
               ; ( Printf.sprintf "domains/%d" di.Xenctrl.domid
-                , Printf.sprintf "/local/domain/%d" di.Xenctrl.domid )
+                , Printf.sprintf "/local/domain/%d" di.Xenctrl.domid
+                )
               ; (Printf.sprintf "domains/%d/create-time" di.Xenctrl.domid, "0")
               ]
               |> List.map (fun (k, v) ->
-                     (Printf.sprintf "/vm/%s/%s" vm.Vm.id k, v))
+                     (Printf.sprintf "/vm/%s/%s" vm.Vm.id k, v)
+                 )
             in
             List.iter
               (fun (k, v) ->
@@ -1558,8 +1619,10 @@ module VM = struct
                 then (
                   debug "xenstore-write %s <- %s" k v ;
                   xs.Xs.write k v
-                ))
-              (minimal_local_kvs @ minimal_vm_kvs))
+                )
+              )
+              (minimal_local_kvs @ minimal_vm_kvs)
+    )
 
   let rename old_name new_name when' =
     with_xc_and_xs @@ fun xc xs ->
@@ -1606,7 +1669,8 @@ module VM = struct
         log_exn_continue "Error stoping vncterm, already dead ?"
           (fun () -> Device.PV_Vnc.stop ~xs domid)
           ()
-        (* If qemu is in a different domain to storage, detach disks *))
+        (* If qemu is in a different domain to storage, detach disks *)
+    )
 
   let destroy =
     on_domain_if_exists (fun xc xs task vm di ->
@@ -1619,7 +1683,8 @@ module VM = struct
               List.filter
                 (fun dev ->
                   let open Device_common in
-                  match dev.frontend.kind with Vbd _ -> true | _ -> false)
+                  match dev.frontend.kind with Vbd _ -> true | _ -> false
+                )
                 devices
             in
             let dps =
@@ -1652,24 +1717,30 @@ module VM = struct
                 try Storage.dp_destroy task dp
                 with e ->
                   warn "Ignoring exception in VM.destroy: %s"
-                    (Printexc.to_string e))
-              dps)
+                    (Printexc.to_string e)
+              )
+              dps
+          )
           (fun () ->
             (* Finally, discard any device caching for the domid destroyed *)
             DeviceCache.discard device_cache di.Xenctrl.domid ;
-            Device.(Qemu.SignalMask.unset Qemu.signal_mask di.Xenctrl.domid)))
+            Device.(Qemu.SignalMask.unset Qemu.signal_mask di.Xenctrl.domid)
+          )
+    )
 
   let pause =
     on_domain (fun xc xs _ _ di ->
         if di.Xenctrl.total_memory_pages = 0n then
           raise (Xenopsd_error Domain_not_built) ;
-        Domain.pause ~xc di.Xenctrl.domid)
+        Domain.pause ~xc di.Xenctrl.domid
+    )
 
   let unpause =
     on_domain (fun xc xs _ _ di ->
         if di.Xenctrl.total_memory_pages = 0n then
           raise (Xenopsd_error Domain_not_built) ;
-        Domain.unpause ~xc di.Xenctrl.domid)
+        Domain.unpause ~xc di.Xenctrl.domid
+    )
 
   let set_xsdata task vm xsdata =
     on_domain
@@ -1697,7 +1768,8 @@ module VM = struct
           for (* need to plug cpus *)
               i = current to target - 1 do
             Device.Vcpu.set ~xs ~dm:(dm_of ~vm) ~devid:i domid true
-          done)
+          done
+      )
       task vm
 
   let set_shadow_multiplier task vm target =
@@ -1721,7 +1793,8 @@ module VM = struct
         if
           not
             (Domain.wait_xen_free_mem xc
-               (Int64.mul (Int64.of_int needed_mib) 1024L))
+               (Int64.mul (Int64.of_int needed_mib) 1024L)
+            )
         then (
           error
             "VM = %s; domid = %d; Failed waiting for Xen to free %d MiB: some \
@@ -1729,12 +1802,14 @@ module VM = struct
             vm.Vm.id domid needed_mib ;
           raise
             (Xenopsd_error
-               (Not_enough_memory
-                  (Memory.bytes_of_mib (Int64.of_int needed_mib))))
+               (Not_enough_memory (Memory.bytes_of_mib (Int64.of_int needed_mib))
+               )
+            )
         ) ;
         debug "VM = %s; domid = %d; shadow_allocation_setto %d MiB" vm.Vm.id
           domid newshadow ;
-        Xenctrl.shadow_allocation_set xc domid newshadow)
+        Xenctrl.shadow_allocation_set xc domid newshadow
+      )
       task vm
 
   let set_memory_dynamic_range task vm min max =
@@ -1745,7 +1820,8 @@ module VM = struct
           ~min:(Int64.to_int (Int64.div min 1024L))
           ~max:(Int64.to_int (Int64.div max 1024L))
           domid ;
-        Mem.balance_memory (Xenops_task.get_dbg task))
+        Mem.balance_memory (Xenops_task.get_dbg task)
+      )
       task vm
 
   let qemu_device_of_vbd_frontend = function
@@ -1786,7 +1862,8 @@ module VM = struct
             | Vgpu, [] ->
                 raise
                   (Xenopsd_error
-                     (Internal_error "Vgpu mode specified but no vGPUs"))
+                     (Internal_error "Vgpu mode specified but no vGPUs")
+                  )
             | Vgpu, vgpus ->
                 Device.Dm.Vgpu vgpus
             | _ ->
@@ -1800,8 +1877,7 @@ module VM = struct
             let static_max_mib =
               Memory.mib_of_kib_used build_info.Domain.memory_max
             in
-            Memory.kib_of_mib
-              (Memory.HVM.build_max_mib static_max_mib video_mib)
+            Memory.kib_of_mib (Memory.HVM.build_max_mib static_max_mib video_mib)
           in
           let open Device.Dm in
           {
@@ -1833,7 +1909,8 @@ module VM = struct
               | Network.Local b | Network.Remote (_, b) ->
                   Some (vif.Vif.mac, b, vif.Vif.position)
               | Network.Sriov _ ->
-                  None)
+                  None
+            )
             vifs
         in
         match ty with
@@ -1863,7 +1940,8 @@ module VM = struct
                     | Vbd.CDROM, _ ->
                         Some (index, path, Cdrom)
                   else
-                    None)
+                    None
+                )
                 vbds
             in
             let usb_enabled =
@@ -1896,7 +1974,8 @@ module VM = struct
                  ?vnc_ip:hvm_info.vnc_ip ~usb ~parallel
                  ~pci_emulations:hvm_info.pci_emulations
                  ~pci_passthrough:hvm_info.pci_passthrough
-                 ~boot_order:hvm_info.boot_order ~nics ~disks ~vgpus ())
+                 ~boot_order:hvm_info.boot_order ~nics ~disks ~vgpus ()
+              )
       )
 
   let clean_memory_reservation task domid =
@@ -1962,7 +2041,8 @@ module VM = struct
                   }
               in
               ( make_build_info !Resources.hvmloader builder_spec_info
-              , hvm_info.timeoffset )
+              , hvm_info.timeoffset
+              )
           | PV {boot= Direct direct} ->
               let builder_spec_info =
                 Domain.BuildPV
@@ -1988,7 +2068,9 @@ module VM = struct
                       }
                   in
                   ( make_build_info b.Bootloader.kernel_path builder_spec_info
-                  , "" ))
+                  , ""
+                  )
+              )
           | PVinPVH {boot= Direct direct} ->
               debug "Checking xen cmdline" ;
               let builder_spec_info =
@@ -2008,6 +2090,7 @@ module VM = struct
                     ; shadow_multiplier= 1.
                     ; video_mib= 0
                     }
+                  
               in
               (make_build_info !Resources.pvinpvh_xen builder_spec_info, "")
           | PVinPVH {boot= Indirect {devices= []}} ->
@@ -2028,7 +2111,8 @@ module VM = struct
                           cmdline= pvinpvh_xen_cmdline
                         ; modules=
                             ( b.Bootloader.kernel_path
-                            , Some b.Bootloader.kernel_args )
+                            , Some b.Bootloader.kernel_args
+                            )
                             ::
                             ( match b.Bootloader.initrd_path with
                             | Some r ->
@@ -2039,8 +2123,10 @@ module VM = struct
                         ; shadow_multiplier= 1.
                         ; video_mib= 0
                         }
+                      
                   in
-                  (make_build_info !Resources.pvinpvh_xen builder_spec_info, ""))
+                  (make_build_info !Resources.pvinpvh_xen builder_spec_info, "")
+              )
         in
         Domain.build task ~xc ~xs ~store_domid ~console_domid ~timeoffset
           ~extras ~vgpus build_info
@@ -2049,7 +2135,8 @@ module VM = struct
         Int64.(
           let min = to_int (div vm.Vm.memory_dynamic_min 1024L)
           and max = to_int (div vm.Vm.memory_dynamic_max 1024L) in
-          Domain.set_memory_dynamic_range ~xc ~xs ~min ~max domid) ;
+          Domain.set_memory_dynamic_range ~xc ~xs ~min ~max domid
+        ) ;
         debug "VM = %s; domid = %d; Domain build completed" vm.Vm.id domid ;
         let _ =
           DB.update_exn vm.Vm.id (fun d ->
@@ -2062,9 +2149,12 @@ module VM = struct
                         build_info= Some build_info
                       ; ty= Some vm.ty
                       }
-                  })
+                  }
+                
+          )
         in
-        ())
+        ()
+      )
       (fun () -> Option.iter Bootloader.delete !kernel_to_cleanup)
 
   let build_domain vm vbds vifs vgpus vusbs extras force xc xs task _ di =
@@ -2115,7 +2205,8 @@ module VM = struct
               Printf.sprintf "VM = %s; domid = %d; Error: %s" vm.Vm.id domid
                 (Printexc.to_string e)
             in
-            debug "%s" m ; raise e)
+            debug "%s" m ; raise e
+      )
       (fun () -> clean_memory_reservation task di.Xenctrl.domid)
 
   let build ?restore_fd task vm vbds vifs vgpus vusbs extras force =
@@ -2140,7 +2231,8 @@ module VM = struct
                 task ~xc ~xs ~dm:qemu_dm info di.Xenctrl.domid ;
               Device.Serial.update_xenstore ~xs di.Xenctrl.domid
           | Vm.PV _ | Vm.PVinPVH _ ->
-              assert false)
+              assert false
+        )
         (create_device_model_config vm vmextra vbds vifs vgpus vusbs) ;
       match vm.Vm.ty with
       | Vm.PV {vncterm= true; vncterm_ip= ip}
@@ -2166,17 +2258,18 @@ module VM = struct
                         xen_platform= Some (xen_platform_of ~vm ~vmextra:d)
                       }
                   }
+                
             | _ ->
                 d
           in
           let () =
             on_domain
-              (create_device_model_exn vbds vifs vgpus vusbs saved_state
-                 vmextra)
+              (create_device_model_exn vbds vifs vgpus vusbs saved_state vmextra)
               task vm
           in
           (* Ensure that the updated vmextra is written back to the DB *)
-          Some vmextra)
+          Some vmextra
+      )
     in
     ()
 
@@ -2201,7 +2294,8 @@ module VM = struct
           Domain.shutdown_wait_for_ack task ~timeout:ack_delay ~xc ~xs domid
             domain_type reason ;
           true
-        with Watch.Timeout _ -> false)
+        with Watch.Timeout _ -> false
+      )
       task vm
 
   let wait_shutdown task vm reason timeout =
@@ -2213,7 +2307,8 @@ module VM = struct
           debug "EVENT on other VM: %s" id ;
           false
       | _ ->
-          debug "OTHER EVENT" ; false)
+          debug "OTHER EVENT" ; false
+      )
 
   (* Mount a filesystem somewhere, with optional type *)
   let mount ?(ty = None) src dest write =
@@ -2253,13 +2348,15 @@ module VM = struct
     finally
       (fun () ->
         mount ~ty:(Some "ext2") device mount_point false ;
-        f mount_point)
+        f mount_point
+      )
       (fun () ->
         ( try umount mount_point
           with e -> debug "Caught %s" (Printexc.to_string e)
         ) ;
         try Unix.rmdir mount_point
-        with e -> debug "Caught %s" (Printexc.to_string e))
+        with e -> debug "Caught %s" (Printexc.to_string e)
+      )
 
   (** open a file, and make sure the close is always done *)
   let with_data ~xc ~xs task data write f =
@@ -2273,7 +2370,8 @@ module VM = struct
                     | `Ok _ ->
                         true
                     | _ ->
-                        false)
+                        false
+                )
               in
               match (write, is_raw_image) with
               | true, _ ->
@@ -2286,7 +2384,8 @@ module VM = struct
                   (* Assume reading from filesystem *)
                   with_mounted_dir_ro p (fun dir ->
                       let filename = dir ^ "/suspend-image" in
-                      Unixext.with_file filename [Unix.O_RDONLY] 0o600 f)
+                      Unixext.with_file filename [Unix.O_RDONLY] 0o600 f
+                  )
             in
             with_fd_of_path path (fun fd ->
                 finally
@@ -2297,7 +2396,10 @@ module VM = struct
                       error
                         "Caught EIO in fsync after suspend; suspend image may \
                          be corrupt" ;
-                      raise (Xenopsd_error IO_error))))
+                      raise (Xenopsd_error IO_error)
+                  )
+            )
+        )
     | FD fd ->
         f fd
 
@@ -2332,8 +2434,10 @@ module VM = struct
             with Watch.Timeout _ ->
               raise
                 (Xenops_interface.Xenopsd_error
-                   Ballooning_timeout_before_migration)
-          ))
+                   Ballooning_timeout_before_migration
+                )
+          )
+      )
       task vm
 
   let assert_can_save vm =
@@ -2343,7 +2447,8 @@ module VM = struct
         | None ->
             failwith (Printf.sprintf "VM %s disappeared" (Uuidm.to_string uuid))
         | Some domid ->
-            Device.Dm.assert_can_suspend ~xs ~dm:(dm_of ~vm) domid)
+            Device.Dm.assert_can_suspend ~xs ~dm:(dm_of ~vm) domid
+    )
 
   let save task progress_callback vm flags data vgpu_data pre_suspend_callback =
     let flags' = List.map (function Live -> Domain.Live) flags in
@@ -2388,7 +2493,8 @@ module VM = struct
                 if not (request_shutdown task vm Suspend 30.) then
                   raise (Xenopsd_error Failed_to_acknowledge_suspend_request) ;
                 if not (wait_shutdown task vm Suspend 1200.) then
-                  raise (Xenopsd_error (Failed_to_suspend (vm.Vm.id, 1200.)))) ;
+                  raise (Xenopsd_error (Failed_to_suspend (vm.Vm.id, 1200.)))
+            ) ;
             (* Record the final memory usage of the domain so we know how much
                to allocate for the resume *)
             let di = Xenctrl.domain_getinfo xc domid in
@@ -2407,7 +2513,8 @@ module VM = struct
                   | Device_common.Vbd _ ->
                       true
                   | _ ->
-                      false)
+                      false
+                )
                 devices
             in
             List.iter (Device.Vbd.hard_shutdown_request ~xs) vbds ;
@@ -2432,7 +2539,10 @@ module VM = struct
                             (Xenopsd_error
                                (Internal_error
                                   (Printf.sprintf
-                                     "Failed to unmarshal VBD backend: %s" m)))
+                                     "Failed to unmarshal VBD backend: %s" m
+                                  )
+                               )
+                            )
                     in
                     let dp = Device.Generic.get_private_key ~xs device _dp_id in
                     match backend with
@@ -2441,8 +2551,10 @@ module VM = struct
                         ()
                     | Some (VDI path) ->
                         let sr, vdi = Storage.get_disk_by_name task path in
-                        Storage.deactivate task dp sr vdi vmid)
-                  vbds_chunk)
+                        Storage.deactivate task dp sr vdi vmid
+                  )
+                  vbds_chunk
+              )
               (Xenops_utils.chunks 10 vbds) ;
             debug "VM = %s; domid = %d; Storing final memory usage" vm.Vm.id
               domid ;
@@ -2456,9 +2568,13 @@ module VM = struct
                             d.persistent with
                             suspend_memory_bytes= Memory.bytes_of_pages pages
                           }
-                      })
+                      }
+                    
+              )
             in
-            ()))
+            ()
+        )
+      )
       task vm
 
   let inject_igmp_query domid vifs =
@@ -2493,8 +2609,7 @@ module VM = struct
               | {VmExtra.build_info= None} ->
                   error "VM = %s; No stored build_info: cannot safely restore"
                     vm.Vm.id ;
-                  raise
-                    (Xenopsd_error (Does_not_exist ("build_info", vm.Vm.id)))
+                  raise (Xenopsd_error (Does_not_exist ("build_info", vm.Vm.id)))
               | {VmExtra.build_info= Some x; VmExtra.ty} ->
                   let initial_target = get_initial_target ~xs domid in
                   let timeoffset =
@@ -2530,10 +2645,10 @@ module VM = struct
                       ~console_domid
                       ~no_incr_generationid (* XXX progress_callback *)
                       ~timeoffset ~extras build_info ~manager_path domid fd
-                      vgpu_fd)
+                      vgpu_fd
+                )
               with e ->
-                error "VM %s: restore failed: %s" vm.Vm.id
-                  (Printexc.to_string e) ;
+                error "VM %s: restore failed: %s" vm.Vm.id (Printexc.to_string e) ;
                 (* As of xen-unstable.hg 779c0ef9682 libxenguest will destroy
                    the domain on failure *)
                 ( if
@@ -2557,27 +2672,31 @@ module VM = struct
             Int64.(
               let min = to_int (div vm.Vm.memory_dynamic_min 1024L)
               and max = to_int (div vm.Vm.memory_dynamic_max 1024L) in
-              Domain.set_memory_dynamic_range ~xc ~xs ~min ~max domid) ;
+              Domain.set_memory_dynamic_range ~xc ~xs ~min ~max domid
+            ) ;
             try inject_igmp_query domid vifs |> ignore
             with e ->
               error "VM %s: inject IGMP query failed: %s" vm.Vm.id
-                (Printexc.to_string e))
-          (fun () -> clean_memory_reservation task di.Xenctrl.domid))
+                (Printexc.to_string e)
+          )
+          (fun () -> clean_memory_reservation task di.Xenctrl.domid)
+      )
       task vm
 
   let s3suspend =
     (* XXX: TODO: monitor the guest's response; track the s3 state *)
     on_domain (fun xc xs task vm di ->
-        Domain.shutdown ~xc ~xs di.Xenctrl.domid Domain.S3Suspend)
+        Domain.shutdown ~xc ~xs di.Xenctrl.domid Domain.S3Suspend
+    )
 
   let s3resume =
     (* XXX: TODO: monitor the guest's response; track the s3 state *)
-    on_domain (fun xc xs task vm di ->
-        Domain.send_s3resume ~xc di.Xenctrl.domid)
+    on_domain (fun xc xs task vm di -> Domain.send_s3resume ~xc di.Xenctrl.domid)
 
   let soft_reset =
     on_domain (fun xc xs task vm di ->
-        Domain.soft_reset ~xc ~xs di.Xenctrl.domid)
+        Domain.soft_reset ~xc ~xs di.Xenctrl.domid
+    )
 
   let get_state vm =
     let uuid = uuid_of_vm vm in
@@ -2604,7 +2723,8 @@ module VM = struct
                   | Device.Socket.Port port ->
                       {Vm.protocol= Vm.Rfb; port; path= ""}
                   | Device.Socket.Unix path ->
-                      {Vm.protocol= Vm.Rfb; port= 0; path})
+                      {Vm.protocol= Vm.Rfb; port= 0; path}
+                  )
                 (Device.get_vnc_port ~xs ~dm:(dm_of ~vm) di.Xenctrl.domid)
             in
             let tc =
@@ -2659,8 +2779,7 @@ module VM = struct
             let rtc =
               try
                 xs.Xs.read
-                  (Printf.sprintf "/vm/%s/rtc/timeoffset"
-                     (Uuidm.to_string uuid))
+                  (Printf.sprintf "/vm/%s/rtc/timeoffset" (Uuidm.to_string uuid))
               with Xs_protocol.Enoent _ -> ""
             in
             let ls_l ~depth root dir =
@@ -2693,7 +2812,8 @@ module VM = struct
                   | Some ((k, v) as entry) ->
                       ( quota
                         - Xenops_utils.xenstore_encoded_entry_size_bytes k v
-                      , entry :: acc )
+                      , entry :: acc
+                      )
                   | None ->
                       (quota, acc)
                 in
@@ -2722,7 +2842,8 @@ module VM = struct
                    (fun acc (dir, excludes, depth) ->
                      ls_lR ?excludes ~depth
                        (Printf.sprintf "/local/domain/%d" di.Xenctrl.domid)
-                       acc dir)
+                       acc dir
+                   )
                    (quota, [])
               |> fun (quota, acc) ->
               (quota, map_tr (fun (k, v) -> (k, Xenops_utils.utf8_recode v)) acc)
@@ -2855,7 +2976,8 @@ module VM = struct
                 | Some x ->
                     List.assoc "featureset" x.VmExtra.persistent.platformdata
                 )
-            })
+            }
+    )
 
   let request_rdp vm enabled =
     let uuid = uuid_of_vm vm in
@@ -2867,7 +2989,8 @@ module VM = struct
             let path =
               Printf.sprintf "/local/domain/%d/control/ts" di.Xenctrl.domid
             in
-            xs.Xs.write path (if enabled then "1" else "0"))
+            xs.Xs.write path (if enabled then "1" else "0")
+    )
 
   let run_script task vm script =
     let uuid = uuid_of_vm vm in
@@ -2885,9 +3008,12 @@ module VM = struct
                     (Xenopsd_error
                        (Unimplemented
                           "run-script is not supported on the given VM (or it \
-                           is still booting)"))
+                           is still booting)"
+                       )
+                    )
               in
-              (di.Xenctrl.domid, path ^ "/control/batcmd"))
+              (di.Xenctrl.domid, path ^ "/control/batcmd")
+      )
     in
     let () =
       with_xc_and_xs (fun xc xs ->
@@ -2902,23 +3028,28 @@ module VM = struct
                 (Xenopsd_error
                    (Failed_to_run_script
                       "A residual run-script instance in progress, either wait \
-                       for its completion or reboot the VM."))
+                       for its completion or reboot the VM."
+                   )
+                )
           | _ ->
               info
                 "Found previous run_script state %s leftover (either not \
                  started or completed), remove."
                 state ;
-              xs.Xs.rm path)
+              xs.Xs.rm path
+      )
     in
     let () =
       Xs.transaction () (fun xs ->
           xs.Xs.write (path ^ "/script") script ;
-          xs.Xs.write (path ^ "/state") "READY")
+          xs.Xs.write (path ^ "/state") "READY"
+      )
     in
     let watch_succ =
       List.map
         (fun s ->
-          Watch.map (fun _ -> ()) (Watch.value_to_become (path ^ "/state") s))
+          Watch.map (fun _ -> ()) (Watch.value_to_become (path ^ "/state") s)
+        )
         ["SUCCESS"; "TRUNCATED"; "FAILURE"]
     in
     let watch_fail = [Watch.key_to_disappear path] in
@@ -2933,7 +3064,8 @@ module VM = struct
           let stdout = try xs.Xs.read (path ^ "/stdout") with _ -> "" in
           let stderr = try xs.Xs.read (path ^ "/stderr") with _ -> "" in
           xs.Xs.rm path ;
-          (succ, flag, rc, stdout, stderr))
+          (succ, flag, rc, stdout, stderr)
+      )
     in
     if not succ then Xenops_task.raise_cancelled task ;
     let truncate s =
@@ -2960,7 +3092,10 @@ module VM = struct
           (Xenopsd_error
              (Failed_to_run_script
                 (Printf.sprintf "flag = %s, rc = %s, stdour = %s, stderr = %s"
-                   flag rc stdout stderr)))
+                   flag rc stdout stderr
+                )
+             )
+          )
 
   let set_domain_action_request vm request =
     let uuid = uuid_of_vm vm in
@@ -2983,7 +3118,8 @@ module VM = struct
                      poweroff"
                     vm.Vm.id ;
                   Some "poweroff"
-              ))
+              )
+    )
 
   let get_domain_action_request vm =
     let uuid = uuid_of_vm vm in
@@ -3024,7 +3160,8 @@ module VM = struct
                   Some Needs_poweroff
               | None ->
                   None
-          ))
+          )
+    )
 
   (* Some hook scripts need to know the domid to avoid confusion when migrating
      vms, now that the behaviour concerning uuids has changed *)
@@ -3034,7 +3171,8 @@ module VM = struct
         | None ->
             []
         | Some domid ->
-            [Xenops_hooks.arg__vmdomid; string_of_int domid])
+            [Xenops_hooks.arg__vmdomid; string_of_int domid]
+    )
 
   let get_internal_state vdi_map vif_map vm =
     let state = DB.read_exn vm.Vm.id in
@@ -3078,7 +3216,9 @@ module VM = struct
           raise
             (Xenopsd_error
                (Internal_error
-                  (Printf.sprintf "Failed to unmarshal persistent_t: %s" m)))
+                  (Printf.sprintf "Failed to unmarshal persistent_t: %s" m)
+               )
+            )
     in
     (* Don't take the timeoffset from [state] (last boot record). Put back the
        one from [vm] which came straight from the platform keys. *)
@@ -3146,7 +3286,8 @@ let on_frontend f frontend =
         | Some x ->
             x
       in
-      f xc xs frontend_di.Xenctrl.domid (VM.get_domain_type ~xs frontend_di))
+      f xc xs frontend_di.Xenctrl.domid (VM.get_domain_type ~xs frontend_di)
+  )
 
 module PCI = struct
   open Pci
@@ -3162,7 +3303,8 @@ module PCI = struct
           | None ->
               []
         in
-        {plugged= List.mem pci_addr all})
+        {plugged= List.mem pci_addr all}
+    )
 
   let get_state vm pci = get_state' vm pci.address
 
@@ -3188,11 +3330,13 @@ module PCI = struct
         let persistent = vm_t.VmExtra.persistent in
         xs.Xs.write
           (Printf.sprintf "/local/domain/0/backend/pci/%d/0/msitranslate"
-             frontend_domid)
+             frontend_domid
+          )
           (if persistent.VmExtra.pci_msitranslate then "1" else "0") ;
         xs.Xs.write
           (Printf.sprintf "/local/domain/0/backend/pci/%d/0/power_mgmt"
-             frontend_domid)
+             frontend_domid
+          )
           (if persistent.VmExtra.pci_power_mgmt then "1" else "0") ;
         if not (Sys.file_exists "/sys/bus/pci/drivers/pciback") then (
           error "PCIBack has not been loaded" ;
@@ -3207,8 +3351,10 @@ module PCI = struct
         let device =
           Device.PCI.
             {host= pci.address; guest= (index, guest_pci); qmp_add= advertise}
+          
         in
-        Device.PCI.add ~xc ~xs ~hvm [device] frontend_domid)
+        Device.PCI.add ~xc ~xs ~hvm [device] frontend_domid
+      )
       vm
 
   let unplug task vm pci =
@@ -3233,7 +3379,8 @@ let set_active_device path active =
       if active then
         xs.Xs.write path "1"
       else
-        safe_rm xs path)
+        safe_rm xs path
+  )
 
 module VGPU = struct
   open Vgpu
@@ -3259,7 +3406,8 @@ module VGPU = struct
           | Some p ->
               p
         in
-        Device.Dm.restore_vgpu task ~xc ~xs frontend_domid vgpus vcpus profile)
+        Device.Dm.restore_vgpu task ~xc ~xs frontend_domid vgpus vcpus profile
+      )
       vm
 
   let active_path vm vgpu =
@@ -3289,7 +3437,8 @@ module VGPU = struct
         | Some pid ->
             {Vgpu.active= true; plugged= true; emulator_pid}
         | None ->
-            {Vgpu.active= get_active vm vgpu; plugged= false; emulator_pid})
+            {Vgpu.active= get_active vm vgpu; plugged= false; emulator_pid}
+      )
       vm
 end
 
@@ -3309,7 +3458,8 @@ module VUSB = struct
         | Some pid, true ->
             {plugged= true}
         | _, _ ->
-            {plugged= false})
+            {plugged= false}
+      )
       vm
 
   let get_device_action_request vm vusb =
@@ -3338,7 +3488,8 @@ module VUSB = struct
           Device.Vusb.vusb_plug ~xs ~privileged ~domid:frontend_domid
             ~id:(snd vusb.Vusb.id) ~hostbus:vusb.Vusb.hostbus
             ~hostport:vusb.Vusb.hostport ~version:vusb.Vusb.version
-            ~speed:vusb.Vusb.speed)
+            ~speed:vusb.Vusb.speed
+      )
       vm
 
   let unplug task vm vusb =
@@ -3348,7 +3499,8 @@ module VUSB = struct
           let privileged = is_privileged vm in
           Device.Vusb.vusb_unplug ~xs ~privileged ~domid:frontend_domid
             ~id:(snd vusb.Vusb.id) ~hostbus:vusb.Vusb.hostbus
-            ~hostport:vusb.Vusb.hostport)
+            ~hostport:vusb.Vusb.hostport
+        )
         vm
     with
     | Xenopsd_error (Does_not_exist (_, _)) ->
@@ -3384,6 +3536,7 @@ module VBD = struct
                     ; BlockDevice {path= ""}
                     ]
                 }
+              
           }
       | Some (Local path) ->
           {
@@ -3397,6 +3550,7 @@ module VBD = struct
                     ; BlockDevice {path}
                     ]
                 }
+              
           }
       | Some (VDI path) ->
           let sr, vdi = Storage.get_disk_by_name task path in
@@ -3441,7 +3595,8 @@ module VBD = struct
             in
             Storage.epoch_begin task sr vdi storage_vm persistent
         | _ ->
-            ())
+            ()
+    )
 
   let epoch_end task vm disk =
     with_xc_and_xs (fun xc xs ->
@@ -3456,7 +3611,8 @@ module VBD = struct
             in
             Storage.epoch_end task sr vdi storage_vm
         | _ ->
-            ())
+            ()
+    )
 
   let _backend_kind = "backend-kind"
 
@@ -3482,15 +3638,16 @@ module VBD = struct
           let _, xenstore_data, _ = params_of_backend vdi.attach_info in
           (* Use the storage manager's preference *)
           if List.mem_assoc _backend_kind xenstore_data then
-            Device_common.kind_of_string
-              (List.assoc _backend_kind xenstore_data)
+            Device_common.kind_of_string (List.assoc _backend_kind xenstore_data)
           else
             Device_common.Vbd !Xenopsd.default_vbd_backend_kind
       | Some (Error (`Msg m)) ->
           raise
             (Xenopsd_error
                (Internal_error
-                  (Printf.sprintf "Error unmarshalling attached_vdi: %s" m)))
+                  (Printf.sprintf "Error unmarshalling attached_vdi: %s" m)
+               )
+            )
 
   let vdi_path_of_device ~xs device =
     Device_common.backend_path_of_device ~xs device ^ "/vdi"
@@ -3571,14 +3728,16 @@ module VBD = struct
                 (fun () ->
                   Device.Vbd.add task ~xc ~xs
                     ~hvm:(domain_type = Vm.Domain_HVM)
-                    x frontend_domid)
+                    x frontend_domid
+                )
             in
             (* We store away the disk so we can implement VBD.stat *)
             Option.iter
               (fun d ->
                 xs.Xs.write
                   (vdi_path_of_device ~xs dev)
-                  (d |> rpc_of disk |> Jsonrpc.to_string))
+                  (d |> rpc_of disk |> Jsonrpc.to_string)
+              )
               vbd.backend ;
             (* NB now the frontend position has been resolved *)
             let open Device_common in
@@ -3632,10 +3791,14 @@ module VBD = struct
                                 qemu_vbds=
                                   (vbd.Vbd.id, q) :: vm_t.persistent.qemu_vbds
                               }
-                          })
+                          }
+                        
+                  )
                 in
-                ())
-              qemu_frontend)
+                ()
+              )
+              qemu_frontend
+        )
         vm
 
   let unplug task vm vbd force =
@@ -3659,12 +3822,10 @@ module VBD = struct
               Some (device_by_id xc xs vm (device_kind_of ~xs vbd) (id_of vbd))
             with
             | Xenopsd_error (Does_not_exist (_, _)) ->
-                debug "VM = %s; VBD = %s; Ignoring missing domain" vm
-                  (id_of vbd) ;
+                debug "VM = %s; VBD = %s; Ignoring missing domain" vm (id_of vbd) ;
                 None
             | Xenopsd_error Device_not_connected ->
-                debug "VM = %s; VBD = %s; Ignoring missing device" vm
-                  (id_of vbd) ;
+                debug "VM = %s; VBD = %s; Ignoring missing device" vm (id_of vbd) ;
                 None
           in
           let backend =
@@ -3685,7 +3846,10 @@ module VBD = struct
                     (Xenopsd_error
                        (Internal_error
                           (Printf.sprintf "Failed to unmarshal VBD backend: %s"
-                             m)))
+                             m
+                          )
+                       )
+                    )
             )
           in
           Option.iter
@@ -3702,7 +3866,9 @@ module VBD = struct
                 (Printf.sprintf "Vbd.clean_shutdown %s" (id_of vbd))
                 (fun () ->
                   (if force then Device.hard_shutdown else Device.clean_shutdown)
-                    task ~xs dev))
+                    task ~xs dev
+                )
+            )
             dev ;
           (* We now have a shutdown device but an active DP: we should destroy
              the DP if the backend is of type VDI *)
@@ -3712,7 +3878,8 @@ module VBD = struct
                 (fun dev ->
                   Xenops_task.with_subtask task
                     (Printf.sprintf "Vbd.release %s" (id_of vbd))
-                    (fun () -> Device.Vbd.release task ~xc ~xs dev))
+                    (fun () -> Device.Vbd.release task ~xc ~xs dev)
+                )
                 dev ;
               (* If we have a qemu frontend, detach this too. *)
               let _ =
@@ -3737,20 +3904,26 @@ module VBD = struct
                                      persistent.qemu_vbds
                                }
                            }
+                         
                        ) else
-                         vm_t))
+                         vm_t
+                   )
+                  )
               in
-              ())
+              ()
+            )
             (fun () ->
               match (domid, backend) with
               | Some x, None | Some x, Some (VDI _) ->
                   Storage.dp_destroy task
                     (Storage.id_of (string_of_int x) vbd.Vbd.id)
               | _ ->
-                  ())
+                  ()
+            )
         with Device_common.Device_error (_, s) ->
           debug "Caught Device_error: %s" s ;
-          raise (Xenopsd_error (Device_detach_rejected ("VBD", id_of vbd, s))))
+          raise (Xenopsd_error (Device_detach_rejected ("VBD", id_of vbd, s)))
+    )
 
   let insert task vm vbd d =
     on_frontend
@@ -3771,7 +3944,8 @@ module VBD = struct
             (vdi_path_of_device ~xs device)
             (d |> rpc_of disk |> Jsonrpc.to_string) ;
           Device.Vbd.media_insert ~xs ~dm:(dm_of ~vm) ~phystype ~params device ;
-          Device_common.add_backend_keys ~xs device "sm-data" xenstore_data)
+          Device_common.add_backend_keys ~xs device "sm-data" xenstore_data
+      )
       vm
 
   let eject task vm vbd =
@@ -3786,7 +3960,9 @@ module VBD = struct
         Storage.dp_destroy task
           (Storage.id_of
              (string_of_int (frontend_domid_of_device device))
-             vbd.Vbd.id))
+             vbd.Vbd.id
+          )
+      )
       vm
 
   let ionice qos pid =
@@ -3812,8 +3988,10 @@ module VBD = struct
                   paths
               with e ->
                 error "Failed to ionice kthread-pid: %s" (Printexc.to_string e)
-            ))
-          vbd.Vbd.qos)
+            )
+            )
+          vbd.Vbd.qos
+    )
 
   let get_qos xc xs vm vbd device =
     try
@@ -3865,7 +4043,9 @@ module VBD = struct
                     raise
                       (Xenopsd_error
                          (Internal_error
-                            (Printf.sprintf "Failed to unmarshal disk: %s" m)))
+                            (Printf.sprintf "Failed to unmarshal disk: %s" m)
+                         )
+                      )
                 )
           in
           {
@@ -3878,7 +4058,8 @@ module VBD = struct
         | Xenopsd_error (Does_not_exist (_, _))
         | Xenopsd_error Device_not_connected
         ->
-          {unplugged_vbd with Vbd.active= get_active vm vbd})
+          {unplugged_vbd with Vbd.active= get_active vm vbd}
+    )
 
   let get_device_action_request vm vbd =
     with_xc_and_xs (fun xc xs ->
@@ -3906,7 +4087,8 @@ module VBD = struct
         with Xenopsd_error Device_not_connected ->
           debug "VM = %s; VBD = %s; Device_not_connected so no action required"
             vm (id_of vbd) ;
-          None)
+          None
+    )
 end
 
 module VIF = struct
@@ -3979,7 +4161,9 @@ module VIF = struct
             (Xenopsd_error
                (Internal_error
                   "Static IPv4 configuration selected, but no address \
-                   specified."))
+                   specified."
+               )
+            )
     in
     let ipv6_setting =
       match vif.ipv6_configuration with
@@ -4001,7 +4185,9 @@ module VIF = struct
             (Xenopsd_error
                (Internal_error
                   "Static IPv6 configuration selected, but no address \
-                   specified."))
+                   specified."
+               )
+            )
     in
     let settings = constant_setting @ ipv4_setting @ ipv6_setting in
     List.map
@@ -4025,10 +4211,13 @@ module VIF = struct
               let open Printf in
               [
                 ( sprintf "pvs-server-%d-addresses" i
-                , String.concat "," server.addresses )
+                , String.concat "," server.addresses
+                )
               ; ( sprintf "pvs-server-%d-ports" i
-                , sprintf "%d-%d" server.first_port server.last_port )
-              ])
+                , sprintf "%d-%d" server.first_port server.last_port
+                )
+              ]
+            )
             srvs
           |> List.flatten
         in
@@ -4084,7 +4273,8 @@ module VIF = struct
           in
           List.iter
             (fun interface ->
-              Interface.DB.write interface.Interface.Interface.name interface)
+              Interface.DB.write interface.Interface.Interface.name interface
+            )
             interfaces ;
           Xenops_task.with_subtask task
             (Printf.sprintf "Vif.add %s" (id_of vif))
@@ -4098,7 +4288,8 @@ module VIF = struct
                     let setup_pvs_proxy_rules =
                       [
                         ( "setup-pvs-proxy-rules"
-                        , !Xc_resources.setup_pvs_proxy_rules )
+                        , !Xc_resources.setup_pvs_proxy_rules
+                        )
                       ]
                     in
                     let pvs_proxy = xenstore_of_pvs_proxy vif.pvs_proxy in
@@ -4131,7 +4322,9 @@ module VIF = struct
                       ~extra_xenserver_keys:(static_ip_setting @ [("mac", mac)])
                       task frontend_domid
                   in
-                  ()))
+                  ()
+            )
+        )
         vm
 
   let plug task vm = plug_exn task vm
@@ -4154,7 +4347,8 @@ module VIF = struct
                     else
                       Device.clean_shutdown
                     )
-                      task ~xs device) ;
+                      task ~xs device
+                  ) ;
                 Xenops_task.with_subtask task
                   (Printf.sprintf "Vif.release %s" (id_of vif))
                   (fun () -> Device.Vif.release task ~xc ~xs device)
@@ -4183,10 +4377,13 @@ module VIF = struct
                                        vm_t.persistent.qemu_vifs
                                  }
                              }
+                           
                        | _, _ ->
                            vm_t
                      else
-                       vm_t))
+                       vm_t
+                 )
+                )
               |> ignore
           | Network.Sriov _ ->
               Xenops_task.with_subtask task
@@ -4201,13 +4398,15 @@ module VIF = struct
           let interfaces = interfaces_of_vif domid vif.id vif.position in
           List.iter
             (fun interface ->
-              Interface.DB.remove interface.Interface.Interface.name)
+              Interface.DB.remove interface.Interface.Interface.name
+            )
             interfaces
         with
         | Xenopsd_error (Does_not_exist (_, _)) ->
             debug "VM = %s; Ignoring missing domain" (id_of vif)
         | Xenopsd_error Device_not_connected ->
-            debug "VM = %s; Ignoring missing device" (id_of vif)) ;
+            debug "VM = %s; Ignoring missing device" (id_of vif)
+    ) ;
     ()
 
   let move task vm vif network =
@@ -4246,17 +4445,20 @@ module VIF = struct
                                     persistent.qemu_vifs
                               }
                           }
+                        
                   | _, _ ->
                       Some vm_t
                 else
-                  Some vm_t)
+                  Some vm_t
+            )
           in
           ()
         with
         | Xenopsd_error (Does_not_exist (_, _)) ->
             debug "VM = %s; Ignoring missing domain" (id_of vif)
         | Xenopsd_error Device_not_connected ->
-            debug "VM = %s; Ignoring missing device" (id_of vif)) ;
+            debug "VM = %s; Ignoring missing device" (id_of vif)
+    ) ;
     ()
 
   let set_carrier task vm vif carrier =
@@ -4276,7 +4478,8 @@ module VIF = struct
         | Xenopsd_error (Does_not_exist (_, _)) ->
             debug "VM = %s; Ignoring missing domain" (id_of vif)
         | Xenopsd_error Device_not_connected ->
-            debug "VM = %s; Ignoring missing device" (id_of vif))
+            debug "VM = %s; Ignoring missing device" (id_of vif)
+    )
 
   let set_locking_mode task vm vif mode =
     with_xc_and_xs (fun xc xs ->
@@ -4308,7 +4511,8 @@ module VIF = struct
             ignore
               (run
                  !Xc_resources.setup_vif_rules
-                 ["classic"; vif_interface_name; vm; devid; "filter"]) ;
+                 ["classic"; vif_interface_name; vm; devid; "filter"]
+              ) ;
             (* Update rules for the tap device if the VM has booted HVM with no
                PV drivers. *)
             let di = Xenctrl.domain_getinfo xc device.frontend.domid in
@@ -4316,7 +4520,9 @@ module VIF = struct
               ignore
                 (run
                    !Xc_resources.setup_vif_rules
-                   ["classic"; tap_interface_name; vm; devid; "filter"]))
+                   ["classic"; tap_interface_name; vm; devid; "filter"]
+                )
+    )
 
   let set_ip_unspecified xs xenstore_path suffix =
     Xs.transaction xs (fun t ->
@@ -4331,7 +4537,8 @@ module VIF = struct
         let ip_setting_gateway =
           Printf.sprintf "%s/%s%s" xenstore_path "gateway" suffix
         in
-        t.Xst.rm ip_setting_gateway)
+        t.Xst.rm ip_setting_gateway
+    )
 
   let set_ip_static xs xenstore_path suffix address gateway =
     Xs.transaction xs (fun t ->
@@ -4351,7 +4558,8 @@ module VIF = struct
             t.Xst.rm ip_setting_gateway
         | Some value ->
             debug "xenstore-write %s <- %s" ip_setting_gateway value ;
-            t.Xst.write ip_setting_gateway value)
+            t.Xst.write ip_setting_gateway value
+    )
 
   let set_ipv4_configuration task vm vif ipv4_configuration =
     with_xc_and_xs (fun xc xs ->
@@ -4371,7 +4579,10 @@ module VIF = struct
               (Xenopsd_error
                  (Internal_error
                     "Static IPv4 configuration selected, but no address \
-                     specified.")))
+                     specified."
+                 )
+              )
+    )
 
   let set_ipv6_configuration task vm vif ipv6_configuration =
     with_xc_and_xs (fun xc xs ->
@@ -4391,7 +4602,10 @@ module VIF = struct
               (Xenopsd_error
                  (Internal_error
                     "Static IPv6 configuration selected, but no address \
-                     specified.")))
+                     specified."
+                 )
+              )
+    )
 
   let set_pvs_proxy task vm vif proxy =
     with_xc_and_xs (fun xc xs ->
@@ -4424,7 +4638,8 @@ module VIF = struct
                    ; vif_interface_name
                    ; private_path
                    ; hotplug_path
-                   ]) ;
+                   ]
+                ) ;
               if VM.get_domain_type ~xs di = Vm.Domain_HVM then
                 try
                   ignore
@@ -4436,7 +4651,8 @@ module VIF = struct
                        ; tap_interface_name
                        ; private_path
                        ; hotplug_path
-                       ])
+                       ]
+                    )
                 with _ ->
                   (* There won't be a tap device if the VM has PV drivers
                      loaded. *)
@@ -4451,13 +4667,17 @@ module VIF = struct
                       if
                         Astring.String.is_prefix ~affix:pvs_proxy_key_prefix key
                       then
-                        t.Xs.rm (Printf.sprintf "%s/%s" private_path key))
-                    keys)
+                        t.Xs.rm (Printf.sprintf "%s/%s" private_path key)
+                    )
+                    keys
+              )
             ) else (
               Xs.transaction xs (fun t ->
-                  t.Xs.writev private_path (xenstore_of_pvs_proxy proxy)) ;
+                  t.Xs.writev private_path (xenstore_of_pvs_proxy proxy)
+              ) ;
               setup "add"
-            ))
+            )
+    )
 
   let get_state vm vif =
     with_xc_and_xs (fun xc xs ->
@@ -4513,7 +4733,8 @@ module VIF = struct
         | Xenopsd_error (Does_not_exist (_, _))
         | Xenopsd_error Device_not_connected
         ->
-          {unplugged_vif with Vif.active= get_active vm vif})
+          {unplugged_vif with Vif.active= get_active vm vif}
+    )
 
   let get_device_action_request vm vif =
     with_xc_and_xs (fun xc xs ->
@@ -4530,7 +4751,8 @@ module VIF = struct
             else
               Some Needs_unplug
           with Xenopsd_error Device_not_connected -> None
-        ))
+        )
+    )
 end
 
 module UPDATES = struct
@@ -4566,7 +4788,9 @@ module Actions = struct
                  VmExtra.{persistent}
              | _ ->
                  extra
-             )))
+             )
+             )
+          )
     in
     ()
 
@@ -4582,7 +4806,8 @@ module Actions = struct
             let pv_drivers_detected =
               match
                 ( value = xenbus_connected
-                , persistent.VmExtra.pv_drivers_detected )
+                , persistent.VmExtra.pv_drivers_detected
+                )
               with
               | true, false ->
                   (* State "connected" (4) means that PV drivers are present for
@@ -4602,9 +4827,11 @@ module Actions = struct
                         try
                           xs.Xs.read
                             (Device_common.backend_state_path_of_device ~xs
-                               device)
+                               device
+                            )
                           = xenbus_connected
-                        with Xs_protocol.Enoent _ -> false)
+                        with Xs_protocol.Enoent _ -> false
+                      )
                       devices
                   in
                   if not found then (* No devices in state "connected" (4) *)
@@ -4620,7 +4847,9 @@ module Actions = struct
                      let persistent =
                        {persistent with VmExtra.pv_drivers_detected}
                      in
-                     VmExtra.{persistent}))
+                     VmExtra.{persistent}
+                     )
+                  )
             in
             if updated then
               Updates.add (Dynamic.Vm vm) internal_updates
@@ -4629,7 +4858,8 @@ module Actions = struct
             ()
             (* the path must have disappeared immediately after the watch fired.
                Let's treat this as if we never saw it. *)
-        ))
+        )
+        )
       (DB.read vm)
 
   let interesting_paths_for_domain domid uuid =
@@ -4672,7 +4902,8 @@ module Actions = struct
     let devid = dev.frontend.devid in
     List.map
       (fun k ->
-        Printf.sprintf "/local/domain/%d/backend/%s/%d/%d/%s" be kind fe devid k)
+        Printf.sprintf "/local/domain/%d/backend/%s/%d/%d/%s" be kind fe devid k
+      )
       interesting_backend_keys
 
   let unmanaged_domain domid id = domid > 0 && not (DB.exists id)
@@ -4689,7 +4920,8 @@ module Actions = struct
     let token = watch_token domid in
     List.iter
       (fun d ->
-        List.iter (Xenstore_watch.unwatch ~xs token) (watches_of_device d))
+        List.iter (Xenstore_watch.unwatch ~xs token) (watches_of_device d)
+      )
       (try IntMap.find domid !device_watches with Not_found -> []) ;
     device_watches := IntMap.remove domid !device_watches ;
     (* Anyone blocked on a domain/device operation which won't happen because
@@ -4870,8 +5102,7 @@ module Actions = struct
           register_rrd_plugin ~domid:(int_of_string domid) ~name ~grant_refs
             ~protocol
         with e ->
-          debug "Failed to register RRD plugin: caught %s"
-            (Printexc.to_string e)
+          debug "Failed to register RRD plugin: caught %s" (Printexc.to_string e)
       )
     | ["local"; "domain"; domid; "rrd"; name; "shutdown"] ->
         let value =
@@ -4897,7 +5128,8 @@ module Actions = struct
             (* Store the rtc/timeoffset for migrate *)
             store_rtc_timeoffset uuid timeoffset ;
             (* Tell the higher-level toolstack about this too *)
-            Updates.add (Dynamic.Vm uuid) internal_updates)
+            Updates.add (Dynamic.Vm uuid) internal_updates
+          )
           timeoffset
     | _ ->
         debug "Ignoring unexpected watch: %s" path
@@ -4980,7 +5212,8 @@ let init () =
   if !Xenopsd.run_hotplug_scripts then
     with_xs (fun xs ->
         xs.Xs.write disable_udev_path "1" ;
-        info "Written %s to disable the hotplug/udev scripts" disable_udev_path) ;
+        info "Written %s to disable the hotplug/udev scripts" disable_udev_path
+    ) ;
   (* XXX: is this completely redundant now? The Citrix PV drivers don't need
      this any more *)
   (* Special XS entry looked for by the XenSource PV drivers (see
@@ -4993,7 +5226,8 @@ let init () =
   with_xs (fun xs ->
       xs.Xs.write xe_key xe_val ;
       xs.Xs.setperms xe_key
-        {Xs_protocol.ACL.owner= 0; other= Xs_protocol.ACL.READ; acl= []}) ;
+        {Xs_protocol.ACL.owner= 0; other= Xs_protocol.ACL.READ; acl= []}
+  ) ;
   Device.Backend.init () ;
   Domain.numa_init () ;
   debug "xenstore is responding to requests" ;
@@ -5010,7 +5244,8 @@ module DEBUG = struct
             | None ->
                 raise (Xenopsd_error (Does_not_exist ("domain", k)))
             | Some di ->
-                Xenctrl.domain_shutdown xc di.Xenctrl.domid Xenctrl.Reboot)
+                Xenctrl.domain_shutdown xc di.Xenctrl.domid Xenctrl.Reboot
+        )
     | _ ->
         debug "DEBUG.trigger cmd=%s Unimplemented" cmd ;
         raise (Xenopsd_error (Unimplemented cmd))

--- a/xc/xenstore_readdir.ml
+++ b/xc/xenstore_readdir.ml
@@ -57,7 +57,8 @@ let ls ~xs = function
           for i = String.length path to longest + 5 do
             print_string " "
           done ;
-          print_endline (Xsraw.string_of_perms perm))
+          print_endline (Xsraw.string_of_perms perm)
+        )
         paths
   | _ ->
       failwith "ls takes exactly one argument"
@@ -125,9 +126,11 @@ let _ =
       if !mode = "" then
         mode := x
       else
-        paths := x :: !paths)
+        paths := x :: !paths
+    )
     (Printf.sprintf "Manipulate xenstore\nAvailable commands are:\n%s\n"
-       (available_commands ())) ;
+       (available_commands ())
+    ) ;
   let paths = List.rev !paths in
   let mode = !mode in
   let xs = Xs.daemon_open () in


### PR DESCRIPTION
Current development for xenopsd happens in xapi.git, where xenopsd has
been integrated. To facilitate backports, reformat xenopsd to the same
format used currently in xapi.git.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>