### PR TITLE
maintenance: fix ci for scheduled lcm runs

### DIFF
--- a/.github/workflows/0.150-lcm.yml
+++ b/.github/workflows/0.150-lcm.yml
@@ -27,6 +27,9 @@ jobs:
       package: "xapi-xenopsd xapi-xenopsd-simulator xapi-xenopsd-cli xapi-xenopsd-xc"
 
     steps:
+      - name: Update apt cache
+        run: sudo apt-get update
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Typical error with github images not being up-to-date make the ci to fail