### PR TITLE
CA-381503: bump qemu filesize limit (Backport)

### DIFF
--- a/scripts/qemu-wrapper
+++ b/scripts/qemu-wrapper
@@ -66,7 +66,7 @@ def unshare(flags):
         raise OSError(ctypes.get_errno(), os.strerror(ctypes.get_errno()))
 
 def restrict_fsize():
-    limit = 256 * 1024
+    limit = 1024 * 1024
     setrlimit(RLIMIT_FSIZE, (limit, limit))
 
 def enable_core_dumps():


### PR DESCRIPTION
QEMU has a file size limit to prevent denial of service attacks. However with the introduction of vTPM the vTPM state is now saved in the qemu device stream. If the vTPM happens to have a lot of data then the quota is hit, qemu returns an error, the migration fails and XAPI kills the original VM.
(Same bug happens if we were trying to take a checkpoint, the VM ends up dead).

Fixing that would require fast resume, which we don't have, however the file size limit needs to be updated. Don't try to be too tight on the size, the vTPM may be a max of 256KiB, so increasing this to 512KiB should work, but to be safe double that to 1MiB.