### PR TITLE
Offload VM CPU Policy checks to Xen

### DIFF
--- a/c_stubs/xenctrlext_stubs.c
+++ b/c_stubs/xenctrlext_stubs.c
@@ -29,6 +29,10 @@
 #include <caml/callback.h>
 #include <caml/unixsupport.h>
 
+/* From OCaml 4.12 */
+#define Val_none Val_int(0)
+#define Tag_some 0
+
 #define _H(__h) ((xc_interface *)(__h))
 #define _D(__d) ((uint32_t)Int_val(__d))
 
@@ -390,6 +394,96 @@ CAMLprim value stub_xenctrlext_cputopoinfo(value xch)
             Store_field(result, i, topo);
         }
         free(cputopo);
+
+	CAMLreturn(result);
+}
+
+/*
+ * Convert an Ocaml int64 array to a C uint32_t array, zero extending as
+ * necessary.
+ */
+static void ocaml_int64_array_to_c_array(value o, uint32_t *c, mlsize_t c_len)
+{
+	mlsize_t i, o_len = caml_array_length(o);
+
+	for (i = 0; i < o_len; ++i)
+		c[i] = Int64_val(Field(o, i));
+	for (; i < c_len; ++i)
+		c[i] = 0;
+}
+
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+
+__attribute__((weak))
+void xc_combine_cpu_featuresets(
+	const uint32_t *p1, const uint32_t *p2, uint32_t *out, size_t len);
+
+/* int64 array (p1) -> int64 array (p2) -> int64 array (new) */
+CAMLprim value stub_xenctrlext_combine_cpu_featuresets(value p1, value p2)
+{
+	CAMLparam2(p1, p2);
+	CAMLlocal1(result);
+
+	mlsize_t p1_len = caml_array_length(p1);
+	mlsize_t p2_len = caml_array_length(p2);
+	mlsize_t len = MAX(p1_len, p2_len);
+	mlsize_t i;
+
+	uint32_t c_p1[len], c_p2[len], c_out[len];
+
+	if (!xc_combine_cpu_featuresets)
+		raise_unix_errno_msg(ENOSYS, "xc_combine_cpu_featuresets");
+
+	if (len == 0)
+		CAMLreturn(Atom(0));
+
+	ocaml_int64_array_to_c_array(p1, c_p1, len);
+	ocaml_int64_array_to_c_array(p2, c_p2, len);
+
+	xc_combine_cpu_featuresets(c_p1, c_p2, c_out, len);
+
+	/* Turn c_out back into an Ocaml int64 array. */
+	result = caml_alloc(len, 0);
+	for ( i = 0; i < len; ++i )
+		Store_field(result, i, caml_copy_int64(c_out[i]));
+
+	CAMLreturn(result);
+}
+
+__attribute__((weak))
+const char *xc_cpu_featuresets_are_compatible(
+	const uint32_t *vm, const uint32_t *host, size_t len, char err[128]);
+
+/* int64 array (vm) -> int64 array (host) -> string option (None on success, string on failure) */
+CAMLprim value stub_xenctrlext_featuresets_are_compatible(value vm, value host)
+{
+	CAMLparam2(vm, host);
+	CAMLlocal1(result);
+
+	mlsize_t vm_len = caml_array_length(vm);
+	mlsize_t host_len = caml_array_length(host);
+	mlsize_t len = MAX(vm_len, host_len);
+
+	uint32_t c_vm[len], c_host[len];
+	char msg[128];
+	const char *err;
+
+	if (!xc_cpu_featuresets_are_compatible)
+		raise_unix_errno_msg(ENOSYS, "xc_cpu_featuresets_are_compatible");
+
+	ocaml_int64_array_to_c_array(vm, c_vm, len);
+	ocaml_int64_array_to_c_array(host, c_host, len);
+
+	err = xc_cpu_featuresets_are_compatible(c_vm, c_host, len, msg);
+
+	if (!err)
+		result = Val_none;
+	else {
+		result = caml_alloc_small(1, Tag_some);
+		Store_field(result, 0, caml_copy_string(err));
+	}
 
 	CAMLreturn(result);
 }

--- a/xc/xenctrlext.ml
+++ b/xc/xenctrlext.ml
@@ -82,3 +82,9 @@ type cputopo = {core: int; socket: int; node: int}
 external numainfo : handle -> numainfo = "stub_xenctrlext_numainfo"
 
 external cputopoinfo : handle -> cputopo array = "stub_xenctrlext_cputopoinfo"
+
+external combine_cpu_policies : int64 array -> int64 array -> int64 array
+  = "stub_xenctrlext_combine_cpu_featuresets"
+
+external policy_is_compatible : int64 array -> int64 array -> string option
+  = "stub_xenctrlext_featuresets_are_compatible"

--- a/xc/xenctrlext.mli
+++ b/xc/xenctrlext.mli
@@ -78,3 +78,9 @@ external vcpu_setaffinity_soft : handle -> domid -> int -> bool array -> unit
 external numainfo : handle -> numainfo = "stub_xenctrlext_numainfo"
 
 external cputopoinfo : handle -> cputopo array = "stub_xenctrlext_cputopoinfo"
+
+external combine_cpu_policies : int64 array -> int64 array -> int64 array
+  = "stub_xenctrlext_combine_cpu_featuresets"
+
+external policy_is_compatible : int64 array -> int64 array -> string option
+  = "stub_xenctrlext_featuresets_are_compatible"

--- a/xc/xenops_server_xen.ml
+++ b/xc/xenops_server_xen.ml
@@ -1116,7 +1116,14 @@ module HOST = struct
 
   let combine_cpu_policies policy1 policy2 =
     let open Cpuid in
-    intersect
+    let combine p1 p2 =
+      try Xenctrlext.combine_cpu_policies p1 p2
+      with Xenctrlext.Unix_error (Unix.ENOSYS, _) ->
+        debug
+          "xc_combine_cpu_policies: ENOSYS; fallback to OCaml implementation" ;
+        intersect p1 p2
+    in
+    combine
       (policy1 |> CPU_policy.to_string |> features_of_string)
       (policy2 |> CPU_policy.to_string |> features_of_string)
     |> string_of_features
@@ -1124,16 +1131,34 @@ module HOST = struct
 
   let is_compatible vm_policy host_policy =
     let open Cpuid in
+    let is_compatible' vm host =
+      let vm' = zero_extend vm (Array.length host) in
+      let compatible = is_subset vm' host in
+      if not compatible then
+        info
+          "The VM's CPU policy is not compatible with the target host's. The \
+           host is missing: %s"
+          (diff vm' host |> string_of_features) ;
+      compatible
+    in
+    let check v h =
+      try
+        match Xenctrlext.policy_is_compatible v h with
+        | None ->
+            true
+        | Some s ->
+            info
+              "The VM's CPU policy is not compatible with the target host's. \
+               The host is missing: %s"
+              s ;
+            false
+      with Xenctrlext.Unix_error (Unix.ENOSYS, _) ->
+        debug "policy_is_compatible: ENOSYS; fallback to OCaml implementation" ;
+        is_compatible' v h
+    in
     let vm = vm_policy |> CPU_policy.to_string |> features_of_string in
     let host = host_policy |> CPU_policy.to_string |> features_of_string in
-    let vm' = zero_extend vm (Array.length host) in
-    let compatible = is_subset vm' host in
-    if not compatible then
-      info
-        "The VM's CPU policy is not compatible with the target host's. The \
-         host is missing: %s"
-        (diff vm' host |> string_of_features) ;
-    compatible
+    check vm host
 end
 
 let dB_m = Mutex.create ()


### PR DESCRIPTION
In order to support MSR_ARCH_CAPS, combining policies becomes more complicated than a simple intersection.  More generally, it is more convenient to have all levelling/compatibility logic in a single codebase to avoid needing linked changes in Xapi.

Where possible, offload the decisions into Xen.

Signed-off-by: Rob Hoes <rob.hoes@citrix.com>
Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>

(cherry picked from commit
https://github.com/xapi-project/xen-api/commit/dc2d84ca2890cc912ef190f40340fd048b81329b)