### PR TITLE
CP-43468: push CPUID logic down from xapi into xenopsd

### DIFF
--- a/cpuid/cpuid.ml
+++ b/cpuid/cpuid.ml
@@ -1,0 +1,81 @@
+(*
+ * Copyright (C) Cloud Software Group.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+let string_of_features features =
+  Array.map (Printf.sprintf "%08Lx") features
+  |> Array.to_list
+  |> String.concat "-"
+
+exception InvalidFeatureString of string
+
+let features_of_string str =
+  let scanf fmt s = Scanf.sscanf s fmt (fun x -> x) in
+  try
+    String.split_on_char '-' str
+    |> (fun lst -> if lst = [""] then [] else lst)
+    |> Array.of_list
+    |> Array.map (scanf "%08Lx%!")
+  with _ -> raise (InvalidFeatureString str)
+
+(** If arr0 is shorter than arr1, extend arr0 with elements from arr1 up to the
+ *  length of arr1. Otherwise, truncate arr0 to the length of arr1. *)
+let extend arr0 arr1 =
+  let new_arr = Array.copy arr1 in
+  let len = min (Array.length arr0) (Array.length arr1) in
+  Array.blit arr0 0 new_arr 0 len ;
+  new_arr
+
+(** If arr is shorter than len elements, extend with zeros up to len elements.
+ *  Otherwise, truncate arr to len elements. *)
+let zero_extend arr len =
+  let zero_arr = Array.make len 0L in
+  extend arr zero_arr
+
+let features_op2 f a b =
+  let n = max (Array.length a) (Array.length b) in
+  Array.map2 f (zero_extend a n) (zero_extend b n)
+
+(** Calculate the intersection of two feature sets.
+ *  Intersection with the empty set is treated as identity, so that intersection
+ *  can be folded easily starting with an accumulator of [||].
+ *  If both sets are non-empty and of differing lengths, and one set is longer
+ *  than the other, the shorter one is zero-extended to match it.
+ *  The returned set is the same length as the longer of the two arguments.  *)
+let intersect left right =
+  match (left, right) with
+  | [||], _ ->
+      right
+  | _, [||] ->
+      left
+  | _, _ ->
+      features_op2 Int64.logand left right
+
+(** Calculate the features that are missing from [right],
+  * but present in [left] *)
+let diff left right =
+  let diff64 a b = Int64.(logand a (lognot b)) in
+  features_op2 diff64 left right
+
+(** equality check that zero-extends if lengths differ *)
+let is_equal left right =
+  let len = max (Array.length left) (Array.length right) in
+  zero_extend left len = zero_extend right len
+
+(** is_subset left right returns true if left is a subset of right *)
+let is_subset left right = is_equal (intersect left right) left
+
+(** is_strict_subset left right returns true if left is a strict subset of right
+    (left is a subset of right, but left and right are not equal) *)
+let is_strict_subset left right =
+  is_subset left right && not (is_equal left right)

--- a/cpuid/cpuid.mli
+++ b/cpuid/cpuid.mli
@@ -1,0 +1,33 @@
+(*
+ * Copyright (C) Cloud Software Group.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+exception InvalidFeatureString of string
+
+val string_of_features : int64 array -> string
+
+val features_of_string : string -> int64 array
+
+val extend : int64 array -> int64 array -> int64 array
+
+val zero_extend : int64 array -> int -> int64 array
+
+val intersect : int64 array -> int64 array -> int64 array
+
+val diff : int64 array -> int64 array -> int64 array
+
+val is_equal : int64 array -> int64 array -> bool
+
+val is_subset : int64 array -> int64 array -> bool
+
+val is_strict_subset : int64 array -> int64 array -> bool

--- a/cpuid/dune
+++ b/cpuid/dune
@@ -1,0 +1,7 @@
+(library
+ (name cpuid)
+ (libraries
+   xapi-idl
+ )
+ (wrapped false)
+)

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -3119,6 +3119,28 @@ module HOST = struct
         B.HOST.update_guest_agent_features features
       )
       ()
+
+  let combine_cpu_policies _ dbg policy1 policy2 =
+    Debug.with_thread_associated dbg
+      (fun () ->
+        debug "HOST.combine_cpu_policies %s %s"
+          (CPU_policy.to_string policy1)
+          (CPU_policy.to_string policy2) ;
+        let module B = (val get_backend () : S) in
+        B.HOST.combine_cpu_policies policy1 policy2
+      )
+      ()
+
+  let is_compatible _ dbg vm_policy host_policy =
+    Debug.with_thread_associated dbg
+      (fun () ->
+        debug "HOST.is_compatible %s %s"
+          (CPU_policy.to_string vm_policy)
+          (CPU_policy.to_string host_policy) ;
+        let module B = (val get_backend () : S) in
+        B.HOST.is_compatible vm_policy host_policy
+      )
+      ()
 end
 
 module VM = struct
@@ -3640,6 +3662,8 @@ let _ =
   Server.HOST.send_debug_keys (HOST.send_debug_keys ()) ;
   Server.HOST.set_worker_pool_size (HOST.set_worker_pool_size ()) ;
   Server.HOST.update_guest_agent_features (HOST.update_guest_agent_features ()) ;
+  Server.HOST.combine_cpu_policies (HOST.combine_cpu_policies ()) ;
+  Server.HOST.is_compatible (HOST.is_compatible ()) ;
   Server.VM.add (VM.add ()) ;
   Server.VM.remove (VM.remove ()) ;
   Server.VM.migrate (VM.migrate ()) ;

--- a/lib/xenops_server.ml
+++ b/lib/xenops_server.ml
@@ -1214,23 +1214,17 @@ let import_metadata id md =
        give it a featureset that contains all features that this host has
        to offer. *)
     if not (List.mem_assoc "featureset" platformdata) then (
-      let string_of_features features =
-        Array.map (Printf.sprintf "%08Lx") features
-        |> Array.to_list
-        |> String.concat "-"
-      in
       let fs =
         let stat = B.HOST.stat () in
-        ( match md.Metadata.vm.Vm.ty with
+        match md.Metadata.vm.Vm.ty with
         | HVM _ | PVinPVH _ ->
             Host.(stat.cpu_info.features_hvm)
         | PV _ ->
             Host.(stat.cpu_info.features_pv)
-        )
-        |> string_of_features
       in
-      debug "Setting Platformdata:featureset=%s" fs ;
-      ("featureset", fs) :: platformdata
+      let fs' = CPU_policy.to_string fs in
+      debug "Setting Platformdata:featureset=%s" fs' ;
+      ("featureset", fs') :: platformdata
     ) else
       platformdata
   in

--- a/lib/xenops_server_plugin.ml
+++ b/lib/xenops_server_plugin.ml
@@ -64,6 +64,11 @@ module type S = sig
     val send_debug_keys : string -> unit
 
     val update_guest_agent_features : Host.guest_agent_feature list -> unit
+
+    val combine_cpu_policies :
+      [`host] CPU_policy.t -> [`host] CPU_policy.t -> [`host] CPU_policy.t
+
+    val is_compatible : [`vm] CPU_policy.t -> [`host] CPU_policy.t -> bool
   end
 
   module VM : sig

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -33,11 +33,11 @@ module HOST = struct
         ; model= ""
         ; stepping= ""
         ; flags= ""
-        ; features= [||]
-        ; features_pv= [||]
-        ; features_hvm= [||]
-        ; features_pv_host= [||]
-        ; features_hvm_host= [||]
+        ; features= CPU_policy.of_string `host ""
+        ; features_pv= CPU_policy.of_string `host ""
+        ; features_hvm= CPU_policy.of_string `host ""
+        ; features_pv_host= CPU_policy.of_string `host ""
+        ; features_hvm_host= CPU_policy.of_string `host ""
         }
     ; hypervisor= {Host.version= ""; capabilities= ""}
     ; chipset_info= {iommu= false; hvm= false}

--- a/lib/xenops_server_skeleton.ml
+++ b/lib/xenops_server_skeleton.ml
@@ -50,6 +50,10 @@ module HOST = struct
   let send_debug_keys _ = ()
 
   let update_guest_agent_features _ = ()
+
+  let combine_cpu_policies _ _ = CPU_policy.of_string `host ""
+
+  let is_compatible _ _ = false
 end
 
 module VM = struct

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,6 @@
 (executable
  (name test)
- (libraries alcotest xenopsd)
+ (libraries alcotest cpuid xapi-test-utils xenopsd)
  (preprocess
   (pps ppx_deriving_rpc ppx_sexp_conv)
  )

--- a/test/test.ml
+++ b/test/test.ml
@@ -1043,4 +1043,4 @@ let _ =
     )
   in
   Debug.log_to_stdout () ;
-  Alcotest.run "xenops test" [suite; Test_topology.suite]
+  Alcotest.run "xenops test" ([suite; Test_topology.suite] @ Test_cpuid.tests)

--- a/test/test_cpuid.ml
+++ b/test/test_cpuid.ml
@@ -1,0 +1,329 @@
+(*
+ * Copyright (C) Cloud Software Group.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+open Test_highlevel
+open Cpuid
+
+module StringOfFeatures = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int64 array
+
+    type output_t = string
+
+    let string_of_input_t = Test_printers.(array int64)
+
+    let string_of_output_t = Test_printers.string
+  end
+
+  let transform = string_of_features
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        ([|0L; 2L; 123L|], "00000000-00000002-0000007b")
+      ; ([|0L|], "00000000")
+      ; ([||], "")
+      ]
+end)
+
+module FeaturesOfString = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = string
+
+    type output_t = int64 array
+
+    let string_of_input_t = Test_printers.string
+
+    let string_of_output_t = Test_printers.(array int64)
+  end
+
+  let transform = features_of_string
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        ("00000000-00000002-0000007b", [|0L; 2L; 123L|])
+      ; ("00000000", [|0L|])
+      ; ("", [||])
+      ]
+end)
+
+module RoundTripFeaturesToFeatures = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int64 array
+
+    type output_t = int64 array
+
+    let string_of_input_t = Test_printers.(array int64)
+
+    let string_of_output_t = Test_printers.(array int64)
+  end
+
+  let transform x = x |> string_of_features |> features_of_string
+
+  let tests =
+    `QuickAndAutoDocumented
+      (List.map (fun x -> (x, x)) [[|0L; 1L; 123L|]; [|1L|]; [|0L|]; [||]])
+end)
+
+module RoundTripStringToString = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = string
+
+    type output_t = string
+
+    let string_of_input_t = Test_printers.string
+
+    let string_of_output_t = Test_printers.string
+  end
+
+  let transform x = x |> features_of_string |> string_of_features
+
+  let tests =
+    `QuickAndAutoDocumented
+      (List.map
+         (fun x -> (x, x))
+         ["00000000-00000002-0000007b"; "00000001"; "00000000"; ""]
+      )
+end)
+
+module ParseFailure = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = string
+
+    type output_t = exn
+
+    let string_of_input_t = Test_printers.string
+
+    let string_of_output_t = Test_printers.exn
+  end
+
+  exception NoExceptionRaised
+
+  let transform x =
+    try
+      ignore (features_of_string x) ;
+      raise NoExceptionRaised
+    with e -> e
+
+  let tests =
+    `QuickAndAutoDocumented
+      (List.map
+         (fun x -> (x, InvalidFeatureString x))
+         ["foo bar baz"; "fgfg-1234"; "0123-foo"; "foo-0123"; "-1234"; "1234-"]
+      )
+end)
+
+module Extend = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int64 array * int64 array
+
+    type output_t = int64 array
+
+    let string_of_input_t = Test_printers.(pair (array int64) (array int64))
+
+    let string_of_output_t = Test_printers.(array int64)
+  end
+
+  let transform (arr0, arr1) = extend arr0 arr1
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        (([||], [||]), [||])
+      ; (([||], [|0L; 2L|]), [|0L; 2L|])
+      ; (([|1L|], [||]), [||])
+      ; (([|1L|], [|0L|]), [|1L|])
+      ; (([|1L|], [|0L; 2L|]), [|1L; 2L|])
+      ; (([|1L; 0L|], [|0L; 2L|]), [|1L; 0L|])
+      ; (([|1L; 0L|], [|0L; 2L; 4L; 9L|]), [|1L; 0L; 4L; 9L|])
+      ]
+end)
+
+module ZeroExtend = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int64 array * int
+
+    type output_t = int64 array
+
+    let string_of_input_t = Test_printers.(pair (array int64) int)
+
+    let string_of_output_t = Test_printers.(array int64)
+  end
+
+  let transform (arr, len) = zero_extend arr len
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        (([|1L|], 2), [|1L; 0L|])
+      ; (([|1L|], 1), [|1L|])
+      ; (([||], 2), [|0L; 0L|])
+      ; (([||], 1), [|0L|])
+      ; (([||], 0), [||])
+      ; (([|1L; 2L|], 0), [||])
+      ; (([|1L; 2L|], 1), [|1L|])
+      ; (([|1L; 2L|], 2), [|1L; 2L|])
+      ]
+end)
+
+module Intersect = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int64 array * int64 array
+
+    type output_t = int64 array
+
+    let string_of_input_t = Test_printers.(pair (array int64) (array int64))
+
+    let string_of_output_t = Test_printers.(array int64)
+  end
+
+  let transform (a, b) = intersect a b
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        (* Intersect should follow monoid laws - identity and commutativity *)
+        (([||], [||]), [||])
+      ; (([|1L; 2L; 3L|], [||]), [|1L; 2L; 3L|])
+      ; (([||], [|1L; 2L; 3L|]), [|1L; 2L; 3L|])
+      ; (([|7L; 3L|], [|5L|]), [|5L; 0L|])
+      ; (([|5L|], [|7L; 3L|]), [|5L; 0L|])
+      ; (([|1L|], [|1L|]), [|1L|])
+      ; (([|1L|], [|1L; 0L|]), [|1L; 0L|])
+      ; (([|1L; 2L; 3L|], [|1L; 1L; 1L|]), [|1L; 0L; 1L|])
+      ; (([|1L; 2L; 3L|], [|0L; 0L; 0L|]), [|0L; 0L; 0L|])
+      ; (([|0b00000000L|], [|0b11111111L|]), [|0b00000000L|])
+      ; (([|0b11111111L|], [|0b11111111L|]), [|0b11111111L|])
+      ; (([|0b01111111L|], [|0b11111111L|]), [|0b01111111L|])
+      ; (([|0b00000111L|], [|0b00001111L|]), [|0b00000111L|])
+      ; (([|0b00011111L|], [|0b00001111L|]), [|0b00001111L|])
+      ; ( ([|0b00000000L; 0b11111111L|], [|0b11111111L; 0b00000000L|])
+        , [|0b00000000L; 0b00000000L|]
+        )
+      ; ( ([|0b11111111L; 0b01010101L|], [|0b11111111L; 0b01010101L|])
+        , [|0b11111111L; 0b01010101L|]
+        )
+      ; ( ([|0b01111111L; 0b10000000L|], [|0b11111111L; 0b00000000L|])
+        , [|0b01111111L; 0b00000000L|]
+        )
+      ; ( ([|0b00000111L; 0b11100000L|], [|0b00001111L; 0b11110000L|])
+        , [|0b00000111L; 0b11100000L|]
+        )
+      ]
+end)
+
+module Equality = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int64 array * int64 array
+
+    type output_t = bool
+
+    let string_of_input_t = Test_printers.(pair (array int64) (array int64))
+
+    let string_of_output_t = Test_printers.bool
+  end
+
+  let transform (a, b) = is_equal a b
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        (([||], [||]), true)
+      ; (([|1L; 2L; 3L|], [|1L; 2L; 3L|]), true)
+      ; (([|1L; 2L; 3L|], [||]), false)
+      ; (([||], [|1L; 2L; 3L|]), false)
+      ; (([|7L; 0L|], [|7L|]), true)
+      ; (([|7L|], [|7L; 0L|]), true)
+      ; (([|7L; 1L; 0L|], [|7L; 1L|]), true)
+      ; (([|7L; 1L|], [|7L; 1L|]), true)
+      ; (([|7L; 1L|], [|7L|]), false)
+      ; (([|7L|], [|7L; 1L|]), false)
+      ; (([|1L; 7L|], [|7L; 1L|]), false)
+      ]
+end)
+
+module Comparisons = Generic.MakeStateless (struct
+  module Io = struct
+    type input_t = int64 array * int64 array
+
+    type output_t = bool * bool
+
+    let string_of_input_t = Test_printers.(pair (array int64) (array int64))
+
+    let string_of_output_t = Test_printers.(pair bool bool)
+  end
+
+  let transform (a, b) = (is_subset a b, is_strict_subset a b)
+
+  let tests =
+    `QuickAndAutoDocumented
+      [
+        (* The following are counterintuitive, because intersection with the empty
+         * set is treated as identity, and intersection is used in is_subset.
+         * Since there are no empty feature sets in reality, these are artificial
+         * scenarios. *)
+        (([||], [||]), (true, false))
+      ; (([|1L; 2L; 3L|], [||]), (true, true))
+      ; (([||], [|1L; 2L; 3L|]), (false, false))
+      ; (* Note that feature flags are automatically zero-extended when compared.
+         * These tests are relevant in upgrade scenarios, if new CPUID leaves are
+         * introduced. *)
+        (([|7L; 3L|], [|5L|]), (false, false))
+      ; (([|5L|], [|7L; 3L|]), (true, true))
+      ; (([|1L|], [|1L|]), (true, false))
+      ; (([|1L|], [|1L; 0L|]), (true, false))
+      ; (([|1L; 0L|], [|1L|]), (true, false))
+      ; (* Below are the more common cases *)
+        ( ( features_of_string
+              "07cbfbff-04082201-20100800-00000001-00000000-00000000-00000000-00000000-00000000"
+          , features_of_string
+              "07c9cbf5-80082201-20100800-00000001-00000000-00000000-00000000-00000000-00000000"
+          )
+        , (false, false)
+        )
+      ; (([|0b00000000L|], [|0b11111111L|]), (true, true))
+      ; (([|0b11111111L|], [|0b11111111L|]), (true, false))
+      ; (([|0b01111111L|], [|0b11111111L|]), (true, true))
+      ; (([|0b00000111L|], [|0b00001111L|]), (true, true))
+      ; (([|0b00011111L|], [|0b00001111L|]), (false, false))
+      ; ( ([|0b00000000L; 0b11111111L|], [|0b11111111L; 0b00000000L|])
+        , (false, false)
+        )
+      ; ( ([|0b11111111L; 0b01010101L|], [|0b11111111L; 0b01010101L|])
+        , (true, false)
+        )
+      ; ( ([|0b01111111L; 0b10000000L|], [|0b11111111L; 0b00000000L|])
+        , (false, false)
+        )
+      ; ( ([|0b00000111L; 0b11100000L|], [|0b00001111L; 0b11110000L|])
+        , (true, true)
+        )
+      ]
+end)
+
+let tests =
+  make_suite "cpuid_"
+    [
+      ("string_of_features", StringOfFeatures.tests)
+    ; ("features_of_string", FeaturesOfString.tests)
+    ; ("roundtrip_features_to_features", RoundTripFeaturesToFeatures.tests)
+    ; ("roundtrip_string_to_features", RoundTripStringToString.tests)
+    ; ("parse_failure", ParseFailure.tests)
+    ; ("extend", Extend.tests)
+    ; ("zero_extend", ZeroExtend.tests)
+    ; ("intersect", Intersect.tests)
+    ; ("equality", Equality.tests)
+    ; ("comparisons", Comparisons.tests)
+    ]

--- a/test/test_cpuid.mli
+++ b/test/test_cpuid.mli
@@ -1,0 +1,15 @@
+(*
+ * Copyright (C) Cloud Software Group.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; version 2.1 only. with the special
+ * exception on linking described in file LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *)
+
+val tests : unit Alcotest.test list

--- a/xc/dune
+++ b/xc/dune
@@ -7,6 +7,7 @@
  (libraries
    astring
    core.linux_ext
+   cpuid
    xenctrl
    xapi-xenopsd
    xenstore

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1110,6 +1110,27 @@ module HOST = struct
               features
         )
     )
+
+  let combine_cpu_policies policy1 policy2 =
+    let open Cpuid in
+    intersect
+      (policy1 |> CPU_policy.to_string |> features_of_string)
+      (policy2 |> CPU_policy.to_string |> features_of_string)
+    |> string_of_features
+    |> CPU_policy.of_string `host
+
+  let is_compatible vm_policy host_policy =
+    let open Cpuid in
+    let vm = vm_policy |> CPU_policy.to_string |> features_of_string in
+    let host = host_policy |> CPU_policy.to_string |> features_of_string in
+    let vm' = zero_extend vm (Array.length host) in
+    let compatible = is_subset vm' host in
+    if not compatible then
+      info
+        "The VM's CPU policy is not compatible with the target host's. The \
+         host is missing: %s"
+        (diff vm' host |> string_of_features) ;
+    compatible
 end
 
 let dB_m = Mutex.create ()

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1023,6 +1023,9 @@ module HOST = struct
         let xen_capabilities = version_capabilities xc in
         let iommu = List.mem CAP_DirectIO p.capabilities in
         let hvm = List.mem CAP_HVM p.capabilities in
+        let features_to_policy x =
+          x |> Cpuid.string_of_features |> CPU_policy.of_string `host
+        in
         {
           Host.cpu_info=
             {
@@ -1035,11 +1038,11 @@ module HOST = struct
             ; model
             ; stepping
             ; flags
-            ; features
-            ; features_pv
-            ; features_hvm
-            ; features_hvm_host
-            ; features_pv_host
+            ; features= features_to_policy features
+            ; features_pv= features_to_policy features_pv
+            ; features_hvm= features_to_policy features_hvm
+            ; features_hvm_host= features_to_policy features_hvm_host
+            ; features_pv_host= features_to_policy features_pv_host
             }
         ; hypervisor=
             {Host.version= xen_version_string; capabilities= xen_capabilities}
@@ -3218,7 +3221,9 @@ module VM = struct
         let fs' =
           fs
           |> Featureset.of_string
-          |> Featureset.zero_pad host_featureset
+          |> Featureset.(
+               host_featureset |> CPU_policy.to_string |> of_string |> zero_pad
+             )
           |> snd
           |> Featureset.to_string
         in


### PR DESCRIPTION
Backport of https://github.com/xapi-project/xen-api/pull/5076.

Depends on:
* https://github.com/xapi-project/xen-api/pull/5091
* https://github.com/xapi-project/xcp-idl/pull/336